### PR TITLE
fix(workflowItemFactory): changed getAsMap()

### DIFF
--- a/antenna-model/src/main/resources/bindings.xjb
+++ b/antenna-model/src/main/resources/bindings.xjb
@@ -280,11 +280,11 @@
     }
 
     public java.util.Map<String,String> getAsMap() {
-        final java.util.Map<String, String> result = entry.stream()
-                .filter(java.util.Objects::nonNull)
-                .filter(e -> getKeyOfEntry(e) != null)
-                .collect(java.util.stream.Collectors.toMap(this::getKeyOfEntry, this::getValueOfEntry, (value1, value2) -> value2));
-        return result;
+        final java.util.Map<String, String> result = new java.util.HashMap<>();
+        entry.stream().filter(java.util.Objects::nonNull)
+            .filter(e -> getKeyOfEntry(e) != null)
+            .forEach(e -> result.put(getKeyOfEntry(e), getValueOfEntry(e)));
+        return java.util.Collections.unmodifiableMap(result);
     }
 
     public static StepConfiguration fromMap(java.util.Map<String,String> map) {

--- a/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/MavenTestProject.java
+++ b/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/MavenTestProject.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.frontend.testProjects;
 
+import com.google.common.collect.ImmutableMap;
 import org.eclipse.sw360.antenna.api.IAttachable;
 import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.model.xml.generated.StepConfiguration;
@@ -90,16 +91,26 @@ public class MavenTestProject extends AbstractTestProjectWithExpectations implem
 
     @Override
     public List<WorkflowStep> getExpectedToolConfigurationProcessors() {
-        final List<WorkflowStep> processors = new BasicConfiguration().getProcessors();
-        processors.stream()
-                .filter(s -> "Source Validator".equals(s.getName()))
-                .forEach( s -> {
-                    final Map<String, String> map = s.getConfiguration().getAsMap();
-                    map.put("missingSourcesSeverity","FAIL");
-                    s.setConfiguration(StepConfiguration.fromMap(map));
-                    s.setDeactivated(true);
-                });
-        return processors;
+        return new BasicConfiguration().getProcessors()
+               .stream()
+               .map( s -> {
+                   if(!"Source Validator".equals(s.getName())) {
+                       return s;
+                   }
+                   final Map<String, String> map = Stream.of(s.getConfiguration().getAsMap(), Collections.singletonMap("missingSourcesSeverity", "FAIL"))
+                           .flatMap(m -> m.entrySet().stream())
+                           .collect(Collectors.toMap(
+                                   Map.Entry::getKey,
+                                   Map.Entry::getValue,
+                                   (v1, v2) -> v2));
+                   WorkflowStep newS = new WorkflowStep();
+                   newS.setName(s.getName());
+                   newS.setClassHint(s.getClassHint());
+                   newS.setConfiguration(StepConfiguration.fromMap(map));
+                   newS.setDeactivated(true);
+                   return newS;
+               })
+               .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Issue: 
- When the workflow was written in the pom.xml and undeclared property values were used in the entry values: `<entryValue>${propertyName}</entryValue>`, a NullPointerException was thrown, originating from StepConfiguration.getAsMap() using a Collectors.toMap() function which can not handle null entrys when internally calling merge. 

Solution:
- Was replaced with individually putting elements into Map and then returning this Map as an unmodifiableMap 