### PR TITLE
Build policy engine harness

### DIFF
--- a/antenna-testing/antenna-rule-engine-testing/pom.xml
+++ b/antenna-testing/antenna-rule-engine-testing/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>antenna-testing</artifactId>
+        <groupId>org.eclipse.sw360.antenna</groupId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>antenna-rule-engine-testing</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-drools-checker</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-api</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-internal</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-compiler</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <!-- ################################ dependencies needed for test harness ################################ -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/AbstractDroolsValidatorTest.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/AbstractDroolsValidatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+
+public class AbstractDroolsValidatorTest {
+
+    private List<Artifact> artifacts;
+    private List<IEvaluationResult> evaluations;
+
+    @Before
+    public void init() {
+        artifacts = new ArrayList<>();
+        evaluations = new ArrayList<>();
+    }
+
+    /**
+     * Add an artifact which will be scanned by this test
+     *
+     * @param artifact to be added to the test run
+     */
+    public void addArtifact(Artifact artifact) {
+        artifacts.add(artifact);
+    }
+
+    /**
+     * Add an evaluation policy used by the rules in the test. Usually, a rule will add artifacts that fail the rule to
+     * one or more evaluation results. Those results will later be scanned for failed artifacts. Therefore, all evaluation
+     * policy results used by the rule to be tested should be added.
+     *
+     * @param evaluationResult to be added to the test run
+     */
+    public void addEvaluationPolicyResult(DroolsEvaluationResult evaluationResult) {
+        evaluations.add(evaluationResult);
+    }
+
+    /**
+     * Given the file name of the rule to be used, creates a Rules object. Use together with RuleResultsAssert via:
+     *
+     * assertThat(rule("MyCustomRule.drl").whenRunning())...
+     *
+     * @param filename of the rule (e.g. "MyCustomRule.drl") in the rules project
+     * @return a Rule object
+     */
+    public Rule rule(String filename) {
+        return new Rule(this, filename, artifacts, evaluations);
+    }
+
+    /**
+     * Entry point for evaluating rules. Use as assertThat(rule("MyCustomRule.drl").whenRunning()
+     *
+     * @param results result of running a rule, obtain via rule("MyCustomRule.drl").whenRunning()
+     * @return
+     */
+    public static RuleResultsAssert assertThat(RuleResults results) {
+        return RuleResultsAssert.assertThat(results);
+    }
+}

