### PR TITLE
internal(csv): Get rid of double csv dependency

### DIFF
--- a/antenna-csv-license-knowledge-base/pom.xml
+++ b/antenna-csv-license-knowledge-base/pom.xml
@@ -50,8 +50,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,12 +188,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
-                <version>1.6</version>
-            </dependency>
-            <dependency>
-                <groupId>com.opencsv</groupId>
-                <artifactId>opencsv</artifactId>
-                <version>4.4</version>
+                <version>1.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
- Remove dependency ro com.opencsv:opencsv:4.4 and replace it by org.apache.commons:commons-csv
- Downgrade org.apache.commons:commons-csv to 1.5 to match the existing CQ

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>