### PR TITLE
ci(jenkins): add script that runs on https://ci.eclipse.org/antenna

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -9,62 +9,242 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+def VERSION
+def IS_SNAPSHOT_VERSION
+
 pipeline {
-    agent any
-
+    agent {
+        kubernetes {
+            label 'antenna-build-pod'
+                        yaml """
+apiVersion: v1
+kind: Pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: maven
+    image: maven:3.6.0-jdk-8
+    command:
+    - cat
+    tty: true
+    resources:
+        requests:
+            memory: "4096Mi"
+        limits:
+            memory: "4096Mi"
+"""
+        }
+    }
+    environment {
+        MAVEN_OPTS = '-Xms4G -Xmx4G'
+    }
+    parameters {
+        choice(
+            choices: ['build', 'build_and_push'],
+            description: '',
+            name: 'REQUESTED_ACTION')
+        booleanParam(
+            name: 'BUILD_WITH_ANTENNA_P2',
+            defaultValue: false,
+            description: '')
+        choice(
+            choices: ['eclipse-jarsigner:sign', ''],
+            description: '',
+            name: 'SIGNING_COMMAND')
+        booleanParam(
+            name: 'RUN_TESTS',
+            defaultValue: true,
+            description: '')
+    }
     stages {
-        stage('P2 download dependencies') {
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // we need to know the version of our project, for that we use the maven-help-plugin
+        stage('determine version') {
             steps {
-                withMaven() {
-                    dir("antenna-p2/dependencies") {
-                        sh 'mvn -B package'
+                container('maven') {
+                    script {
+                        VERSION = sh (
+                            script: 'mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout',
+                            returnStdout: true
+                        ).trim()
+                        IS_SNAPSHOT_VERSION = (VERSION ==~ /.*-SNAPSHOT/)
+                    }
+                }
+                sh "echo \"VERSION is: ${VERSION} with IS_SNAPSHOT_VERSION=${IS_SNAPSHOT_VERSION}\""
+
+                sh 'rm -rf localRepository'
+                sh 'mkdir -p localRepository'
+            }
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // handle the p2 dependency part (the stuff below ./antena-p2)
+        // this either gets created (if flag is true) or removed
+        stage('build deps for p2') {
+            when {
+                environment name: 'BUILD_WITH_ANTENNA_P2', value: 'true'
+            }
+            steps {
+                sh 'rm -rf repository'
+                sh 'mkdir -p repository'
+                container('maven') {
+                    dir ('antenna-p2') {
+                        dir ('dependencies') {
+                            // see: https://stackoverflow.com/questions/48327214/xtext-maven-build-fails-under-jenkins-docker/51278987
+                            sh 'mvn -Dmaven.repo.local=$(readlink -f ../../localRepository) --batch-mode package'
+                        }
+                        sh 'mvn -Dmaven.repo.local=$(readlink -f ../localRepository) --batch-mode package'
+                    }
+                }
+            }
+        }
+        stage('cleanup deps for p2') {
+            when {
+                environment name: 'BUILD_WITH_ANTENNA_P2', value: 'false'
+            }
+            steps {
+                sh 'rm -rf repository'
+                sh 'mkdir -p repository'
+                sh 'rm -rf antenna-p2/repository_manager/target'
+            }
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // build antenna
+        stage('build') {
+            steps {
+                sh 'rm -rf repository'
+                sh 'mkdir -p repository'
+                container('maven') {
+                    // build antenna and also deploy it to an output repository
+                    sh """
+                      mvn -Dmaven.repo.local=\$(readlink -f localRepository) \
+                          --batch-mode \
+                          install -DskipTests ${params.SIGNING_COMMAND}
+                      mvn -Dmaven.repo.local=\$(readlink -f localRepository) \
+                          --batch-mode \
+                          install -DskipTests ${params.SIGNING_COMMAND} deploy \
+                          -pl "!antenna-testing,!antenna-testing/antenna-core-common-testing,!antenna-testing/antenna-frontend-stubs-testing,!antenna-testing/antenna-rule-engine-testing" \
+                          -DaltDeploymentRepository=localRepositoryFolder::default::file:\$(readlink -f ./repository)
+                    """
+                }
+                sh 'ls repository/org/eclipse/sw360/antenna/'
+            }
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // run tests and try to execute antenna
+        stage('test') {
+            when {
+                environment name: 'RUN_TESTS', value: 'true'
+            }
+            steps {
+                container('maven') {
+                    // run maven tests
+                    sh '''
+                      mvn -Dmaven.repo.local=$(readlink -f localRepository) \
+                        --batch-mode \
+                        test
+                    '''
+
+                    // test as maven plugin
+                    sh '''
+                      tmpdir="$(mktemp -d)"
+                      locRep="$(readlink -f localRepository)"
+                      cp -r example-projects/example-project example-projects/example-policies $tmpdir
+                      cd $tmpdir/example-project
+                      mvn -Dmaven.repo.local="$locRep" \
+                        --batch-mode \
+                        package
+                      cd -
+                    '''
+
+                    // test as CLI tool
+                    sh '''
+                      tmpdir="$(mktemp -d)"
+                      cp -r example-projects/example-project example-projects/example-policies $tmpdir
+                      .travis/runCLI.sh $tmpdir/example-project
+                      java -jar antenna-testing/antenna-frontend-stubs-testing/target/antenna-test-project-asserter.jar ExampleTestProject $tmpdir/example-project/target
+                    '''
+
+                    // test the antenna site
+                    dir("antenna-documentation") {
+                        sh '''
+                          mvn -Dmaven.repo.local=$(readlink -f ../localRepository) \
+                            --batch-mode \
+                            site -Psite-tests
+                        '''
                     }
                 }
             }
         }
 
-        stage('P2 build') {
-            steps {
-                withMaven() {
-                    dir("antenna-p2") {
-                        sh 'mvn -B package'
-                    }
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // push generated repository to download.eclipse.org
+        // depending on the version, the result gets pushed to
+        //   - https://download.eclipse.org/antenna/snapshots (and all old snapshot builds will be deleted) or
+        //   - https://download.eclipse.org/antenna/releases
+        stage ('push repository to download.eclipse.org to antenna/snapshots') {
+            when {
+                expression {
+                    wantsToPush = params.REQUESTED_ACTION == 'build_and_push'
+                    return wantsToPush && IS_SNAPSHOT_VERSION
                 }
             }
-        }
-
-
-        stage('Clean') {
             steps {
-                withMaven() {
-                    sh 'mvn clean'
+                sh """
+                  if [[ "${params.SIGNING_COMMAND}x" == "x" ]]; then
+                    echo "pushing is only allowed if signing was done"
+                    exit 1
+                  fi
+                """
+                container('maven') {
+                    sh 'find repository -iname \'*.jar\' -print -exec jarsigner -verify {} \\;'
                 }
+                sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+                    sh '''
+                      ssh -o StrictHostKeyChecking=no \
+                          genie.antenna@projects-storage.eclipse.org \
+                          rm -rf /home/data/httpd/download.eclipse.org/antenna/snapshots
+                      ssh -o StrictHostKeyChecking=no \
+                          genie.antenna@projects-storage.eclipse.org \
+                          mkdir -p /home/data/httpd/download.eclipse.org/antenna/snapshots
+                      scp -o StrictHostKeyChecking=no \
+                          -r ./repository/* \
+                          genie.antenna@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/antenna/snapshots
+                    '''
+                }
+                sh 'Snapshot release is published at https://download.eclipse.org/antenna/snapshots'
             }
         }
-        
-        stage('Build') {
-            steps {
-                withMaven() {
-                    sh 'mvn -B -DskipTests install'
+        stage ('push repository to download.eclipse.org to antenna/releases') {
+            when {
+                expression {
+                    wantsToPush = params.REQUESTED_ACTION == 'build_and_push'
+                    return wantsToPush && ! IS_SNAPSHOT_VERSION
                 }
             }
-        }
-
-        stage('Test') {
             steps {
-                withMaven() {
-                    sh 'mvn test'
+                sh """
+                  if [[ "${params.SIGNING_COMMAND}x" == "x" ]]; then
+                    echo "pushing is only allowed if signing was done"
+                    exit 1
+                  fi
+                """
+                container('maven') {
+                    sh 'find repository -iname \'*.jar\' -print -exec jarsigner -verify {} \\;'
                 }
-            }
-        }
-        
-        stage('Test-Site') {
-            steps {
-                dir("antenna-documentation") {
-                    withMaven() {
-                        sh 'mvn clean site -Psite-tests'
-                    }
+                sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+                    sh '''
+                      ssh -o StrictHostKeyChecking=no \
+                          genie.antenna@projects-storage.eclipse.org \
+                          mkdir -p /home/data/httpd/download.eclipse.org/antenna/releases
+                      scp -o StrictHostKeyChecking=no \
+                          -r ./repository/* \
+                          genie.antenna@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/antenna/releases
+                    '''
                 }
+                sh 'Release is published at https://download.eclipse.org/antenna/releases'
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,25 @@
         </dependencies>
     </dependencyManagement>
 
+
+    <pluginRepositories>
+      <pluginRepository>
+        <id>repo.eclipse.org</id>
+        <url>https://repo.eclipse.org/content/repositories/cbi</url>
+        <releases>
+          <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+      </pluginRepository>
+    </pluginRepositories>
+    <repositories>
+      <repository>
+        <id>eclipse-antenna-snapshot</id>
+        <url>https://download.eclipse.org/antenna/snapshots/</url>
+      </repository>
+    </repositories>
     <build>
         <resources>
             <resource>
@@ -432,6 +451,11 @@
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
                 </plugin>
+                <plugin>
+                  <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                  <artifactId>eclipse-jarsigner-plugin</artifactId>
+                  <version>1.1.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -496,6 +520,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                <artifactId>eclipse-jarsigner-plugin</artifactId>
+                <version>1.1.5</version>
+                <configuration>
+                    <resigningStrategy>OVERWRITE</resigningStrategy>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Corresponding Jenkins build job: https://ci.eclipse.org/antenna/job/build-pipeline

# Current State / things to do:
- [x] sign jars without invalidating signatures in child chars
- [x] push repository to eclipse
  - [x] get genie ssh login working with the following code:
    ```
                stage ('ls remote repository') {
                    steps {
                        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
                            sh '''
                              ssh genie.antenna@projects-storage.eclipse.org ls -alF /home/data/httpd/download.eclipse.org
                              ssh genie.antenna@projects-storage.eclipse.org ls -alF /home/data/httpd/download.eclipse.org/antenna
                              ssh genie.antenna@projects-storage.eclipse.org ls -alF /home/data/httpd/download.eclipse.org/antenna/snapshots
                            '''
                        }
                    }
                }
    ```
- [x] `mvn package` in `antenna-p2/dependencies` currently fails. See: **Details to [id1]**
- [x] find out where to download the pushed artifacts (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=546057)
  ==> https://download.eclipse.org/antenna/snapshots/org/eclipse/sw360/antenna/?d
- [x] test the repository:
  ```
    <repositories>
      <repository>
        <id>eclipse-antenna-snapshot</id>
        <url>https://download.eclipse.org/antenna/snapshots/</url>
      </repository>
    </repositories>
  ```
  works and adds the following to the log:
  ```
  Downloaded from eclipse-antenna-snapshot: https://download.eclipse.org/antenna/snapshots/org/eclipse/sw360/antenna/antenna-model/1.0.0-SNAPSHOT/antenna-model-1.0.0-20190402.131236-1.jar (170 kB at 22 kB/s)
  ```
- [x] test the artifacts
- [x] make it possible to release build
  - see: https://jenkins.io/blog/2018/05/16/pipelines-with-git-tags/


### Details to [id1]
The corresponding code is:
```
                 dir ('antenna-p2/dependencies') {
￼                      container('maven') {
 ￼                         sh 'mvn package'
￼                      }
￼                  }
```
although the following works:
```
$ docker run -it --rm --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven/antenna-p2/dependencies maven:3.6.0-jdk-8-alpine mvn package
```