--- a/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/PartialRuleAssertionResults.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/PartialRuleAssertionResults.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PartialRuleAssertionResults extends AbstractAssert<PartialRuleAssertionResults, RuleResults> {
+    private List<Artifact> artifacts;
+
+    PartialRuleAssertionResults(RuleResults results, List<Artifact> artifacts) {
+        super(results, PartialRuleAssertionResults.class);
+        this.artifacts = artifacts;
+    }
+
+    /**
+     * Passes test if all artifacts for this partial result fail policy with ID id. Additional artifacts may also fail
+     * with the given id.
+     *
+     * Usage: failsArtifacts(artifact1, artifact2).withPolicyId("MyId") will only pass if artifact1 and artifact2 fail
+     * the rule for policy "MyId". If they fail only for different policies or not at all, the test will fail.
+     *
+     * @param id of evaluation result where the artifacts should have failed the rule
+     * @return The original RuleResults for method chaining
+     */
+    public RuleResultsAssert withPolicyId(String id) {
+        IEvaluationResult correctPolicyResult = findEvaluationWithId(id);
+
+        if (!correctPolicyResult.getFailedArtifacts().containsAll(artifacts)) {
+            List<Artifact> unexpectedlyPassingArtifacts =
+                    filterPassingArtifactsWhichAreExpectedToFail(this.artifacts, correctPolicyResult.getFailedArtifacts());
+            failWithMessage("Expected rule " + actual.getName() + " to fail artifacts "
+                    + unexpectedlyPassingArtifacts + ".");
+        }
+
+        return new RuleResultsAssert(actual);
+    }
+
+    /**
+     * Passes test if all artifacts for this partial result fail policy with ID id and those are the only artifacts that
+     * fail the rule
+     *
+     * Usage: failsArtifacts(artifact1, artifact2).withPolicyId("MyId") will pass if artifact1 and artifact2 fail
+     * the rule for policy "MyId" and are the only failures for that rule.
+     *
+     * @param id of evaluation result where the artifacts should have failed the rule
+     * @return The original RuleResults for method chaining
+     */
+    public RuleResultsAssert whichAreExactlyThoseWithPolicyId(String id) {
+        IEvaluationResult correctPolicyResult = findEvaluationWithId(id);
+
+        if (!correctPolicyResult.getFailedArtifacts().containsAll(artifacts) || !artifacts.containsAll(correctPolicyResult.getFailedArtifacts())) {
+            List<Artifact> unexpectedlyPassingArtifacts =
+                    filterPassingArtifactsWhichAreExpectedToFail(this.artifacts, correctPolicyResult.getFailedArtifacts());
+
+            List<Artifact> unexpectedlyFailingArtifacts = correctPolicyResult.getFailedArtifacts()
+                    .stream()
+                    .filter(artifact -> !artifacts.contains(artifact))
+                    .collect(Collectors.toList());
+
+            failWithMessage("Expected rule" + actual.getName() + "  to fail artifacts "
+                    + unexpectedlyPassingArtifacts + " but instead failed artifacts " + unexpectedlyFailingArtifacts + ".");
+        }
+
+        return new RuleResultsAssert(actual);
+    }
+
+    private IEvaluationResult findEvaluationWithId(String id) {
+        return actual.getEvaluations().stream()
+                .filter(evaluation -> evaluation.getId().equals(id))
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("Policy with Id " + id + " does not exist"));
+    }
+
+    private List<Artifact> filterPassingArtifactsWhichAreExpectedToFail(List<Artifact> actualViolations, Set<Artifact> expectedViolations) {
+        return expectedViolations.stream()
+                .filter(artifact -> !actualViolations.contains(artifact))
+                .collect(Collectors.toList());
+    }
+}

--- a/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/Rule.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/Rule.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieRepository;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.io.ResourceFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.List;
+
+public class Rule {
+    private static final String RELATIVE_PATH_TO_RULES_FOLDER = "../../../policies/rules/";
+
+    private final String name;
+    private AbstractDroolsValidatorTest validatorTest;
+    private List<Artifact> artifacts;
+    private List<IEvaluationResult> evaluations;
+
+    Rule(AbstractDroolsValidatorTest test, String rule, List<Artifact> artifacts, List<IEvaluationResult> evaluations) {
+        this.validatorTest = test;
+        this.artifacts = artifacts;
+        this.evaluations = evaluations;
+        this.name = rule;
+    }
+
+    /**
+     * Run the rule. Using all artifacts and policy evaluations added before creating the rule, this command runs the
+     * rules and outputs all artifacts that fail the rules grouped by policy evaluation. In the sw360antenna workflow step,
+     * this list is then processed further.
+     *
+     * @return results of running the rule, i.e. a list of all evaluation results containing all failed artifacts together
+     *   with the severity evaluation.
+     * @throws FileNotFoundException if the rule file cannot be found in the resource folder
+     */
+    public RuleResults whenRunning() throws FileNotFoundException {
+        URL resource = getUrlToRuleFile(name);
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
+
+        File ruleFile = new File(resource.getPath());
+        kieFileSystem.write(ResourceFactory.newFileResource(ruleFile).setResourceType(ResourceType.DRL));
+
+        KieBuilder kieBuilder = kieServices.newKieBuilder(kieFileSystem);
+        kieBuilder.buildAll();
+
+        KieRepository kieRepository = kieServices.getRepository();
+        KieContainer kieContainer = kieServices.newKieContainer(kieRepository.getDefaultReleaseId());
+        KieSession kieSession = kieContainer.newKieSession();
+
+        artifacts.forEach(kieSession::insert);
+        evaluations.forEach(kieSession::insert);
+
+        int rulesFired = kieSession.fireAllRules();
+
+        return new RuleResults(name, evaluations);
+    }
+
+    private URL getUrlToRuleFile(String rule) throws FileNotFoundException {
+        URL resource = validatorTest.getClass().getResource(RELATIVE_PATH_TO_RULES_FOLDER + rule);
+
+        if (resource == null) {
+            throw new FileNotFoundException("Could not find file for rule " + rule + ".");
+        }
+        return resource;
+    }
+}

