### PR TITLE
add(rule): test rule spanning multiple artifacts

### DIFF
--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
@@ -70,5 +70,11 @@
             <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-json-analyzer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
@@ -109,6 +109,7 @@ public class DroolsEngine implements IRuleEngine {
     private List<IEvaluationResult> getEvaluationResults() {
         List<IEvaluationResult> results = new ArrayList<>();
         results.add(new DroolsEvaluationResult("Dummy", "Dummy rule", IEvaluationResult.Severity.FAIL));
+        results.add(new DroolsEvaluationResult("multipleArtifacts", "EPL vs GPL rule", IEvaluationResult.Severity.FAIL));
         return results;
     }
 

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitorTest.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsRuleFolderVisitorTest.java
@@ -48,8 +48,8 @@ public class DroolsRuleFolderVisitorTest {
         Files.walkFileTree(folderPath, collectRuleFiles);
         List<File> collectedFiles = collectRuleFiles.getRuleFiles();
 
-        assertThat(collectedFiles).hasSize(1);
-        assertThat(collectedFiles.get(0).getAbsolutePath()).endsWith("DummyRule.drl");
+        assertThat(collectedFiles).hasSize(2);
+        assertThat(collectedFiles.stream().map(File::getAbsolutePath).filter(s -> s.endsWith("DummyRule.drl"))).hasSize(1);
     }
 
     @Test

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/rules/EPLvsGPL.drl
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/rules/EPLvsGPL.drl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.exampleproject
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.DeclaredLicenseInformation;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult;
+
+import java.util.List;
+import java.util.Optional;
+
+function boolean checkForDeclaredLicense(Artifact artifact, String license) {
+    return artifact.askForGet(DeclaredLicenseInformation.class)
+            .map(dLicense -> dLicense.evaluate().contains(license))
+            .orElse(false);
+}
+
+rule "EPL vs GPL"
+no-loop true
+when
+    a1 : Artifact( )
+    a2 : Artifact( )
+    e : DroolsEvaluationResult( getId() == "multipleArtifacts" )
+    eval(checkForDeclaredLicense(a1 ,"EPL 2.0")
+    && checkForDeclaredLicense(a2 ,"GPL 2.0"))
+then
+    modify (e) { addFailedArtifact(a1) }
+    modify (e) { addFailedArtifact(a2) }
+end


### PR DESCRIPTION
Signed-off-by: Stephanie Neubauer <Stephanie.Neubauer@bosch-si.com>

a new rule was added to the resource/policies folder that test Artifacts against each other. Here a known License issue (EPL and GPL can not be in the project) was used to test and demonstrate. 
There were minor file changes to support multiple drool evaluation results in the code
