### PR TITLE
fix(cli): cli pom reader can now handle custom plugin names, necessary for custom assemblies

### DIFF
--- a/antenna-frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AbstractAntennaCLIFrontend.java
+++ b/antenna-frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AbstractAntennaCLIFrontend.java
@@ -35,6 +35,7 @@ public abstract class AbstractAntennaCLIFrontend implements AntennaFrontend {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAntennaCLIFrontend.class);
     private final Map<String, IAttachable> output = new HashMap<>();
     private DefaultProject project;
+    protected String pluginDescendantArtifactIdName = "antenna-maven-plugin";
 
     public AbstractAntennaCLIFrontend(File pomFile) {
         Path buildDir = getBuildDirFromPomFile(pomFile);
@@ -56,7 +57,7 @@ public abstract class AbstractAntennaCLIFrontend implements AntennaFrontend {
      */
     @Override
     public AntennaFrontendHelper init() throws AntennaConfigurationException {
-        ToolConfiguration toolConfiguration = new AntennaCLISettingsReader()
+        ToolConfiguration toolConfiguration = new AntennaCLISettingsReader(pluginDescendantArtifactIdName)
                 .readSettingsToToolConfiguration(project);
         
         // TODO: should be removed after P2ArtifactResolverOSGi works for AbstractAntennaCLIFrontend

--- a/antenna-frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLISettingsReader.java
+++ b/antenna-frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLISettingsReader.java
@@ -37,9 +37,17 @@ import java.util.stream.Collectors;
 class AntennaCLISettingsReader {
 
     private static final Logger log = LoggerFactory.getLogger(AntennaCLISettingsReader.class);
-    private static final String ANTENNA_CONF_XPATH = "descendant::plugin[artifactId='antenna-maven-plugin']/descendant-or-self::configuration";
-    
+    private String antennaConfXpath;
+
     private TemplateRenderer tr = new TemplateRenderer();
+
+    public AntennaCLISettingsReader(){
+        this("antenna-maven-plugin");
+    }
+
+    public AntennaCLISettingsReader(String pluginDescendantArtifactName){
+         antennaConfXpath = "descendant::plugin[artifactId='" + pluginDescendantArtifactName + "']/descendant-or-self::configuration";
+    }
 
     private void readProjectStringSetting(XmlSettingsReader reader, String name, Consumer<String> setter) {
         String value = reader.getStringProperty(name);
@@ -49,26 +57,26 @@ class AntennaCLISettingsReader {
     }
 
     private void readAntennaStringSetting(XmlSettingsReader reader, String name, Consumer<String> setter) {
-        String value = reader.getStringPropertyByXPath(ANTENNA_CONF_XPATH, name);
+        String value = reader.getStringPropertyByXPath(antennaConfXpath, name);
         if (value != null) {
             setter.accept(value);
         }
     }
 
     private void readAntennaStringSetting(XmlSettingsReader reader, String name, String defaultValue, Consumer<String> setter) {
-        String value = reader.getStringPropertyByXPath(ANTENNA_CONF_XPATH, name, defaultValue);
+        String value = reader.getStringPropertyByXPath(antennaConfXpath, name, defaultValue);
         if (value != null) {
             setter.accept(value);
         }
     }
 
     private void readAntennaIntSetting(XmlSettingsReader reader, String name, int defaultValue, Consumer<Integer> setter) {
-        int value = reader.getIntProperty(ANTENNA_CONF_XPATH, name, defaultValue);
+        int value = reader.getIntProperty(antennaConfXpath, name, defaultValue);
         setter.accept(value);
     }
 
     private void readAntennaBooleanSetting(XmlSettingsReader reader, String name, boolean defaultValue, Consumer<Boolean> setter) {
-        boolean value = reader.getBooleanProperty(ANTENNA_CONF_XPATH, name, defaultValue);
+        boolean value = reader.getBooleanProperty(antennaConfXpath, name, defaultValue);
         setter.accept(value);
     }
 


### PR DESCRIPTION
- A String variable was introduced that contains the plugin artifact id name
- When the protected variable of AbstractAntennaCLIFrontend is changed in one of it's inheriting classes, it gives the new artifact id name to the AntennaCliSettingsReader via constructor, where the CONF_XPATH is then changed, enabling the user to chose between the antenna artifact id they want.