### PR TITLE
fix: HTML report generator

### DIFF
--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.model.util;
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
+import org.eclipse.sw360.antenna.model.artifact.facts.GenericArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.BundleCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ArtifactUtils {
+    private ArtifactUtils() {
+        // only static methods
+    }
+
+    public static <T extends ArtifactFact> Optional<T> getMostDominantFact(Class<T> tClass,
+                                                                           List<Class<? extends T>> preferedFactTypes,
+                                                                           Artifact artifact) {
+        return getMostDominantFact(tClass, preferedFactTypes, a -> Optional.empty(), artifact);
+    }
+
+    public static <T extends ArtifactFact> Optional<T> getMostDominantFact(Class<T> tClass,
+                                                                           List<Class<? extends T>> preferedFactTypes,
+                                                                           Function<Artifact, Optional<? extends T>> fallback,
+                                                                           Artifact artifact) {
+        final Optional<T> prefered = preferedFactTypes.stream()
+                .map(preferedFact -> artifact.askFor(preferedFact)
+                        .map(tClass::cast))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+        if(prefered.isPresent()) {
+            return prefered;
+        }
+
+        final Optional<T> other = artifact.askForAll(tClass)
+                .stream()
+                .findFirst();
+        if(other.isPresent()) {
+            return other;
+        }
+
+        return fallback.apply(artifact)
+                .map(tClass::cast);
+    }
+
+    public static Optional<ArtifactCoordinates> getMostDominantArtifactCoordinates(List<Class<? extends ArtifactCoordinates>> preferedCoordinatesTypes,Artifact artifact) {
+        return getMostDominantFact(ArtifactCoordinates.class,
+                preferedCoordinatesTypes,
+                a -> a.askFor(ArtifactFilename.class)
+                        .map(ArtifactFilename::getFilename)
+                        .map(fn -> new GenericArtifactCoordinates(fn, "-")),
+                artifact);
+    }
+}

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
@@ -15,7 +15,9 @@ import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
 import org.eclipse.sw360.antenna.model.artifact.facts.GenericArtifactCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.BundleCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.JavaCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.util.ArtifactUtils;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentType;
