### PR TITLE
Add drools checker

### DIFF
--- a/antenna-api/src/main/java/org/eclipse/sw360/antenna/api/IRuleEngine.java
+++ b/antenna-api/src/main/java/org/eclipse/sw360/antenna/api/IRuleEngine.java
@@ -12,7 +12,9 @@
 package org.eclipse.sw360.antenna.api;
 
 import java.util.Collection;
+import java.util.Optional;
 
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 
 /**
@@ -24,10 +26,10 @@ public interface IRuleEngine {
      *
      * @return Results of evaluation.
      */
-    IPolicyEvaluation evaluate(Collection<Artifact> artifacts);
+    IPolicyEvaluation evaluate(Collection<Artifact> artifacts) throws AntennaException;
 
     /**
      * @return The version of this rule set.
      */
-    String getRulesetVersion();
+    Optional<String> getRulesetVersion();
 }

--- a/antenna-basic-assembly/antenna-basic-configuration/pom.xml
+++ b/antenna-basic-assembly/antenna-basic-configuration/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-drools-checker</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>antenna-csv-generator</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
+++ b/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
@@ -31,7 +31,14 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
 
     @Override
     public List<String> getOtherFilesToCopy() {
-        return Stream.of("src/reportData.json", "src/dependencies.csv").collect(Collectors.toList());
+        return Stream.of("src/reportData.json", "src/dependencies.csv")
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getOutOfProjectFilesToCopy() {
+        return Stream.of("../example-policies/rules/DummyRule.drl", "../example-policies/policies/policies.properties")
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -86,6 +93,11 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
                     s.setConfiguration(StepConfiguration.fromMap(map));
                     s.setDeactivated(true);
                 });
+        // checkers
+        WorkflowStep checker1 = mkWorkflowStep("Drools Policy Engine", "org.eclipse.sw360.antenna.workflow.processors.checkers.AntennaDroolsChecker",
+                "base.dir", this.projectRoot.toString(),
+                "folder.path", "../example-policies");
+        processors.add(checker1);
         return processors;
     }
 

--- a/antenna-workflow-steps/pom.xml
+++ b/antenna-workflow-steps/pom.xml
@@ -29,6 +29,7 @@
         <!-- processors -->
         <module>processors/antenna-conf-processor</module>
         <module>processors/abstract-antenna-compliance-checker</module>
+        <module>processors/checkers/antenna-drools-checker</module>
         <module>processors/enricher/antenna-artifact-resolver</module>
         <module>processors/enricher/antenna-child-jar-resolver</module>
         <module>processors/enricher/antenna-license-knowledgebase-resolver</module>

