### PR TITLE
polEng(multFolder): allows multiple rule folders

### DIFF
--- a/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
+++ b/antenna-testing/antenna-frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testProjects/ExampleTestProject.java
@@ -111,7 +111,7 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
         // checkers
         WorkflowStep checker1 = mkWorkflowStep("Drools Policy Engine", "org.eclipse.sw360.antenna.workflow.processors.checkers.AntennaDroolsChecker",
                 "base.dir", this.projectRoot.toString(),
-                "folder.path", "../example-policies");
+                "folder.paths", "../example-policies");
         processors.add(checker1);
         return processors;
     }

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AntennaDroolsChecker.java
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AntennaDroolsChecker.java
@@ -18,21 +18,27 @@ import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
 import org.eclipse.sw360.antenna.bundle.DroolsEngine;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 public class AntennaDroolsChecker extends AbstractComplianceChecker {
     private final DroolsEngine droolsEngine = new DroolsEngine();
 
     private static final String BASEDIR_KEY = "base.dir";
-    private static final String POLICIES_FOLDER_PATH = "folder.path";
+    private static final String POLICIES_FOLDER_PATH = "folder.paths";
     private static final String NO_VERSION = "no version string specified";
 
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         super.configure(configMap);
         droolsEngine.setRulesetDirectory(getConfigValue(BASEDIR_KEY, configMap));
-        droolsEngine.setRulesetPath(getConfigValue(POLICIES_FOLDER_PATH, configMap));
+
+        StringTokenizer tokenizer = new StringTokenizer(getConfigValue(POLICIES_FOLDER_PATH, configMap), ";");
+        List<String> folderList = new ArrayList<>();
+        while(tokenizer.hasMoreTokens()) {
+            folderList.add(tokenizer.nextToken());
+        }
+
+        droolsEngine.setRulesetPaths(folderList);
     }
 
     @Override

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/policies.properties
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/policies.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+policies.version=0.0.0

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/policies.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/policies.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<policies>
+    <policy>
+        <id>DummyTheSecond</id>
+        <description>This is a dummy policy.</description>
+        <severity>WARN</severity>
+    </policy>
+</policies>

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/rules/DummyRuleTheSecond.drl
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/src/test/resources/policiesTheSecond/rules/DummyRuleTheSecond.drl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.exampleproject
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.xml.generated.MatchState;
+import org.eclipse.sw360.antenna.bundle.DroolsEvaluationResult
+
+import java.util.List;
+
+rule "Artifacts have to be open source"
+no-loop true
+when
+    a : Artifact( isProprietary() == true )
+    e : DroolsEvaluationResult( getId() == "DummyTheSecond" )
+then
+    modify (e) { addFailedArtifact(a) };
+end

--- a/example-projects/example-project/src/workflow.xml
+++ b/example-projects/example-project/src/workflow.xml
@@ -54,7 +54,7 @@
             <classHint>org.eclipse.sw360.antenna.workflow.processors.checkers.AntennaDroolsChecker</classHint>
             <configuration>
                 <entry key="base.dir" value="${project.basedir}"/>
-                <entry key="folder.path" value="../example-policies"/>
+                <entry key="folder.paths" value="../example-policies"/>
             </configuration>
         </step>
     </processors>


### PR DESCRIPTION
Signed-off-by: Stephanie Neubauer [Stephanie.Neubauer@bosch-si.com]

Changed to <List ruleSetPaths> and then the related Functions to handle the List accordingly.

Added test testing if the added folder "policiesTheSecond" is crawled correctly and the rules are also executed. It is. Additional test to check that rulesetVersions are given correctly. 

Workflow key has been changed from `folder.path` to `folder.paths`

This PR relates #57