### PR TITLE
feat(processor): Add resolver to download source urls

### DIFF
--- a/antenna-basic-assembly/antenna-basic-configuration/pom.xml
+++ b/antenna-basic-assembly/antenna-basic-configuration/pom.xml
@@ -104,6 +104,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-source-url-resolver</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>antenna-license-knowledgebase-resolver</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/antenna-core/src/main/java/org/eclipse/sw360/antenna/exceptions/FailedToDownloadException.java
+++ b/antenna-core/src/main/java/org/eclipse/sw360/antenna/exceptions/FailedToDownloadException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.exceptions;
+
+public class FailedToDownloadException extends Exception {
+    public FailedToDownloadException(String message) {
+        super(message);
+    }
+}

--- a/antenna-core/src/main/java/org/eclipse/sw360/antenna/util/HttpHelper.java
+++ b/antenna-core/src/main/java/org/eclipse/sw360/antenna/util/HttpHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.util;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
+import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
+import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HttpHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpHelper.class);
+    private CloseableHttpClient httpClient;
+
+    public HttpHelper(AntennaContext context) {
+        httpClient = getConfiguredHttpClient(context);
+    }
+
+    public File downloadFile(String url, Path targetDirectory) throws IOException, FailedToDownloadException {
+        String filename = Paths.get(url).getFileName().toString();
+        return downloadFile(url, targetDirectory, filename);
+    }
+
+    public File downloadFile(String url, Path targetDirectory, String filename) throws IOException, FailedToDownloadException {
+        File targetFile = targetDirectory.resolve(filename).toFile();
+
+        try (CloseableHttpResponse response = getFromUrl(url)) {
+            if(response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                throw new FailedToDownloadException("File not found on URL=["+url+"]");
+            } else if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                throw new IOException("Reason: " + response.getStatusLine().getReasonPhrase());
+            }
+
+            HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                try (InputStream is = entity.getContent()) {
+                    FileUtils.copyInputStreamToFile(is, targetFile);
+                }
+            }
+        } catch (IOException e) {
+            throw new IOException("Encountered a problem while downloading the file " + url + ": " + e.getMessage());
+        }
+
+        if (!targetFile.exists()) {
+            throw new FailedToDownloadException("File does not exist after downloading.");
+        }
+        return targetFile;
+    }
+
+    private CloseableHttpClient getConfiguredHttpClient(AntennaContext context) {
+        ToolConfiguration tc = context.getToolConfiguration();
+
+        if (tc.useProxy()) {
+            LOGGER.info("Using proxy on host {} and port {}", tc.getProxyHost(), tc.getProxyPort());
+            return HttpClients.custom()
+                    .useSystemProperties()
+                    .setProxy(new HttpHost(tc.getProxyHost(), tc.getProxyPort()))
+                    .build();
+        } else {
+            return HttpClients.createDefault();
+        }
+    }
+
+    private CloseableHttpResponse getFromUrl(String url) throws IOException {
+        try {
+            HttpGet getRequest = new HttpGet(url);
+            LOGGER.info("Downloading {}", url);
+            return httpClient.execute(getRequest);
+        } catch (IOException e) {
+            throw new IOException("Error while downloading " + url + ": " + e.getMessage());
+        }
+    }
+}

