### PR TITLE
feature(policyengine): read policies from xml file

### DIFF
--- a/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
+++ b/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
@@ -37,7 +37,10 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
 
     @Override
     public List<String> getOutOfProjectFilesToCopy() {
-        return Stream.of("../example-policies/rules/DummyRule.drl", "../example-policies/policies/policies.properties")
+        return Stream.of(
+                "../example-policies/rules/DummyRule.drl",
+                "../example-policies/policies/policies.properties",
+                "../example-policies/policies.xml")
                 .collect(Collectors.toList());
     }
 

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>abstract-antenna-compliance-checker</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -77,4 +82,59 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>org.eclipse.sw360.antenna.drools.xml.generated</packageName>
+                    <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+                    <locale>en</locale>
+                    <sources>
+                        <source>
+                            ${project.basedir}/src/main/resources/policy.xsd
+                        </source>
+                    </sources>
+                    <arguments>
+                        <argument>-Xequals</argument>
+                        <argument>-XhashCode</argument>
+                        <argument>-Xinject-code</argument>
+                    </arguments>
+                    <xjbSources>
+                        <xjbSource>
+                            ${project.basedir}/src/main/resources/bindings.xjb
+                        </xjbSource>
+                    </xjbSources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEngine.java
@@ -40,6 +40,7 @@ public class DroolsEngine implements IRuleEngine {
     private String rulesetPath = "";
     private static final String RULES_SUBFOLDER = "rules";
     private static final String POLICIES_PROPERTIES_FILENAME = "policies.properties";
+    private static final String POLICIES_FILENAME = "policies.xml";
     private static final String POLICIES_VERSION = "policies.version";
 
     public void setRulesetDirectory(String rulesetDirectory) {
@@ -105,12 +106,8 @@ public class DroolsEngine implements IRuleEngine {
         }
     }
 
-    // TODO Load evaluation result definitions from folder given by workflow step
-    private List<IEvaluationResult> getEvaluationResults() {
-        List<IEvaluationResult> results = new ArrayList<>();
-        results.add(new DroolsEvaluationResult("Dummy", "Dummy rule", IEvaluationResult.Severity.FAIL));
-        results.add(new DroolsEvaluationResult("multipleArtifacts", "EPL vs GPL rule", IEvaluationResult.Severity.FAIL));
-        return results;
+    private List<IEvaluationResult> getEvaluationResults() throws AntennaException {
+        return DroolsEvaluationResultReader.getEvaluationResult(Paths.get(rulesetDirectory, rulesetPath, POLICIES_FILENAME));
     }
 
     @Override

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResult.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResult.java
@@ -23,6 +23,8 @@ public class DroolsEvaluationResult implements IEvaluationResult {
     private String description;
     private Set<Artifact> failedArtifacts = new HashSet<>();
 
+    public DroolsEvaluationResult() {};
+
     public DroolsEvaluationResult(String id, String description, Severity severity) {
         this(id, description, severity, null);
     }
@@ -54,6 +56,18 @@ public class DroolsEvaluationResult implements IEvaluationResult {
     @Override
     public Set<Artifact> getFailedArtifacts() {
         return this.failedArtifacts;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setSeverity(Severity severity) {
+        this.severity = severity;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public void addFailedArtifact(Artifact a) {

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResultReader.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResultReader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.drools.xml.generated.Policies;
+import org.eclipse.sw360.antenna.util.XmlSettingsReader;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class DroolsEvaluationResultReader {
+
+    private DroolsEvaluationResultReader() {
+        // Utility class
+    }
+
+    public static List<IEvaluationResult> getEvaluationResult(Path policesPath) throws AntennaException {
+        if (policesPath.toFile().exists() && policesPath.toFile().isFile()) {
+            try {
+                String policyXml = Files.lines(policesPath).map(String::trim).collect(Collectors.joining());
+                XmlSettingsReader policyReader = new XmlSettingsReader(policyXml);
+                List<IEvaluationResult> result = new ArrayList<>();
+                policyReader.getComplexType("policies", Policies.class).getPolicy().forEach(result::add);
+                return result;
+            } catch (Exception e) {
+                throw new AntennaException("Could not read the policies. Details: " + e.getMessage());
+            }
+        } else if (policesPath.toFile().exists() && !policesPath.toFile().isFile()) {
+            throw new AntennaException("Given path [" + policesPath.normalize().toString() + "] is not a file.");
+        } else {
+            throw new AntennaException("Given path [" + policesPath.normalize().toString() + "] does not exist.");
+        }
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/resources/bindings.xjb
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/resources/bindings.xjb
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<jxb:bindings version="1.0"
+              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+              xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector">
+
+    <jxb:bindings schemaLocation="policy.xsd">
+        <jxb:bindings node="//xsd:complexType[@name='policy']">
+            <jxb:class name="FromXmlPolicy" ref="org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult"/>
+        </jxb:bindings>
+        <jxb:bindings node="//xsd:complexType[@name='severity']">
+            <jxb:class name="FromXmlSeverity" ref="org.eclipse.sw360.antenna.api.IEvaluationResult.Severity"/>
+        </jxb:bindings>
+    </jxb:bindings>
+</jxb:bindings>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/resources/policy.xsd
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/resources/policy.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="policies">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="policy" type="policy" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:complexType name="policy">
+        <xsd:sequence>
+            <xsd:element name="id" type="xsd:string"/>
+            <xsd:element name="description" type="xsd:string"/>
+            <xsd:element name="severity" type="severity"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="severity">
+    </xsd:complexType>
+</xsd:schema>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEngineTest.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEngineTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DroolsEngineTest {
 
     private static final String RESOURCE_PATH = "../../../../../policies/policies.properties";
+    private static final String POLICIES_FILENAME = "policies.xml";
     private DroolsEngine droolsEngine;
 
     @Before
@@ -57,6 +58,11 @@ public class DroolsEngineTest {
         IPolicyEvaluation evaluationResults = droolsEngine.evaluate(Arrays.asList(artifact1, artifact2));
 
         List<Artifact> failedArtifacts = getAllFailedArtifactsOfEvaluator(evaluationResults, "Dummy");
+
+        assertThat(evaluationResults.getEvaluationResults().stream()
+                .map(IEvaluationResult::getId)
+                .anyMatch(s -> s.equals("Dummy")))
+                .isEqualTo(true);
 
         assertThat(failedArtifacts).containsExactly(artifact2);
     }

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResultReaderTest.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/java/org/eclipse/sw360/antenna/bundle/DroolsEvaluationResultReaderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.bundle;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sw360.antenna.api.IEvaluationResult.Severity.WARN;
+
+public class DroolsEvaluationResultReaderTest {
+
+    private static final String POLICY_ID = "Dummy";
+    private static final String POLICY_DESC = "This is a dummy policy.";
+    private static final IEvaluationResult.Severity POLICY_SEVERITY = WARN;
+
+    private static final String EXP_MSG_IS_NOT_FILE = "is not a file";
+    private static final String EXP_MSG_DOES_NOT_FILE = "does not exist";
+
+    private static final String POLICIES_FILENAME = "../../../../../policies/policies.xml";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void testNotExistingPolicyFile() throws AntennaException {
+        Path p = Paths.get("not/existing/file");
+
+        thrown.expect(AntennaException.class);
+        thrown.expectMessage(EXP_MSG_DOES_NOT_FILE);
+
+        DroolsEvaluationResultReader.getEvaluationResult(p);
+    }
+
+    @Test
+    public void testIsNotPolicyFile() throws AntennaException, IOException {
+        Path p = testFolder.newFolder("rootOfFile").toPath();
+
+        thrown.expect(AntennaException.class);
+        thrown.expectMessage(EXP_MSG_IS_NOT_FILE);
+
+        DroolsEvaluationResultReader.getEvaluationResult(p);
+    }
+
+    @Test
+    public void testWithValidPolicyFile() throws URISyntaxException, AntennaException {
+        Path p = Paths.get(getClass().getResource(POLICIES_FILENAME).toURI());
+        List<IEvaluationResult> r = DroolsEvaluationResultReader.getEvaluationResult(p);
+
+        assertThat(r).hasSize(2);
+        assertThat(r.stream()
+            .map(IEvaluationResult::getId)
+            .anyMatch(i -> i.equals(POLICY_ID))).isEqualTo(true);
+        assertThat(r.stream()
+                .map(IEvaluationResult::getDescription)
+                .anyMatch(d -> d.contains(POLICY_DESC))).isEqualTo(true);
+        assertThat(r.stream()
+                .map(IEvaluationResult::getSeverity)
+                .anyMatch(s -> s.equals(POLICY_SEVERITY))).isEqualTo(true);
+    }
+}

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/policies.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policies/policies.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<policies>
+    <policy>
+        <id>Dummy</id>
+        <description>This is a dummy policy.</description>
+        <severity>WARN</severity>
+    </policy>
+    <policy>
+        <id>multipleArtifacts</id>
+        <description>EPL vs GPL rule</description>
+        <severity>FAIL</severity>
+    </policy>
+</policies>

--- a/example-projects/example-policies/policies.xml
+++ b/example-projects/example-policies/policies.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<policies>
+    <policy>
+        <id>A1</id>
+        <description>Dummy A1 Policy</description>
+        <severity>FAIL</severity>
+    </policy>
+    <policy>
+        <id>A2</id>
+        <description>Dummy A2 Policy</description>
+        <severity>WARN</severity>
+    </policy>
+</policies>


### PR DESCRIPTION
This PR extends the drools checker. It allows specifying evaluation results via an xml file named `policies.xml`.