--- a/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AbstractComplianceChecker.java
+++ b/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AbstractComplianceChecker.java
@@ -31,7 +31,7 @@ public abstract class AbstractComplianceChecker extends AbstractProcessor {
     private IEvaluationResult.Severity failOn;
     protected static final String FAIL_ON_KEY = "failOn";
 
-    public abstract IPolicyEvaluation evaluate(Collection<Artifact> artifacts);
+    public abstract IPolicyEvaluation evaluate(Collection<Artifact> artifacts) throws AntennaException;
 
     public abstract String getRulesetDescription();
 

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
@@ -1,0 +1,74 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.sw360.antenna</groupId>
+        <artifactId>antenna-workflow-steps</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+        <relativePath>../../..</relativePath>
+    </parent>
+
+    <artifactId>antenna-drools-checker</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>abstract-antenna-compliance-checker</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-api</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-internal</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-compiler</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <!-- ################################ testing dependencies ################################ -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
+import org.eclipse.sw360.antenna.api.IRuleEngine;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieRepository;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.io.ResourceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class DroolsEngine implements IRuleEngine {
+    private Logger logger = LoggerFactory.getLogger(DroolsEngine.class);
+    private String rulesetDirectory = "";
+    private String rulesetPath = "";
+    private static final String RULES_SUBFOLDER = "rules";
+    private static final String POLICIES_PROPERTIES_FILENAME = "policies.properties";
+    private static final String POLICIES_VERSION = "policies.version";
+
+    public void setRulesetDirectory(String rulesetDirectory) {
+        this.rulesetDirectory = rulesetDirectory;
+    }
+
+    public void setRulesetPath(String rulesetPath) {
+        this.rulesetPath = rulesetPath;
+    }
+
+    @Override
+    public IPolicyEvaluation evaluate(Collection<Artifact> artifacts) throws AntennaException {
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
+
+        addAllRules(kieFileSystem);
+
+        KieSession kieSession = openKieSession(kieServices, kieFileSystem);
+        artifacts.forEach(kieSession::insert);
+
+        List<IEvaluationResult> evaluationResults = getEvaluationResults();
+        evaluationResults.forEach(kieSession::insert);
+
+        int rulesFired = kieSession.fireAllRules();
+        logger.info(rulesFired + " drools rules fired");
+
+        DroolsPolicyEvaluation evaluation = new DroolsPolicyEvaluation();
+        evaluationResults.forEach(evaluation::addEvaluationResult);
+
+        return evaluation;
+    }
+
+    private void addAllRules(KieFileSystem kieFileSystem) throws AntennaException {
+        List<File> ruleFiles = getAllRulesInConfiguredFolder();
+        if (ruleFiles.isEmpty()) {
+            throw new AntennaException("No rules provided. Please check whether the rules are installed at " +
+                    Paths.get(rulesetDirectory, rulesetPath).normalize().toString());
+        }
+
+        ruleFiles.forEach(ruleFile ->
+                kieFileSystem.write(ResourceFactory.newFileResource(ruleFile).setResourceType(ResourceType.DRL))
+        );
+    }
+
+    private KieSession openKieSession(KieServices kieServices, KieFileSystem kieFileSystem) {
+        KieBuilder kieBuilder = kieServices.newKieBuilder(kieFileSystem);
+        kieBuilder.buildAll();
+
+        KieRepository kieRepository = kieServices.getRepository();
+        KieContainer kieContainer = kieServices.newKieContainer(kieRepository.getDefaultReleaseId());
+        return kieContainer.newKieSession();
+    }
+
+    private List<File> getAllRulesInConfiguredFolder() {
+        Path folderPath = Paths.get(rulesetDirectory, rulesetPath, RULES_SUBFOLDER).normalize();
+        try {
+            DroolsRuleFolderVisitor collectRuleFiles = new DroolsRuleFolderVisitor();
+            Files.walkFileTree(folderPath, collectRuleFiles);
+            return collectRuleFiles.getRuleFiles();
+        } catch (IOException ex) {
+            // Code is unreachable, DroolsRuleFolderVisitor will handle all IOExceptions
+            throw new AntennaExecutionException("Exception when scanning directory" + folderPath.toString());
+        }
+    }
+
+    // TODO Load evaluation result definitions from folder given by workflow step
+    private List<IEvaluationResult> getEvaluationResults() {
+        List<IEvaluationResult> results = new ArrayList<>();
+        results.add(new DroolsEvaluationResult("Dummy", "Dummy rule", IEvaluationResult.Severity.FAIL));
+        return results;
+    }
+
+    @Override
+    public Optional<String> getRulesetVersion() {
+        Properties appProperties = new Properties();
+        Path policiesVersionPath = Paths.get(rulesetDirectory, rulesetPath, POLICIES_PROPERTIES_FILENAME).normalize();
+        try (FileInputStream policiesFile = new FileInputStream((policiesVersionPath.toFile()));
+             InputStream policiesStream = new DataInputStream(policiesFile)) {
+            appProperties.load(policiesStream);
+            return Optional.ofNullable(appProperties.getProperty(POLICIES_VERSION));
+        } catch (IOException ex) {
+            logger.warn("Could not find or read version file. Details: " + ex.getMessage());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResult.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResult.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DroolsEvaluationResult implements IEvaluationResult {
+    private String id;
+    private Severity severity;
+    private String description;
+    private Set<Artifact> failedArtifacts = new HashSet<>();
+
+    public DroolsEvaluationResult(String id, String description, Severity severity) {
+        this(id, description, severity, null);
+    }
+
+    public DroolsEvaluationResult(String id, String description, Severity severity, Set<Artifact> artifacts) {
+        this.id = id;
+        this.description = description;
+        this.severity = severity;
+        if (artifacts != null) {
+            this.failedArtifacts = artifacts;
+        }
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public Severity getSeverity() {
+        return this.severity;
+    }
+
+    @Override
+    public Set<Artifact> getFailedArtifacts() {
+        return this.failedArtifacts;
+    }
+
+    public void addFailedArtifact(Artifact a) {
+        this.failedArtifacts.add(a);
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsPolicyEvaluation.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsPolicyEvaluation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DroolsPolicyEvaluation implements IPolicyEvaluation {
+    private Set<IEvaluationResult> evaluationResults = new HashSet<>();
+
+    @Override
+    public Set<IEvaluationResult> getEvaluationResults() {
+        return evaluationResults;
+    }
+
+    public void addEvaluationResult(IEvaluationResult result) {
+        this.evaluationResults.add(result);
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitor.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DroolsRuleFolderVisitor implements FileVisitor<Path> {
+    private Logger logger = LoggerFactory.getLogger(DroolsEngine.class);
+    private List<File> ruleFiles = new ArrayList<>();
+
+    public List<File> getRuleFiles() {
+        return ruleFiles;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path path, BasicFileAttributes basicFileAttributes) {
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path path, BasicFileAttributes basicFileAttributes) {
+        if (Files.isRegularFile(path) && path.toString().endsWith(".drl")) {
+            ruleFiles.add(path.toFile());
+        }
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path path, IOException e) {
+        logger.warn("File [" + path.toString() + "] could not be read.");
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path path, IOException e) {
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AntennaDroolsChecker.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AntennaDroolsChecker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.workflow.processors.checkers;
+
+import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
+import org.eclipse.sw360.antenna.bundle.DroolsEngine;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class AntennaDroolsChecker extends AbstractComplianceChecker {
+    private final DroolsEngine droolsEngine = new DroolsEngine();
+
+    private static final String BASEDIR_KEY = "base.dir";
+    private static final String POLICIES_FOLDER_PATH = "folder.path";
+    private static final String NO_VERSION = "no version string specified";
+
+    @Override
+    public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
+        super.configure(configMap);
+        droolsEngine.setRulesetDirectory(getConfigValue(BASEDIR_KEY, configMap));
+        droolsEngine.setRulesetPath(getConfigValue(POLICIES_FOLDER_PATH, configMap));
+    }
+
+    @Override
+    public IPolicyEvaluation evaluate(Collection<Artifact> artifacts) throws AntennaException {
+        return droolsEngine.evaluate(artifacts);
+    }
+
+    @Override
+    public WorkflowStepResult postProcessResult(WorkflowStepResult result) {
+        result.addAdditionalReportComment("Evaluated with Antenna Drools Engine, rules and policies version ["
+                + droolsEngine.getRulesetVersion().orElse(NO_VERSION) + "]");
+        return result;
+    }
+
+    @Override
+    public String getRulesetDescription() {
+        return "Antenna Drools Engine, rules and policies version [" +
+                droolsEngine.getRulesetVersion().orElse(NO_VERSION) + "]";
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEngineTest.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEngineTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DroolsEngineTest {
+
+    private static final String RESOURCE_PATH = "../../../../../policies/policies.properties";
+    private DroolsEngine droolsEngine;
+
+    @Before
+    public void init() throws URISyntaxException {
+        URL resource = getClass().getResource(RESOURCE_PATH);
+        Path path = Paths.get(resource.toURI());
+        String resourcesFolderPath = path.getParent().getParent().toString();
+
+        droolsEngine = new DroolsEngine();
+        droolsEngine.setRulesetDirectory(resourcesFolderPath);
+        droolsEngine.setRulesetPath("policies");
+    }
+
+    @Test
+    public void evaluateIdentifiesNonOSSLicensesAsFailuresWithDummyRule() throws AntennaException {
+        Artifact artifact1 = new Artifact();
+        artifact1.setProprietary(false);
+
+        Artifact artifact2 = new Artifact();
+        artifact2.setProprietary(true);
+
+        IPolicyEvaluation evaluationResults = droolsEngine.evaluate(Arrays.asList(artifact1, artifact2));
+
+        List<Artifact> failedArtifacts = getAllFailedArtifacts(evaluationResults);
+
+        assertThat(failedArtifacts).containsExactly(artifact2);
+    }
+
+    @Test(expected = AntennaException.class)
+    public void evaluateThrowsAnExceptionIfRulesetCannotBeFound() throws AntennaException {
+        droolsEngine = new DroolsEngine();
+        droolsEngine.setRulesetDirectory("");
+        droolsEngine.evaluate(Collections.emptyList());
+    }
+
+    @Test
+    public void getVersionsCanReadPropertiesFile() {
+        assertThat(droolsEngine.getRulesetVersion()).contains("0.0.0");
+    }
+
+    private List<Artifact> getAllFailedArtifacts(IPolicyEvaluation evaluationResults) {
+        return evaluationResults.getEvaluationResults()
+                    .stream()
+                    .map(IEvaluationResult::getFailedArtifacts)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toList());
+    }
+
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitorTest.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DroolsRuleFolderVisitorTest {
+
+    private static final String RESOURCE_PATH = "../../../../../policies/policies.properties";
+    private Path folderPath;
+
+    @Before
+    public void init() throws URISyntaxException {
+        URL resource = getClass().getResource(RESOURCE_PATH);
+        Path path = Paths.get(resource.toURI());
+        String resourcesFolderPath = path.getParent().getParent().toString();
+
+        folderPath = Paths.get(resourcesFolderPath, "policies", "");
+    }
+
+    @Test
+    public void usingFileVisitorOnExistingDirectoryWorksCorrectly() throws Exception {
+        DroolsRuleFolderVisitor collectRuleFiles = new DroolsRuleFolderVisitor();
+        Files.walkFileTree(folderPath, collectRuleFiles);
+        List<File> collectedFiles = collectRuleFiles.getRuleFiles();
+
+        assertThat(collectedFiles).hasSize(1);
+        assertThat(collectedFiles.get(0).getAbsolutePath()).endsWith("DummyRule.drl");
+    }
+
+    @Test
+    public void usingFileVisitorOnMissingDirectoryDoesNotThrow() throws Exception {
+        DroolsRuleFolderVisitor collectRuleFiles = new DroolsRuleFolderVisitor();
+        Files.walkFileTree(Paths.get("some/path"), collectRuleFiles);
+        List<File> collectedFiles = collectRuleFiles.getRuleFiles();
+
+        assertThat(collectedFiles).hasSize(0);
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/policies.properties
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/policies.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+policies.version=0.0.0

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/rules/DummyRule.drl
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/rules/DummyRule.drl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.exampleproject
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult
+
+import java.util.List;
+
+rule "Artifacts must be open source"
+no-loop true
+when
+    a : Artifact( isProprietary() == true )
+    e : DroolsEvaluationResult( getId() == "Dummy" )
+then
+    modify (e) { addFailedArtifact(a) };
+end

--- a/example-projects/example-policies/policies.properties
+++ b/example-projects/example-policies/policies.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+policies.version=0.0.0

--- a/example-projects/example-policies/rules/DummyRule.drl
+++ b/example-projects/example-policies/rules/DummyRule.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.exampleproject
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult
+
+import java.util.List;
+
+rule "Unkown artifact"
+no-loop true
+when
+    a : Artifact( getMatchState() == MatchState.UNKNOWN,
+        isProprietary() == false )
+    e : DroolsEvaluationResult( getId() == "Dummy" )
+then
+    modify (e) { addFailedArtifact(a) };
+end

--- a/example-projects/example-project/src/workflow.xml
+++ b/example-projects/example-project/src/workflow.xml
@@ -48,6 +48,16 @@
             </configuration>
         </step>
     </generators>
+    <processors>
+        <step>
+            <name>Drools Policy Engine</name>
+            <classHint>org.eclipse.sw360.antenna.workflow.processors.checkers.AntennaDroolsChecker</classHint>
+            <configuration>
+                <entry key="base.dir" value="${project.basedir}"/>
+                <entry key="folder.path" value="../example-policies"/>
+            </configuration>
+        </step>
+    </processors>
     <outputHandlers>
         <step>
             <name>Add disclosure document to jar</name>


### PR DESCRIPTION
This PR introduces a checker workflow step.

Current scope:
- Rules can be written in Drools and have to be provided in a folder referenced in the workflow step
- Rules will be evaluated for all artifacts and the build will fail if any rule fires

Missing:
- Documentation (the API may still change significantly, until then, the example projects will show how to use the features)

Features to be added:
- Allow specifying evaluation results (currently, all rule failures will be added to a "dummy" policy evaluation.
- Allow or simplify writing rules comparing information between artifacts.