### PR TITLE
Improve special license strings

### DIFF
--- a/antenna-documentation/src/site/markdown/json-analyzer-step.md
+++ b/antenna-documentation/src/site/markdown/json-analyzer-step.md
@@ -77,3 +77,13 @@ Add this configuration to the workflow.xml
 
 * `file.path`: Destination of a JSON file that matches the above format.
 * `base.path`: Destination to the the source files that the JSON report refers to.
+
+### Special license fields
+
+There are number of special strings which can be used to convey failure messages using the "licenseId" field:
+
+* `Not-Declared`: Only within `declaredLicenses`. No license was declared by the project (via package managers for instance), although some license text is configured or found.
+* `No-Sources`: Only within `observedLicenses`. No sources are provided for the component so it's license could not be checked.
+* `No-Source-License`: Only within `observedLicenses`. Sources for the component are available, but license information in sources is missing or incomplete.
+* `Not-Provided`: Only within `declaredLicenses`. No license was provided by the project (via package managers for instance).
+* `Not-Supported`: Only within `observedLicenses`. This should only be used by scanning tools. It means that license information is not handled by the scanner and must be checked differently.

--- a/antenna-documentation/src/site/markdown/json-analyzer-step.md
+++ b/antenna-documentation/src/site/markdown/json-analyzer-step.md
@@ -87,3 +87,4 @@ There are number of special strings which can be used to convey failure messages
 * `No-Source-License`: Only within `observedLicenses`. Sources for the component are available, but license information in sources is missing or incomplete.
 * `Not-Provided`: Only within `declaredLicenses`. No license was provided by the project (via package managers for instance).
 * `Not-Supported`: Only within `observedLicenses`. This should only be used by scanning tools. It means that license information is not handled by the scanner and must be checked differently.
+* `Non-Standard`: A license is configured which is of non-standard license threat group.