@@ -24,31 +26,20 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SW360ComponentAdapterUtils {
+    private static final List<Class<? extends ArtifactCoordinates>> preferedCoordinatesTypes = Stream.of(MavenCoordinates.class,
+            BundleCoordinates.class).collect(Collectors.toList());
+
     private static Optional<ArtifactCoordinates> getMostDominantArtifactCoordinates(Artifact artifact) {
-        final Optional<ArtifactCoordinates> mavenCoordinates = artifact.askFor(MavenCoordinates.class)
-                .map(ArtifactCoordinates.class::cast);
-        if(mavenCoordinates.isPresent()) {
-            return mavenCoordinates;
-        }
-        final Optional<ArtifactCoordinates> bundleCoordinates = artifact.askFor(BundleCoordinates.class)
-                .map(ArtifactCoordinates.class::cast);
-        if(bundleCoordinates.isPresent()) {
-            return bundleCoordinates;
-        }
-        final Optional<ArtifactCoordinates> otherCoordinates = artifact.askForAll(ArtifactCoordinates.class)
-                .stream()
-                .findFirst();
-        if(otherCoordinates.isPresent()) {
-            return otherCoordinates;
-        }
-        return artifact.askFor(ArtifactFilename.class)
-                .map(ArtifactFilename::getFilename)
-                .map(fn -> new GenericArtifactCoordinates(fn, "-"))
-                .map(ArtifactCoordinates.class::cast);
+        return ArtifactUtils.getMostDominantArtifactCoordinates(
+                preferedCoordinatesTypes,
+                artifact);
     }
 
     public static String createComponentName(Artifact artifact) {

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/pom.xml
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/pom.xml
@@ -35,5 +35,27 @@
 			<artifactId>antenna-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- ################################ testing dependencies ################################ -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sw360.antenna</groupId>
+			<artifactId>antenna-core-common-testing</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency> <!-- necessary for mocking -->
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/ArtifactForHTMLReport.java
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/ArtifactForHTMLReport.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.workflow.generators;
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.BundleCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
+import org.eclipse.sw360.antenna.model.util.ArtifactUtils;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ArtifactForHTMLReport {
+    private final String identifier;
+    private final LicenseInformation license;
+    private final String ankerTag;
+
+    private static final List<Class<? extends ArtifactCoordinates>> preferedCoordinatesTypes = Stream.of(
+            MavenCoordinates.class,
+            BundleCoordinates.class).collect(Collectors.toList());
+
+    public ArtifactForHTMLReport(Artifact artifact) {
+        this.identifier = ArtifactUtils.getMostDominantArtifactCoordinates(preferedCoordinatesTypes, artifact)
+                .map(ArtifactCoordinates::toString)
+                .orElse("");
+        this.ankerTag = UUID.randomUUID().toString();
+        this.license = ArtifactLicenseUtils.getFinalLicenses(artifact);
+    }
+
+
+    public ArtifactForHTMLReport(String identifier, LicenseInformation licenseInformation) {
+        this.identifier = identifier;
+        this.license = licenseInformation;
+        this.ankerTag = UUID.randomUUID().toString();
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public LicenseInformation getLicense() {
+        return license;
+    }
+
+    public String getAnkerTag() {
+        return ankerTag;
+    }
+}

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/resources/licenseReport.vm
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/resources/licenseReport.vm
@@ -47,9 +47,9 @@
     <a name="artifacts"></a>
     <ul>
     #foreach($artifact in $artifacts)
-        <li><a href="#$artifact.getArtifactIdentifier().getFilename()">
-        #if ( $artifact.getArtifactIdentifier() && $artifact.getArtifactIdentifier().getFilename() )
-            $artifact.getArtifactIdentifier().getFilename()
+        <li><a href="#$artifact.ankerTag">
+        #if ( $artifact.identifier )
+            $artifact.identifier
         #else
             Artifact Identifier not provided
         #end
@@ -59,18 +59,18 @@
     <hr />
     #foreach($artifact in $artifacts)
     <div>
-        <a name="$artifact.getArtifactIdentifier().getFilename()"></a>
+        <a name="$artifact.ankerTag"></a>
         <a class="top" href="#licenses">&#8679;</a>
         <h2>
-            #if ( $artifact.getArtifactIdentifier() && $artifact.getArtifactIdentifier().getFilename() )
-                $artifact.getArtifactIdentifier().getFilename()
+            #if ( $artifact.identifier )
+                $artifact.identifier
             #else
                 Artifact Identifier not provided
             #end
         </h2>
         <p>License:<br />
         <ul>
-        $artifact.getFinalLicenses().getHTMLLinkStr()
+        $artifact.license.getHTMLLinkStr()
         </ul>
         </p>
     </div>
@@ -81,12 +81,15 @@
     <div>
         <a name="$license.getName()"></a>
         <a class="top" href="#artifacts">&#8679;</a>
-        #if($license.getLongName()&&$license.getText())
-        <h3>$license.getLongName()</h3>
-        <p>$license.getText().replaceAll("(\r\n|\n)", "<br />")</p>
+        #if($license.getLongName())
+            <h3>$license.getLongName()</h3>
         #else
-        <h3>$license.getName()</h3>
-        <p>No license text available</p>
+            <h3>$license.getName()</h3>
+        #end
+        #if($license.getText())
+            <p>$license.getText().replaceAll("(\r\n|\n)", "<br />")</p>
+        #else
+            <p>No license text available</p>
         #end
     </div>
     <hr />

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/test/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGeneratorTest.java
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/test/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGeneratorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2018.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.workflow.generators;
+
+import org.eclipse.sw360.antenna.model.xml.generated.License;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseOperator;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseStatement;
+import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HTMLReportGeneratorTest extends AntennaTestWithMockedContext {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private HTMLReportGenerator htmlReportGenerator;
+    private Charset charset = Charset.forName("UTF-8");
+
+    public final String licenseName1 = "LicenseName1";
+    public final String licenseText1 = "Some Super Long LicenseText1";
+    public final String licenseName2 = "LicenseName2";
+    public final String licenseText2 = "Some Super Long LicenseText2";
+    public final String licenseName3 = "LicenseName3";
+    public final String licenseText3 = "Some Super Long LicenseText3";
+    public final String licenseFullName2 = "LicenseFullName2";
+    public final String artifactId1 = "ArtifactId1";
+    public final String artifactId2 = "ArtifactId2";
+    public final String artifactId3 = "ArtifactId3";
+    public final String artifactId4 = "ArtifactId4";
+
+    public Set<ArtifactForHTMLReport> artifacts;
+
+    @Before
+    public void setUp() throws Exception {
+        when(toolConfigMock.getEncoding()).thenReturn(charset);
+
+        htmlReportGenerator = new HTMLReportGenerator();
+        htmlReportGenerator.setAntennaContext(antennaContextMock);
+        htmlReportGenerator.configure(Collections.emptyMap());
+
+        final License license1 = new License();
+        license1.setName(licenseName1);
+        license1.setText(licenseText1);
+        final ArtifactForHTMLReport artifact1 = new ArtifactForHTMLReport(artifactId1, license1);
+
+        final ArtifactForHTMLReport artifact2 = new ArtifactForHTMLReport(artifactId2, null);
+
+        final License license2 = new License();
+        license2.setName(licenseName2);
+        license2.setText(licenseText2);
+        license2.setLongName(licenseFullName2);
+        final ArtifactForHTMLReport artifact3 = new ArtifactForHTMLReport(artifactId3, license2);
+
+        final License license3 = new License();
+        license3.setName(licenseName3);
+        license3.setText(licenseText3);
+        final LicenseStatement license4 = new LicenseStatement();
+        license4.setLeftStatement(license1);
+        license4.setRightStatement(license3);
+        license4.setOp(LicenseOperator.AND);
+        final ArtifactForHTMLReport artifact4 = new ArtifactForHTMLReport(artifactId4, license4);
+
+        artifacts = Stream.of(artifact1, artifact2, artifact3, artifact4).collect(Collectors.toSet());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        temporaryFolder.delete();
+        verify(toolConfigMock).getEncoding();
+    }
+
+    @Test
+    public void testThatArtifactsAreIncluded() throws Exception {
+        final File outputFile = temporaryFolder.newFile();
+
+        htmlReportGenerator.writeReportToFile(artifacts, outputFile);
+
+        byte[] encoded = Files.readAllBytes(outputFile.toPath());
+        final String contentOfFile = new String(encoded, charset);
+
+        assertThat(contentOfFile).contains(licenseName1);
+        assertThat(contentOfFile).contains(licenseText1);
+        assertThat(contentOfFile).contains(artifactId1);
+        assertThat(contentOfFile).contains(licenseName2);
+        assertThat(contentOfFile).contains(licenseText2);
+        assertThat(contentOfFile).contains(licenseFullName2);
+        assertThat(contentOfFile).contains(licenseName3);
+        assertThat(contentOfFile).contains(licenseText3);
+        assertThat(contentOfFile).contains(artifactId2);
+        assertThat(contentOfFile).contains(artifactId3);
+        assertThat(contentOfFile).contains(artifactId4);
+
+    }
+
+}


### PR DESCRIPTION
Previously the html report looked like:
![screenshot1](https://user-images.githubusercontent.com/1187050/50272679-ca496c80-0438-11e9-9763-a86cfe40b45f.png)
This PR fixes it so that the output looks like:
![screenshot2](https://user-images.githubusercontent.com/1187050/50272693-d1707a80-0438-11e9-8554-71aa49c43240.png)