--- a/antenna-core/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
+++ b/antenna-core/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.util;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
+import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
+import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.io.*;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpHelperTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private ToolConfiguration toolConfigMock;
+    @Mock
+    private AntennaContext antennaContextMock;
+    @Mock
+    private CloseableHttpClient httpClientMock;
+    @Mock
+    private CloseableHttpResponse httpResponseMock;
+    @Mock
+    private HttpEntity httpEntityMock;
+    @Mock
+    private StatusLine statusLine;
+
+    private HttpHelper httpHelper;
+
+    @Before
+    public void setUp() throws Exception {
+        when(toolConfigMock.getAntennaTargetDirectory())
+                .thenReturn(temporaryFolder.newFolder("target").toPath());
+        when(antennaContextMock.getToolConfiguration())
+                .thenReturn(toolConfigMock);
+
+        httpHelper = new HttpHelper(antennaContextMock);
+        ReflectionUtils.setVariableValueInObject(httpHelper, "httpClient", httpClientMock);
+    }
+
+    @Test
+    public void downloadFileWritesTheFileToDisk() throws Exception {
+        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+        File expectedJarFile = new File(targetDirectory.toFile(), "archive.zip");
+
+        when(httpResponseMock.getStatusLine())
+                .thenReturn(statusLine);
+        when(httpResponseMock.getStatusLine().getStatusCode())
+                .thenReturn(HttpStatus.SC_OK);
+        when(httpResponseMock.getEntity())
+                .thenReturn(httpEntityMock);
+        when(httpClientMock.execute(any(HttpGet.class)))
+                .then((Answer<CloseableHttpResponse>) httpGetMock -> {
+                    new FileOutputStream(expectedJarFile).close();
+                    return httpResponseMock;
+                });
+        when(httpEntityMock.getContent())
+                .then((Answer<InputStream>) result -> new FileInputStream(expectedJarFile));
+
+        File resultFile = httpHelper.downloadFile("https://example.com/folder/archive.zip", targetDirectory);
+
+        assertThat(resultFile).isEqualTo(expectedJarFile);
+    }
+
+    @Test(expected = FailedToDownloadException.class)
+    public void downloadFileThrowsExceptionOn404StatusCode() throws Exception {
+        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+
+        when(httpResponseMock.getStatusLine())
+                .thenReturn(statusLine);
+        when(httpResponseMock.getStatusLine().getStatusCode())
+                .thenReturn(HttpStatus.SC_NOT_FOUND);
+        when(httpClientMock.execute(any(HttpGet.class)))
+                .thenReturn(httpResponseMock);
+
+        httpHelper.downloadFile("https://example.com/archive.zip", targetDirectory);
+
+        verify(httpResponseMock, never()).getEntity();
+    }
+}

--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactSourceUrl.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactSourceUrl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.model.artifact.facts;
+
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFactWithPayload;
+
+public class ArtifactSourceUrl extends ArtifactFactWithPayload<String> {
+    public ArtifactSourceUrl(String sourceUrl) {
+        super(sourceUrl);
+    }
+
+    @Override
+    public String getFactContentName() {
+        return "Source URL";
+    }
+
+    @Override
+    public Class<? extends ArtifactFact> getKey() {
+        return ArtifactSourceUrl.class;
+    }
+}

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -19,6 +19,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     private String name;
     private String version;
     private String cpeid;
+    private String downloadurl;
     private Set<String> mainLicenseIds;
 
     public String getComponentId() {
@@ -64,5 +65,13 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     public SW360Release setMainLicenseIds(Set<String> mainLicenseIds) {
         this.mainLicenseIds = mainLicenseIds;
         return this;
+    }
+
+    public String getDownloadurl() {
+        return downloadurl;
+    }
+
+    public void setDownloadurl(String downloadurl) {
+        this.downloadurl = downloadurl;
     }
 }

--- a/antenna-workflow-steps/pom.xml
+++ b/antenna-workflow-steps/pom.xml
@@ -34,6 +34,7 @@
         <module>processors/enricher/antenna-license-knowledgebase-resolver</module>
         <module>processors/enricher/antenna-license-resolver</module>
         <module>processors/enricher/antenna-manifest-resolver</module>
+        <module>processors/enricher/antenna-source-url-resolver</module>
         <module>processors/enricher/antenna-sw360-enricher</module>
         <module>processors/validators/antenna-coordinates-validator</module>
         <module>processors/validators/antenna-source-validator</module>

--- a/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/test/java/org/eclipse/sw360/antenna/bundle/HttpRequesterTest.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/test/java/org/eclipse/sw360/antenna/bundle/HttpRequesterTest.java
@@ -10,66 +10,38 @@
  */
 package org.eclipse.sw360.antenna.bundle;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.maven.repository.ArtifactDoesNotExistException;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
