### PR TITLE
fix(config): isProprietary tag is checked and set when not null

### DIFF
--- a/antenna-core/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
+++ b/antenna-core/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.configuration;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.model.Configuration;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactCore;
 import org.eclipse.sw360.antenna.model.artifact.ArtifactSelector;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactIdentifier;
@@ -33,6 +34,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,6 +78,16 @@ public class ConfigurationTest {
         assertThat(configuration.getValidForIncompleteSources().size()).isEqualTo(2);
         assertThat(configuration.getConfiguredSW360Project().getName()).isEqualTo("anyProjectName");
         assertThat(configuration.getConfiguredSW360Project().getVersion()).isEqualTo("anyProjectVersion");
+
+    }
+
+    @Test
+    public void testBuildArtifactFlags() {
+        String isProprietaryList = configuration.getAddArtifact().stream()
+                .map(ArtifactCore::prettyPrint)
+                .collect(Collectors.joining(";"));
+
+        assertThat(isProprietaryList).contains("Flags: [isProprietary: false]");
     }
 
     @Test

--- a/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/FromXmlArtifactBuilder.java
+++ b/antenna-model/src/main/java/org/eclipse/sw360/antenna/model/artifact/FromXmlArtifactBuilder.java
@@ -54,6 +54,10 @@ public class FromXmlArtifactBuilder implements IArtifactBuilder {
             final LicenseInformation licenseInfo = declaredLicense.getLicenseInfo().getValue();
             artifact.addFact(new DeclaredLicenseInformation(licenseInfo));
         }
+        if(isProprietary != null) {
+            artifact.setProprietary(isProprietary);
+        }
+
         return artifact;
     }
 }


### PR DESCRIPTION
Signed-off-by: Stephanie Neubauer <Stephanie.Neubauer@bosch-si.com>

added null check for `isProprietary` and then set artifact flag, added Test to ConfigurationTest for Flags

Related to issue: #79