--- a/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/RuleResults.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/RuleResults.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+
+import java.util.List;
+
+public class RuleResults {
+    private List<IEvaluationResult> evaluations;
+    private String name;
+
+    RuleResults(String name, List<IEvaluationResult> evaluations) {
+        this.evaluations = evaluations;
+        this.name = name;
+    }
+
+    List<IEvaluationResult> getEvaluations() {
+        return evaluations;
+    }
+
+    String getName() {
+        return name;
+    }
+}

--- a/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/RuleResultsAssert.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/RuleResultsAssert.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RuleResultsAssert extends AbstractAssert<RuleResultsAssert, RuleResults> {
+
+    RuleResultsAssert(RuleResults ruleResults) {
+        super(ruleResults, RuleResultsAssert.class);
+    }
+
+    static RuleResultsAssert assertThat(RuleResults actual) {
+        return new RuleResultsAssert(actual);
+    }
+
+    /**
+     * Passes the test only if some artifacts fail the rule
+     */
+    public void fails() {
+        List<Artifact> actualViolations = getAllArtifactViolations();
+
+        if (actualViolations.isEmpty()) {
+            failWithMessage("Expected rule " + actual.getName() +
+                    " to fail some artifacts but failed none.");
+        }
+    }
+
+    /**
+     * Passes the test only if all artifacts pass the rule
+     */
+    public void passesAllArtifacts() {
+        List<Artifact> actualViolations = getAllArtifactViolations();
+
+        if (!actualViolations.isEmpty()) {
+            failWithMessage("Expected rule " + actual.getName() +
+                    " to pass all artifacts but failed " + actualViolations + ".");
+        }
+    }
+
+    /**
+     * Fails the test if all given artifacts are listed as artifact failures. There may be more failures.
+     * Use this method when asserting artifact failures for a certain policy.
+     *
+     * @param artifacts expected to fail the rules test
+     * @return an assertion object which also encapsulates the artifacts handed into this method
+     */
+    public PartialRuleAssertionResults failsArtifacts(Artifact... artifacts) {
+        List<Artifact> allArtifactViolations = getAllArtifactViolations();
+
+        if (!allArtifactViolations.containsAll(Arrays.asList(artifacts))) {
+            List<Artifact> passingArtifactsWhichShouldFail =
+                    filterPassingArtifactsWhichAreExpectedToFail(allArtifactViolations, Arrays.asList(artifacts));
+            failWithMessage("Expected rule " + actual.getName() +
+                    " to fail artifacts " + passingArtifactsWhichShouldFail + " but did not.");
+        }
+
+        return new PartialRuleAssertionResults(actual, Arrays.asList(artifacts));
+    }
+
+    /**
+     * Fails the test if the given list of artifacts is identical to the complete list of failures (including duplicates)
+     *
+     * @param artifacts expected to fail the rules test
+     * @return an assertion object which also encapsulates the artifacts handed into this method
+     */
+    public PartialRuleAssertionResults failsExactlyArtifacts(Artifact... artifacts) {
+        List<Artifact> actualViolations = getAllArtifactViolations();
+        List<Artifact> expectedViolations = Arrays.asList(artifacts);
+
+        if (!actualViolations.containsAll(expectedViolations) || !expectedViolations.containsAll(actualViolations)) {
+            List<Artifact> passingArtifactsWhichShouldFail =
+                    filterPassingArtifactsWhichAreExpectedToFail(actualViolations, expectedViolations);
+
+            List<Artifact> artifactsWhichAlsoFail = actualViolations.stream()
+                    .filter(expectedViolations::contains)
+                    .collect(Collectors.toList());
+
+            failWithMessage("Expected rule " + actual.getName() + " to fail artifacts "
+                    + passingArtifactsWhichShouldFail + " but instead failed additional artifacts " + artifactsWhichAlsoFail + ".");
+        }
+
+        return new PartialRuleAssertionResults(actual, expectedViolations);
+    }
+
+    private List<Artifact> filterPassingArtifactsWhichAreExpectedToFail(List<Artifact> actualViolations, List<Artifact> expectedViolations) {
+        return expectedViolations.stream()
+                .filter(artifact -> !actualViolations.contains(artifact))
+                .collect(Collectors.toList());
+    }
+
+    private List<Artifact> getAllArtifactViolations() {
+        return actual.getEvaluations().stream()
+                .map(IEvaluationResult::getFailedArtifacts)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/antenna-testing/antenna-rule-engine-testing/src/test/java/org/eclipse/sw360/antenna/droolstesting/DroolsAssertionsTest.java
+++ b/antenna-testing/antenna-rule-engine-testing/src/test/java/org/eclipse/sw360/antenna/droolstesting/DroolsAssertionsTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.droolstesting;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactMatchingMetadata;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.eclipse.sw360.antenna.droolstesting.AbstractDroolsValidatorTest.assertThat;
+
+public class DroolsAssertionsTest {
+
+    @Test(expected = AssertionError.class)
+    public void passesAllArtifactsFailsTestIfSomeArtifactIsInFailure() {
+        Artifact artifact = new Artifact();
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).passesAllArtifacts();
+    }
+
+    @Test
+    public void failsPassesTestIfSomeArtifactIsInFailure() {
+        Artifact artifact = new Artifact();
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).fails();
+    }
+
+    @Test
+    public void failsArtifactsPassesTestIfAllExpectedArtifactsFail() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsArtifacts(artifact1, artifact2);
+    }
+
+    @Test
+    public void failsArtifactsPassesTestIfOnlyASubsetOfFailedArtifactsIsDeclaredAsFailure() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsArtifacts(artifact1);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void failsArtifactsFailsTestIfSomeDeclaredFailureIsMissing() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsArtifacts(artifact1);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void failsExactlyArtifactsFailsTestIfOnlyASubsetOfFailedArtifactsIsDeclaredAsFailure() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsExactlyArtifacts(artifact1);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void failsExactlyArtifactsFailsTestIfUndeclaredArtifactsFail() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsExactlyArtifacts(artifact2);
+    }
+
+    @Test
+    public void withPolicyIdPassesTestIfDeclaredArtifactsFail() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults = getTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Collections.singletonList(droolsEvaluationResults));
+
+        assertThat(testing).failsArtifacts(artifact2).withPolicyId("TestId");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void whichAreExactlyThoseWithPolicyIdFailsTestIfSomeArtifactsAreMissing() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+        Artifact artifact3 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.SIMILAR));
+
+        IEvaluationResult droolsEvaluationResults1 = getTestIdEvaluation(artifact1, artifact3);
+        IEvaluationResult droolsEvaluationResults2 = getWrongTestIdEvaluation(artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Arrays.asList(droolsEvaluationResults1, droolsEvaluationResults2));
+
+        assertThat(testing).failsArtifacts(artifact1).whichAreExactlyThoseWithPolicyId("TestId");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void withPolicyIdFailsTestIfArtifactsFailWithWrongPolicyFail() {
+        Artifact artifact1 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.UNKNOWN));
+        Artifact artifact2 = new Artifact().addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+
+        IEvaluationResult droolsEvaluationResults1 = getTestIdEvaluation();
+        IEvaluationResult droolsEvaluationResults2 = getWrongTestIdEvaluation(artifact1, artifact2);
+
+        RuleResults testing = new RuleResults("MyCustomRule", Arrays.asList(droolsEvaluationResults1, droolsEvaluationResults2));
+
+        assertThat(testing).failsArtifacts(artifact1, artifact2).withPolicyId("TestId");
+    }
+
+    private IEvaluationResult getTestIdEvaluation(Artifact... artifacts) {
+        return new DroolsEvaluationResult("TestId", "For testing",
+                IEvaluationResult.Severity.INFO, new HashSet<>(Arrays.asList(artifacts)));
+    }
+
+    private IEvaluationResult getWrongTestIdEvaluation(Artifact... artifacts) {
+        return new DroolsEvaluationResult("WrongTestId", "For testing",
+                IEvaluationResult.Severity.FAIL, new HashSet<>(Arrays.asList(artifacts)));
+    }
+
+}