+import org.eclipse.sw360.antenna.util.HttpHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.*;
-import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
-import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.mockito.Mockito;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Parameterized.class)
-@PrepareForTest(HttpClients.class)
+@RunWith(Parameterized.class)
 public class HttpRequesterTest extends AntennaTestWithMockedContext {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    @Mock
     private ToolConfiguration toolConfigMock = Mockito.mock(ToolConfiguration.class);
-    
-    @Mock
-    private CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
-    @Mock
-    private CloseableHttpResponse httpResponseMock = Mockito.mock(CloseableHttpResponse.class);
-    @Mock
-    private HttpEntity httpEntityMock = Mockito.mock(HttpEntity.class);
-    @Mock 
-    private StatusLine statusLine = Mockito.mock(StatusLine.class);
-    
-    @Captor
-    private ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+    private HttpHelper httpHelperMock = Mockito.mock(HttpHelper.class);
 
-    private HttpRequester hr = new HttpRequester(antennaContextMock);
+    private HttpRequester hr;
     
     private MavenCoordinates mavenCoordinates;
 
@@ -85,84 +57,54 @@ public class HttpRequesterTest extends AntennaTestWithMockedContext {
     }
 
     @Before
-    public void before() throws IOException {
+    public void before() throws Exception {
         String sourceRepositoryUrl = "http://test.repo" 
                 + "/" + HttpRequester.GROUP_ID_PLACEHOLDER 
                 + "/" + HttpRequester.ARTIFACT_ID_PLACEHOLDER 
                 + "/" + HttpRequester.VERSION_PLACEHOLDER + "/";
-        
-        mavenCoordinates = new MavenCoordinates("groupId", "artifactId", "version");
 
-        PowerMockito.mockStatic(HttpClients.class);
-        Mockito.when(HttpClients.createDefault()).thenReturn(httpClientMock);
-        Mockito.when(toolConfigMock.getSourcesRepositoryUrl())
+        mavenCoordinates = new MavenCoordinates("artifactId", "groupId", "version");
+
+
+        when(toolConfigMock.getSourcesRepositoryUrl())
                 .thenReturn(sourceRepositoryUrl);
-        Mockito.when(toolConfigMock.getAntennaTargetDirectory())
+        when(toolConfigMock.getAntennaTargetDirectory())
                 .thenReturn(temporaryFolder.newFolder("target").toPath());
-        Mockito.when(antennaContextMock.getToolConfiguration())
+        when(antennaContextMock.getToolConfiguration())
                 .thenReturn(toolConfigMock);
+
+        hr = new HttpRequester(antennaContextMock);
+        ReflectionUtils.setVariableValueInObject(hr, "httpHelper", httpHelperMock);
     }
         
     @Test
-    public void requestFileTestThatRequestIsComposedCorrectly() throws Exception {
-        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
-        final String expectedJarBaseName = hr.getExpectedJarBaseName(mavenCoordinates, isSource);
-        File expectedJarFile = new File(targetDirectory.toFile(), expectedJarBaseName);
-        
-        Mockito.when(httpResponseMock.getStatusLine())
-                .thenReturn(statusLine);
-        Mockito.when(httpResponseMock.getStatusLine().getStatusCode())
-                .thenReturn(HttpStatus.SC_OK);
-        Mockito.when(httpResponseMock.getEntity())
-                .thenReturn(httpEntityMock);
-        Mockito.when(httpClientMock.execute(ArgumentMatchers.any(HttpGet.class)))
-                .then((Answer<CloseableHttpResponse>) httpGetMock -> {
-                    new FileOutputStream(expectedJarFile).close();
-                    return httpResponseMock;
-                });
-        Mockito.when(httpEntityMock.getContent())
-                .then((Answer<InputStream>) result -> new FileInputStream(expectedJarFile));
-
-        File resultFile = hr.requestFile(mavenCoordinates, targetDirectory, isSource);
-        Mockito.verify(httpClientMock).execute(captor.capture());
-        Mockito.verify(httpEntityMock).getContent();
-        
-        assertThat(resultFile).isEqualTo(expectedJarFile);
-        
-        HttpGet response = captor.getValue();
-        Iterator<Path> requestPathIterator = Paths.get(response.getURI().getPath()).iterator();
-        
-        assertThat(requestPathIterator.next().toString()).isEqualTo(mavenCoordinates.getGroupId());
-        assertThat(requestPathIterator.next().toString()).isEqualTo(mavenCoordinates.getArtifactId());
-        assertThat(requestPathIterator.next().toString()).isEqualTo(mavenCoordinates.getVersion());
-        assertThat(requestPathIterator.next().toString()).isEqualTo(expectedJarBaseName);
-    }
-    
-    @Test(expected = ArtifactDoesNotExistException.class)
-    public void requestFileTestThatRecognizedNonExistingArtifact() throws Exception {
+    public void requestFileUsesTheCorrectUrl() throws Exception {
         Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
 
-        Mockito.when(httpResponseMock.getStatusLine())
-                .thenReturn(statusLine);
-        Mockito.when(httpResponseMock.getStatusLine().getStatusCode())
-                .thenReturn(HttpStatus.SC_OK);
-        Mockito.when(httpClientMock.execute(ArgumentMatchers.any(HttpGet.class)))
-                .thenReturn(httpResponseMock);
-        
-       hr.requestFile(mavenCoordinates, targetDirectory, isSource);
-    }
-    
-    @Test(expected = ArtifactDoesNotExistException.class)
-    public void requestFileTestThatHandlesReturnCodes() throws Exception {
-        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
-
-        Mockito.when(httpResponseMock.getStatusLine())
-                .thenReturn(statusLine);
-        Mockito.when(httpResponseMock.getStatusLine().getStatusCode())
-                .thenReturn(HttpStatus.SC_NOT_FOUND);
-        Mockito.when(httpClientMock.execute(ArgumentMatchers.any(HttpGet.class)))
-                .thenReturn(httpResponseMock);
-        
         hr.requestFile(mavenCoordinates, targetDirectory, isSource);
+
+        String filename = "artifactId-version" + (isSource ? "-sources" : "") + ".jar";
+        verify(httpHelperMock).downloadFile("http://test.repo/groupId/artifactId/version/" + filename, targetDirectory, filename);
+    }
+
+    @Test(expected = IOException.class)
+    public void requestFilePassesThroughExceptions() throws Exception {
+        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+        when(httpHelperMock.downloadFile(anyString(), eq(targetDirectory), anyString())).thenThrow(new IOException("Failed to download"));
+
+        hr.requestFile(mavenCoordinates, targetDirectory, isSource);
+    }
+
+    @Test
+    public void requestFileDoesNotDownloadIfFileExists() throws Exception {
+        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+        String filename = "artifactId-version" + (isSource ? "-sources" : "") + ".jar";
+        File expectedFile = new File(targetDirectory.toFile(), filename);
+
+        new FileOutputStream(expectedFile).close();
+
+        hr.requestFile(mavenCoordinates, targetDirectory, isSource);
+
+        verify(httpHelperMock, never()).downloadFile(anyString(), eq(targetDirectory), anyString());
     }
 }

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2018.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.sw360.antenna</groupId>
+		<artifactId>antenna-workflow-steps</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../..</relativePath>
+	</parent>
+
+	<artifactId>antenna-source-url-resolver</artifactId>
+	<version>2.0.1-SNAPSHOT</version>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.sw360.antenna</groupId>
+			<artifactId>antenna-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-core</artifactId>
+			<version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+		<!-- ################################ testing dependencies ################################ -->
+		<dependency>
+			<groupId>org.eclipse.sw360.antenna</groupId>
+			<artifactId>antenna-core-common-testing</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+</project>

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.workflow.processors.enricher;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
+import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor;
+import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
+import org.eclipse.sw360.antenna.util.HttpHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+
+public class SourceUrlResolver extends AbstractProcessor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceUrlResolver.class);
+    private HttpHelper httpHelper;
+    private Path dependencyTargetDirectory;
+
+    @Override
+    public Collection<Artifact> process(Collection<Artifact> artifacts) {
+        LOGGER.info("Resolve source urls...");
+        resolveSourceUrls(artifacts);
+        LOGGER.info("Resolve source urls... done");
+        return artifacts;
+    }
+
+    private void resolveSourceUrls(Collection<Artifact> artifacts) {
+        for (Artifact artifact : artifacts) {
+            Optional<String> sourceUrl = artifact.askForGet(ArtifactSourceUrl.class);
+            if (sourceUrl.isPresent()) {
+                try {
+                    File file = httpHelper.downloadFile(sourceUrl.get(), dependencyTargetDirectory);
+                    artifact.addFact(new ArtifactSourceFile(file.toPath()));
+                } catch (IOException | FailedToDownloadException e) {
+                    LOGGER.warn(e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void configure(Map<String,String> configMap) throws AntennaConfigurationException {
+        super.configure(configMap);
+        httpHelper = new HttpHelper(context);
+        dependencyTargetDirectory = context.getToolConfiguration().getDependenciesDirectory();
+    }
+}

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/test/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolverTest.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/test/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolverTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.workflow.processors.enricher;
+
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
+import org.eclipse.sw360.antenna.util.HttpHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SourceUrlResolverTest {
+    @Mock
+    private HttpHelper httpHelper;
+
+    private SourceUrlResolver resolver;
+
+    @Before
+    public void setUp() throws Exception {
+        resolver = new SourceUrlResolver();
+        ReflectionUtils.setVariableValueInObject(resolver, "httpHelper", httpHelper);
+    }
+
+    @Test
+    public void processDownloadsSourcesAndSetsTheSourceFileFact() throws Exception {
+        when(httpHelper.downloadFile(eq("https://example.com/artifact0.zip"), any()))
+                .thenReturn(new File("artifact0.zip"));
+
+        Artifact artifact0 = new Artifact();
+        artifact0.addFact(new ArtifactSourceUrl("https://example.com/artifact0.zip"));
+
+        Artifact artifact1 = new Artifact();
+
+        Collection<Artifact> artifacts = Arrays.asList(artifact0, artifact1);
+
+        resolver.process(artifacts);
+
+        assertThat(artifact0.askForGet(ArtifactSourceFile.class).isPresent()).isTrue();
+        assertThat(artifact0.askForGet(ArtifactSourceFile.class).get().toString()).isEqualTo("artifact0.zip");
+
+        assertThat(artifact1.askForGet(ArtifactSourceFile.class).isPresent()).isFalse();
+    }
+}

--- a/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SW360Enricher.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SW360Enricher.java
@@ -16,9 +16,10 @@ import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
 import org.eclipse.sw360.antenna.model.artifact.facts.ConfiguredLicenseInformation;
-import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
 import org.eclipse.sw360.antenna.model.reporting.MessageType;
+import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
 import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseOperator;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseStatement;
@@ -28,7 +29,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 import java.util.Collection;
 import java.util.List;
@@ -66,11 +66,18 @@ public class SW360Enricher extends AbstractProcessor {
             Optional<SW360Release> release = connector.findReleaseForArtifact(artifact);
             if (release.isPresent()) {
                 updateLicenses(artifact, release.get());
+                addSourceUrlIfAvailable(artifact, release.get());
             } else {
                 warnAndReport(artifact, "No SW360 release found for artifact.");
             }
         }
         return intermediates;
+    }
+
+    private void addSourceUrlIfAvailable(Artifact artifact, SW360Release release) {
+        if (release.getDownloadurl() != null && !release.getDownloadurl().isEmpty()) {
+            artifact.addFact(new ArtifactSourceUrl(release.getDownloadurl()));
+        }
     }
 
     private void updateLicenses(Artifact artifact, SW360Release release) {

--- a/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/test/java/org/eclipse/sw360/antenna/workflow/processors/SW360EnricherTest.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/test/java/org/eclipse/sw360/antenna/workflow/processors/SW360EnricherTest.java
@@ -15,6 +15,7 @@ import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
 import org.eclipse.sw360.antenna.model.artifact.facts.DeclaredLicenseInformation;
 import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
 import org.eclipse.sw360.antenna.model.xml.generated.License;
@@ -64,6 +65,21 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
 
         connector = Mockito.mock(SW360MetaDataReceiver.class);
         ReflectionTestUtils.setField(sw360Enricher, "connector", connector);
+    }
+
+    @Test
+    public void downloadUrlIsStoredAsFact() throws AntennaException {
+        SW360Release release0 = new SW360Release();
+        release0.setDownloadurl("some_download_url");
+        release0.set_Embedded(new SW360ReleaseEmbedded());
+        release0.get_Embedded().setLicenses(Collections.emptyList());
+
+        when(connector.findReleaseForArtifact(artifacts.get(0))).thenReturn(Optional.of(release0));
+
+        sw360Enricher.process(artifacts);
+
+        assertThat(artifacts.get(0).askFor(ArtifactSourceUrl.class).isPresent()).isTrue();
+        assertThat(artifacts.get(0).askForGet(ArtifactSourceUrl.class).get()).isEqualTo("some_download_url");
     }
 
     @Test


### PR DESCRIPTION
Belongs to #19.

The `SourceUrlResolver` converts each `SourceUrlFact` to a `SourceFileFact`.
This PR also moves common HTTP helper code to the antenna-core.
