### PR TITLE
fix(sw360): Allow to create projects without user metadata

### DIFF
--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -109,7 +109,6 @@ public class SW360MetaDataUpdater {
     public void createProject(String projectName, String projectVersion, Collection<SW360Release> releases) throws AntennaException, IOException {
         String id;
         HttpHeaders header = createHttpHeaders(userId, password);
-        SW360User user = userClientAdapter.getUserById(userId, header);
 
         Optional<String> projectId = projectClientAdapter.getProjectIdByNameAndVersion(projectName, projectVersion, header);
 
@@ -118,7 +117,7 @@ public class SW360MetaDataUpdater {
             LOGGER.debug("Could not update project " + projectId.get() + ", because the endpoint is not available.");
             id = projectId.get();
         } else {
-            id = projectClientAdapter.addProject(projectName, projectVersion, user, header);
+            id = projectClientAdapter.addProject(projectName, projectVersion, header);
         }
         projectClientAdapter.addSW360ReleasesToSW360Project(id, releases, header);
     }

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
@@ -54,9 +54,9 @@ public class SW360ProjectClientAdapter {
                 .flatMap(SW360HalResourceUtility::getLastIndexOfLinkObject);
     }
 
-    public String addProject(String projectName, String projectVersion, SW360User user, HttpHeaders header) throws AntennaException, JsonProcessingException {
+    public String addProject(String projectName, String projectVersion, HttpHeaders header) throws AntennaException, JsonProcessingException {
         SW360Project sw360Project = new SW360Project();
-        SW360ProjectAdapterUtils.prepareProject(sw360Project, projectName, projectVersion, user);
+        SW360ProjectAdapterUtils.prepareProject(sw360Project, projectName, projectVersion);
         SW360Project responseProject = projectClient.createProject(sw360Project, header);
 
         return SW360HalResourceUtility.getLastIndexOfLinkObject(responseProject.get_Links()).orElse("");

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
@@ -23,7 +23,7 @@ public class SW360UserClientAdapter {
         restUrl = backendURL;
     }
 
-    public SW360User getUserById(String userId, HttpHeaders header) throws AntennaException {
+    public SW360User getUserByEmail(String userId, HttpHeaders header) throws AntennaException {
         SW360UserClient userClient = new SW360UserClient(restUrl);
             return userClient.getUserByEmail(userId, header);
     }

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
@@ -34,23 +34,16 @@ public class SW360ProjectAdapterUtils {
         }
     }
 
-    public static void setBusinessUnit(SW360Project project, String department) {
-        if ((department != null) && (!department.isEmpty())) {
-            project.setBusinessUnit(department);
-        }
-    }
-
     public static void setClearingTeam(SW360Project project, String clearingTeam) {
         if ((clearingTeam != null) && (!clearingTeam.isEmpty())) {
             project.setClearingTeam(clearingTeam);
         }
     }
 
-    public static void prepareProject(SW360Project sw360Project, String projectName, String projectVersion, SW360User user) {
+    public static void prepareProject(SW360Project sw360Project, String projectName, String projectVersion) {
         SW360ProjectAdapterUtils.setName(sw360Project, projectName);
         SW360ProjectAdapterUtils.setVersion(sw360Project, projectVersion);
         SW360ProjectAdapterUtils.setDescription(sw360Project, projectName + " " + projectVersion);
-        SW360ProjectAdapterUtils.setBusinessUnit(sw360Project, user.getDepartment());
         sw360Project.setProjectType(SW360ProjectType.PRODUCT);
         sw360Project.setVisibility(SW360Visibility.BUISNESSUNIT_AND_MODERATORS);
     }


### PR DESCRIPTION
The functionality to get the metadata of a user fails, if the SW360 is configured to work with screenname instead of email. This removes the functionality and proves, that it was never necessary. The organisation is on creation filled with the organisation of the creator.