--- a/antenna-testing/pom.xml
+++ b/antenna-testing/pom.xml
@@ -26,6 +26,7 @@
         <module>antenna-core-common-testing</module>
         <module>antenna-frontend-stubs-testing</module>
         <module>antenna-stupid-license-knowledge-base</module>
+        <module>antenna-rule-engine-testing</module>
     </modules>
 
     <profiles>

--- a/example-projects/rules-test-development-project/pom.xml
+++ b/example-projects/rules-test-development-project/pom.xml
@@ -1,0 +1,91 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.sw360.antenna</groupId>
+    <artifactId>rules-test-development-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test PolicyDevelopmentEnvironment</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-api</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-model</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-rule-engine-testing</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-api</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-internal</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-compiler</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+            <version>6.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/resources</directory>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/example-projects/rules-test-development-project/src/resources/policies/policies.properties
+++ b/example-projects/rules-test-development-project/src/resources/policies/policies.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+policies.version=0.0.0

--- a/example-projects/rules-test-development-project/src/resources/policies/rules/UnknownArtifactRule.drl
+++ b/example-projects/rules-test-development-project/src/resources/policies/rules/UnknownArtifactRule.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.bosch.tina.rules.drools
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult;
+
+import java.util.List;
+
+rule "Unkown artifact"
+no-loop true
+when
+    a : Artifact( getMatchState() == MatchState.UNKNOWN,
+        isProprietary() == false )
+    e : DroolsEvaluationResult( getId() == "Unknown" )
+then
+    modify (e) { addFailedArtifact(a) };
+end

