### PR TITLE
Site improvements

### DIFF
--- a/antenna-documentation/pom.xml
+++ b/antenna-documentation/pom.xml
@@ -47,7 +47,7 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.7</version>
+                        <version>1.8</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/antenna-documentation/src/site/markdown/dev-guide.md
+++ b/antenna-documentation/src/site/markdown/dev-guide.md
@@ -81,10 +81,12 @@ Antenna provides also some further means to debug. If you run e.g. the example p
 
 ## Build the documentation
 
-Just type in your command `$ mvn site:run` .
-The site starts up in the port 9000 
+Go into the `antenna-documentation` subfolder and call  `mvn site site:run`.
+This will build the documentation site and start it up in port 9000
 
 Open a browser and type the directory `http://localhost:9000`
+
+Once the site is run, it can also be started from the main folder via `mvn site:run`
 
 ## How to implement a custom worflow item
 

--- a/antenna-documentation/src/site/markdown/how-to-configure-antenna.md
+++ b/antenna-documentation/src/site/markdown/how-to-configure-antenna.md
@@ -3,6 +3,6 @@
 Before you use Antenna, you need to set some configuration settings.
 There are actually three levels to configure the tool behavior:
 
-1. On a build system integration level. This is done in the [Tool Configuration](tool-configuration.md).
-2. On a tool behavior level. This is done in the [Workflow Configuration](workflow-configuration.md).
-3. On a data level. This is done in the [config.xml](config-configuration.md).
+1. On a build system integration level. This is done in the [Tool Configuration](tool-configuration.html).
+2. On a tool behavior level. This is done in the [Workflow Configuration](workflow-configuration.html).
+3. On a data level. This is done in the [config.xml](config-configuration.html).

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
                 <plugin>
                     <groupId>org.apache.maven</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
@@ -402,7 +402,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.7.1</version>
                     <configuration>
                         <port>9000</port>
                         <tempWebappDirectory>${basedir}/target/site/tempdir</tempWebappDirectory>
@@ -475,6 +475,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <inherited>false</inherited>
                 <version>3.0.1</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>

--- a/pom.xml
+++ b/pom.xml
@@ -224,11 +224,6 @@
                 <version>${spring.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework.hateoas</groupId>
-                <artifactId>spring-hateoas</artifactId>
-                <version>0.25.0.RELEASE</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>


### PR DESCRIPTION
Connects to #60 

This PR fixes broken links in the documentation. All links within md files are now to html files so that link forwarding of the site works correctly.

Only links in the README are left as is to other md files, because the README is not contained in the documentation site.

In addition:
- it fixes the site generation after #52 
- it improves the documentation on how to use and build the update site.