--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseInformation.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseInformation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.model.artifact.facts;
+
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MissingLicenseInformation implements ArtifactFact<MissingLicenseInformation> {
+
+    private final List<MissingLicenseReasons> missingLicenseReasons = new ArrayList<>();
+
+    public MissingLicenseInformation(List<MissingLicenseReasons> missingLicenseReasons) {
+        this.missingLicenseReasons.addAll(missingLicenseReasons);
+    }
+
+    public List<MissingLicenseReasons> getMissingLicenseReasons() {
+        return missingLicenseReasons;
+    }
+
+    @Override
+    public String getFactContentName() {
+        return "Reasons for missing license information";
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public String prettyPrint() {
+        return missingLicenseReasons.stream().map(reason -> reason.prettyPrintReason).collect(Collectors.joining(" AND "));
+    }
+}

--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseReasons.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseReasons.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.model.artifact.facts;
+
+
+public enum MissingLicenseReasons {
+    NOT_DECLARED("No license was declared by the project or a declared license could not be found."),
+    NO_SOURCES("No sources provided hence licenses cannot be found."),
+    NO_LICENSE_IN_SOURCES("Sources are provided but do not contain license headers."),
+    NOT_PROVIDED("No license was specified."),
+    NOT_SUPPORTED("Retrieving license information failed for this component");
+
+    public final String prettyPrintReason;
+
+    MissingLicenseReasons(String prettyPrintReason) {
+        this.prettyPrintReason = prettyPrintReason;
+    }
+}

--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseReasons.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/MissingLicenseReasons.java
@@ -17,7 +17,8 @@ public enum MissingLicenseReasons {
     NO_SOURCES("No sources provided hence licenses cannot be found."),
     NO_LICENSE_IN_SOURCES("Sources are provided but do not contain license headers."),
     NOT_PROVIDED("No license was specified."),
-    NOT_SUPPORTED("Retrieving license information failed for this component");
+    NOT_SUPPORTED("Retrieving license information failed for this component"),
+    NON_STANDARD("Configured license is of non-standard threat-group");
 
     public final String prettyPrintReason;
 

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/JsonReader.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/JsonReader.java
@@ -11,6 +11,10 @@
 
 package org.eclipse.sw360.antenna.util;
 
+import com.github.cliftonlabs.json_simple.JsonArray;
+import com.github.cliftonlabs.json_simple.JsonException;
+import com.github.cliftonlabs.json_simple.JsonObject;
+import com.github.cliftonlabs.json_simple.Jsoner;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.*;
 import org.eclipse.sw360.antenna.model.artifact.facts.dotnet.DotNetCoordinates;
@@ -18,7 +22,6 @@ import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactPathnames;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.javaScript.JavaScriptCoordinates;
 import org.eclipse.sw360.antenna.model.xml.generated.*;
-import org.json.simple.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +65,7 @@ public class JsonReader {
             }
             stream.close();
             return artifactList;
-        } catch (IOException | DeserializationException e) {
+        } catch (IOException | JsonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
@@ -20,61 +20,24 @@ import java.util.Iterator;
 
 public class LicenseSupport {
     public static LicenseInformation mapLicenses(Collection<String> licenses) {
-        // The overall statement
-        LicenseStatement licenseStatement = new LicenseStatement();
-        // Indicator for each new statement
-        LicenseStatement temporaryLStatement = new LicenseStatement();
-                int c=0;
-                for (Iterator<String> i = licenses.iterator(); i.hasNext();) {
-                    String licenseName = i.next();
-                    License license = new License();
-                    license.setName(licenseName);
-                    if(i.hasNext()){
-                        ++c;
-                        temporaryLStatement = LicenseSupport.createStatement(licenseStatement, temporaryLStatement, license);
-                    }
-                    else if (c==0) {
-                        return license;
-                    }
-                    else if (c==1){
-                        licenseStatement.setRightStatement(license);
-                        return licenseStatement;
-                    }
-                    else {
-                        temporaryLStatement.setRightStatement(license);
-                        return licenseStatement;
-                    }
+        Iterator<String> iterator = licenses.iterator();
+        if (!iterator.hasNext()) {
+            return new LicenseStatement();
         }
-        return licenseStatement;
+
+        return computeRecursiveLicenseStatement(iterator, new LicenseStatement());
     }
 
+    private static LicenseInformation computeRecursiveLicenseStatement(Iterator<String> iterator, LicenseStatement leftLicense) {
+        License license = new License();
+        license.setName(iterator.next());
 
-    public static LicenseStatement createStatement(LicenseStatement licenseStatement, LicenseStatement temporaryLStatement, License license){
-        if(temporaryLStatement.getLeftStatement() == null) {
-            if (licenseStatement.getLeftStatement() == null) {
-                licenseStatement.setLeftStatement(license);
-                licenseStatement.setOp(LicenseOperator.AND);
-                return temporaryLStatement;
-            } else {
-                LicenseStatement newLicenseStatement = new LicenseStatement();
-                newLicenseStatement.setLeftStatement(license);
-                newLicenseStatement.setOp(LicenseOperator.AND);
-                licenseStatement.setRightStatement(newLicenseStatement);
-                return newLicenseStatement;
-            }
+        if (iterator.hasNext()) {
+            leftLicense.setLeftStatement(license);
+            leftLicense.setOp(LicenseOperator.AND);
+            leftLicense.setRightStatement(computeRecursiveLicenseStatement(iterator, new LicenseStatement()));
+            return leftLicense;
         }
-        else{
-            if (temporaryLStatement.getLeftStatement() == null) {
-                temporaryLStatement.setLeftStatement(license);
-                temporaryLStatement.setOp(LicenseOperator.AND);
-                return temporaryLStatement;
-            } else {
-                LicenseStatement newLicenseStatement = new LicenseStatement();
-                newLicenseStatement.setLeftStatement(license);
-                newLicenseStatement.setOp(LicenseOperator.AND);
-                temporaryLStatement.setRightStatement(newLicenseStatement);
-                return newLicenseStatement;
-            }
-        }
+        return license;
     }
 }

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/SpecialLicenseInformation.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/SpecialLicenseInformation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.util;
+
+import org.eclipse.sw360.antenna.model.artifact.facts.MissingLicenseInformation;
+import org.eclipse.sw360.antenna.model.artifact.facts.MissingLicenseReasons;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SpecialLicenseInformation {
+    public static final Map<String, MissingLicenseReasons> SPECIAL_INFORMATION
+            = new HashMap<String, MissingLicenseReasons>()
+    {{
+        put("No-Sources", MissingLicenseReasons.NO_SOURCES);
+        put("No-Source-License", MissingLicenseReasons.NO_LICENSE_IN_SOURCES);
+        put("Not-Declared", MissingLicenseReasons.NOT_DECLARED);
+        put("Not-Provided", MissingLicenseReasons.NOT_PROVIDED);
+        put("Not-Supported", MissingLicenseReasons.NOT_SUPPORTED);
+    }};
+}

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/SpecialLicenseInformation.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/SpecialLicenseInformation.java
@@ -26,5 +26,6 @@ public class SpecialLicenseInformation {
         put("Not-Declared", MissingLicenseReasons.NOT_DECLARED);
         put("Not-Provided", MissingLicenseReasons.NOT_PROVIDED);
         put("Not-Supported", MissingLicenseReasons.NOT_SUPPORTED);
+        put("Non-Standard", MissingLicenseReasons.NON_STANDARD);
     }};
 }

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
@@ -11,14 +11,14 @@
 
 package org.eclipse.sw360.antenna.workflow.analyzers;
 
+import com.github.cliftonlabs.json_simple.JsonException;
+import com.github.cliftonlabs.json_simple.Jsoner;
 import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.api.workflow.ManualAnalyzer;
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
 import org.eclipse.sw360.antenna.util.JsonReader;
-import org.json.simple.DeserializationException;
-import org.json.simple.Jsoner;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class JsonAnalyzer extends ManualAnalyzer {
         try (FileInputStream fileInputStream = new FileInputStream(componentInfoFile);
              InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, toolConfig.getEncoding())) {
             Jsoner.deserialize(inputStreamReader);
-        } catch (DeserializationException e) {
+        } catch (JsonException e) {
             throw new AntennaException("Encountered a problem when trying to parse "
                     + componentInfoFile.getAbsolutePath() + ": " + e.getMessage());
         } catch (IOException e) {

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
@@ -17,8 +17,8 @@ import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.api.workflow.ManualAnalyzer;
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
 import org.eclipse.sw360.antenna.util.JsonReader;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import org.json.simple.DeserializationException;
+import org.json.simple.Jsoner;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,9 +36,9 @@ public class JsonAnalyzer extends ManualAnalyzer {
 
         // Check that JSON file contains valid JSON.
         try (FileInputStream fileInputStream = new FileInputStream(componentInfoFile);
-             InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, toolConfig.getEncoding())){
-            new JSONParser().parse(inputStreamReader);
-        } catch (ParseException e) {
+             InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, toolConfig.getEncoding())) {
+            Jsoner.deserialize(inputStreamReader);
+        } catch (DeserializationException e) {
             throw new AntennaException("Encountered a problem when trying to parse "
                     + componentInfoFile.getAbsolutePath() + ": " + e.getMessage());
         } catch (IOException e) {

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/JsonReaderTest.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/JsonReaderTest.java
@@ -75,6 +75,7 @@ public class JsonReaderTest {
         issues.ifPresent(i -> {
             assertThat(i.stream().map(Issue::getStatus)).contains(SecurityIssueStatus.OPEN);
             assertThat(i.stream().map(Issue::getReference)).contains("CVE-2018-8014");
+            assertThat(i.stream().map(Issue::getSeverity)).contains(5.9);
         });
     }
 

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/JsonReaderTest.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/JsonReaderTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.sw360.antenna.util;
 
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
-import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactIssues;
-import org.eclipse.sw360.antenna.model.artifact.facts.DeclaredLicenseInformation;
+import org.eclipse.sw360.antenna.model.artifact.facts.*;
 import org.eclipse.sw360.antenna.model.artifact.facts.dotnet.DotNetCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.MissingLicenseInformation;
 import org.eclipse.sw360.antenna.model.artifact.facts.javaScript.JavaScriptCoordinates;
 import org.eclipse.sw360.antenna.model.xml.generated.Issue;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
@@ -38,7 +38,7 @@ public class JsonReaderTest {
     private List<Artifact> artifacts;
 
     @Test
-    public void testMapLicenses() throws URISyntaxException, IOException{
+    public void testMapLicenses() throws URISyntaxException, IOException {
         Path recordFilePath = Paths.get(".", "target", "foo");
         JsonReader jsonReader = new JsonReader(recordFilePath, Paths.get("tmp"), Charset.forName("UTF-8"));
         URI uri = this.getClass().getClassLoader().getResource("data.json").toURI();
@@ -48,7 +48,20 @@ public class JsonReaderTest {
     }
 
     @Test
-    public void testParseData2() throws URISyntaxException, IOException{
+    public void testMappingAdditionalInformationForLicenses() throws URISyntaxException, IOException {
+        Path recordFilePath = Paths.get(".", "target", "foo");
+        JsonReader jsonReader = new JsonReader(recordFilePath, Paths.get("tmp"), Charset.forName("UTF-8"));
+        URI uri = this.getClass().getClassLoader().getResource("data.json").toURI();
+        InputStream iStream = Files.newInputStream(Paths.get(uri));
+        artifacts = jsonReader.createArtifactsList(iStream);
+
+        assertThat(artifacts.get(0).askForGet(ObservedLicenseInformation.class)).isEmpty();
+        assertThat(artifacts.get(0).askFor(MissingLicenseInformation.class).get().getMissingLicenseReasons())
+                .containsExactlyInAnyOrder(MissingLicenseReasons.NO_LICENSE_IN_SOURCES);
+    }
+
+    @Test
+    public void testParseData2() throws URISyntaxException, IOException {
         Path recordFilePath = Paths.get(".", "target", "foo");
         JsonReader jsonReader = new JsonReader(recordFilePath, Paths.get("tmp"), Charset.forName("UTF-8"));
         URI uri = this.getClass().getClassLoader().getResource("data2.json").toURI();

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.util;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class LicenseSupportTest {
+    @Test
+    public void singleLicenseIsTreatedSimply() {
+        Collection<String> license = Collections.singletonList("Single License");
+        LicenseInformation actualLicenseSupport = LicenseSupport.mapLicenses(license);
+
+        Assertions.assertThat(actualLicenseSupport.toString()).startsWith("Single License");
+    }
+
+    @Test
+    public void mulitpleLicensesTreatedCorrectly() {
+        Collection<String> license = Arrays.asList("First License", "Second License", "Third License");
+        LicenseInformation actualLicenseSupport = LicenseSupport.mapLicenses(license);
+
+        Assertions.assertThat(actualLicenseSupport.toString())
+                .startsWith("( First License AND ( Second License AND Third License ) )");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>com.github.cliftonlabs</groupId>
                 <artifactId>json-simple</artifactId>
-                <version>2.3.1</version>
+                <version>3.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Connects to #57 

There are currently a few special license strings propagated through the json analyzer. This makes writing rules a bit weird.

In addition, this PR does a bit of cleanup:
- refactoring of LicenseSupport
- update json-analyzer with newest api and update dependency to current version (connects to #59 )