--- a/example-projects/rules-test-development-project/src/test/java/org/eclipse/rulestesting/RulesTests.java
+++ b/example-projects/rules-test-development-project/src/test/java/org/eclipse/rulestesting/RulesTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.rulestesting;
+
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactMatchingMetadata;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult;
+import org.eclipse.sw360.antenna.droolstesting.AbstractDroolsValidatorTest;
+import org.junit.Test;
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieRepository;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.api.io.ResourceType;
+
+public class RulesTests extends AbstractDroolsValidatorTest {
+    @Test
+    public void testArtifactWithRuleAndFailedArtifact() throws Exception {
+        Artifact artifact = new Artifact();
+        addArtifact(artifact);
+
+        addEvaluationPolicyResult(
+                new DroolsEvaluationResult("Unknown", "Some description of unknown artifacts", IEvaluationResult.Severity.FAIL, null));
+
+        assertThat(rule("UnknownArtifactRule.drl").whenRunning())
+                .failsExactlyArtifacts(artifact)
+                .withPolicyId("Unknown");
+    }
+
+    @Test
+    public void testArtifactWithRuleAndPassedArtifacts() throws Exception {
+        Artifact artifact = new Artifact();
+        artifact.addFact(new ArtifactMatchingMetadata(MatchState.EXACT));
+        addArtifact(artifact);
+
+        addEvaluationPolicyResult(
+                new DroolsEvaluationResult("Unknown", "Some description of unknown artifacts", IEvaluationResult.Severity.FAIL, null));
+
+        assertThat(rule("UnknownArtifactRule.drl").whenRunning()).passesAllArtifacts();
+    }
+}


### PR DESCRIPTION
This is the first iteration of help and documentation to develop rules for the policy engine.

The example development environment shows how it is possible to write readable and easy tests.