### PR TITLE
Version defined as commit string

### DIFF
--- a/antenna-api/pom.xml
+++ b/antenna-api/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-management</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <artifactId>antenna-api</artifactId>
 

--- a/antenna-basic-assembly/antenna-basic-configuration/pom.xml
+++ b/antenna-basic-assembly/antenna-basic-configuration/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-basic-configuration</artifactId>

--- a/antenna-basic-assembly/antenna-basic-rules/pom.xml
+++ b/antenna-basic-assembly/antenna-basic-rules/pom.xml
@@ -17,11 +17,10 @@
     <parent>
         <artifactId>antenna-basic-assembly</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-basic-rules</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/antenna-basic-assembly/antenna-cli/pom.xml
+++ b/antenna-basic-assembly/antenna-cli/pom.xml
@@ -10,12 +10,13 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-cli</artifactId>
@@ -56,11 +57,13 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                             <resource>META-INF/kie.conf</resource>
                         </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                     </transformers>
                     <filters>
                         <filter>
@@ -72,7 +75,6 @@
                             </excludes>
                         </filter>
                     </filters>
-		    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                 </configuration>
                 <executions>
                     <execution>

--- a/antenna-basic-assembly/antenna-gradle-plugin/pom.xml
+++ b/antenna-basic-assembly/antenna-gradle-plugin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-gradle-plugin</artifactId>

--- a/antenna-basic-assembly/antenna-maven-plugin/pom.xml
+++ b/antenna-basic-assembly/antenna-maven-plugin/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-maven-plugin</artifactId>

--- a/antenna-basic-assembly/antenna-spdx-license-knowledge-base/pom.xml
+++ b/antenna-basic-assembly/antenna-spdx-license-knowledge-base/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-basic-assembly/generators/antenna-sw360-disclosure-document-generator/pom.xml
+++ b/antenna-basic-assembly/generators/antenna-sw360-disclosure-document-generator/pom.xml
@@ -14,12 +14,11 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-basic-assembly</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>antenna-sw360-disclosure-document-generator</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <properties>
         <sw360.version>3.3.0-M1</sw360.version>
     </properties>

--- a/antenna-basic-assembly/pom.xml
+++ b/antenna-basic-assembly/pom.xml
@@ -16,11 +16,10 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-basic-assembly</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Antenna Basic assembly</name>
 

--- a/antenna-core/pom.xml
+++ b/antenna-core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-csv-license-knowledge-base/pom.xml
+++ b/antenna-csv-license-knowledge-base/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-documentation/pom.xml
+++ b/antenna-documentation/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-frontend-stubs/antenna-frontend-api/pom.xml
+++ b/antenna-frontend-stubs/antenna-frontend-api/pom.xml
@@ -11,6 +11,14 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.sw360.antenna</groupId>
+        <artifactId>antenna-frontend-stubs</artifactId>
+        <version>${revision}${qualifier}</version>
+    </parent>
+    <artifactId>antenna-frontend-api</artifactId>
+    <name>antenna-frontend-api</name>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
@@ -30,12 +38,4 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <parent>
-        <groupId>org.eclipse.sw360.antenna</groupId>
-        <artifactId>antenna-frontend-stubs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>antenna-frontend-api</artifactId>
-    <name>antenna-frontend-api</name>
 </project>

--- a/antenna-frontend-stubs/cli-frontend-stub/pom.xml
+++ b/antenna-frontend-stubs/cli-frontend-stub/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-frontend-stubs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>cli-frontend-stub</artifactId>

--- a/antenna-frontend-stubs/gradle-frontend-stub/pom.xml
+++ b/antenna-frontend-stubs/gradle-frontend-stub/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-frontend-stubs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>gradle-frontend-stub</artifactId>

--- a/antenna-frontend-stubs/maven-frontend-stub/pom.xml
+++ b/antenna-frontend-stubs/maven-frontend-stub/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-frontend-stubs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>maven-frontend-stub</artifactId>
@@ -38,9 +38,24 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <scope>provided</scope>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cliftonlabs</groupId>
+            <artifactId>json-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -48,15 +63,98 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
+            <artifactId>maven-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
+            <artifactId>maven-compat</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.spdx</groupId>
+            <artifactId>spdx-tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.hateoas</groupId>
+            <artifactId>spring-hateoas</artifactId>
         </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>

--- a/antenna-frontend-stubs/pom.xml
+++ b/antenna-frontend-stubs/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-management</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-frontend-stubs</artifactId>

--- a/antenna-model/pom.xml
+++ b/antenna-model/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-management</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <artifactId>antenna-model</artifactId>
     <dependencies>

--- a/antenna-p2/bundles/antenna-p2-repository-manager/pom.xml
+++ b/antenna-p2/bundles/antenna-p2-repository-manager/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>bundles</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-p2/bundles/pom.xml
+++ b/antenna-p2/bundles/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-p2</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>bundles</artifactId>
     <packaging>pom</packaging>

--- a/antenna-p2/features/pom.xml
+++ b/antenna-p2/features/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-p2</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>antenna-p2-resolver-feature</artifactId>
     <packaging>eclipse-feature</packaging>

--- a/antenna-p2/pom.xml
+++ b/antenna-p2/pom.xml
@@ -15,9 +15,10 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <artifactId>antenna-p2</artifactId>
+    <version>${revision}${p2qualifier}</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 

--- a/antenna-p2/repository_manager/pom.xml
+++ b/antenna-p2/repository_manager/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-p2</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>repository_manager</artifactId>
     <packaging>eclipse-repository</packaging>

--- a/antenna-p2/tests/antenna-p2-repository-manager-tests/pom.xml
+++ b/antenna-p2/tests/antenna-p2-repository-manager-tests/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-p2-tests</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>antenna-p2-repository-manager-tests</artifactId>
     <packaging>eclipse-test-plugin</packaging>

--- a/antenna-p2/tests/pom.xml
+++ b/antenna-p2/tests/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-p2</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>antenna-p2-tests</artifactId>
     <packaging>pom</packaging>

--- a/antenna-sw360-adapter/pom.xml
+++ b/antenna-sw360-adapter/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>antenna-management</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/antenna-core-common-testing/pom.xml
+++ b/antenna-testing/antenna-core-common-testing/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-testing</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/antenna-frontend-stubs-testing/pom.xml
+++ b/antenna-testing/antenna-frontend-stubs-testing/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-testing</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/antenna-rule-engine-testing/pom.xml
+++ b/antenna-testing/antenna-rule-engine-testing/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>antenna-testing</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>antenna-rule-engine-testing</artifactId>

--- a/antenna-testing/antenna-sw360-integration-testing/pom.xml
+++ b/antenna-testing/antenna-sw360-integration-testing/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-testing</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/antenna-system-test/pom.xml
+++ b/antenna-testing/antenna-system-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>antenna-testing</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/antenna-test-license-knowledge-base/pom.xml
+++ b/antenna-testing/antenna-test-license-knowledge-base/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-testing</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/antenna-testing/pom.xml
+++ b/antenna-testing/pom.xml
@@ -14,11 +14,10 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-management</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-testing</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Antenna Testing</name>
 

--- a/antenna-workflow-steps/analyzers/antenna-csv-analyzer/pom.xml
+++ b/antenna-workflow-steps/analyzers/antenna-csv-analyzer/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-csv-analyzer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/pom.xml
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-json-analyzer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/analyzers/antenna-mvn-dependency-tree-analyzer/pom.xml
+++ b/antenna-workflow-steps/analyzers/antenna-mvn-dependency-tree-analyzer/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-mvn-dependency-tree-analyzer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/analyzers/antenna-ort-result-analyzer/pom.xml
+++ b/antenna-workflow-steps/analyzers/antenna-ort-result-analyzer/pom.xml
@@ -15,12 +15,11 @@
     <parent>
         <artifactId>antenna-workflow-steps</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>antenna-ort-result-analyzer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/pom.xml
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-HTML-report-generator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/generators/antenna-csv-generator/pom.xml
+++ b/antenna-workflow-steps/generators/antenna-csv-generator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-csv-generator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/generators/antenna-source-zip-generator/pom.xml
+++ b/antenna-workflow-steps/generators/antenna-source-zip-generator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-source-zip-generator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/generators/antenna-sw360-update-generator/pom.xml
+++ b/antenna-workflow-steps/generators/antenna-sw360-update-generator/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-workflow-steps</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/antenna-workflow-steps/outputHandlers/antenna-add-to-archive-output-handler/pom.xml
+++ b/antenna-workflow-steps/outputHandlers/antenna-add-to-archive-output-handler/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-add-to-archive-output-handler</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/pom.xml
+++ b/antenna-workflow-steps/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-management</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
     </parent>
 
     <artifactId>antenna-workflow-steps</artifactId>

--- a/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/pom.xml
+++ b/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>abstract-antenna-compliance-checker</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/antenna-conf-processor/pom.xml
+++ b/antenna-workflow-steps/processors/antenna-conf-processor/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-conf-processor</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
+++ b/antenna-workflow-steps/processors/checkers/antenna-drools-checker/pom.xml
@@ -15,12 +15,11 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-workflow-steps</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../../..</relativePath>
     </parent>
 
     <artifactId>antenna-drools-checker</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-artifact-resolver</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-child-jar-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-child-jar-resolver/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-child-jar-resolver</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-license-knowledgebase-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-license-knowledgebase-resolver/pom.xml
@@ -15,12 +15,11 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-workflow-steps</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../../..</relativePath>
     </parent>
 
     <artifactId>antenna-license-knowledgebase-resolver</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-license-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-license-resolver/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-license-resolver</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-manifest-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-manifest-resolver/pom.xml
@@ -15,12 +15,11 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-workflow-steps</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../../..</relativePath>
     </parent>
 
     <artifactId>antenna-manifest-resolver</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-p2-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-p2-resolver/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360.antenna</groupId>
         <artifactId>antenna-workflow-steps</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${qualifier}</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>antenna-p2-resolver</artifactId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>repository_manager</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}${p2qualifier}</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-source-url-resolver</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-sw360-enricher</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/validators/antenna-coordinates-validator/pom.xml
+++ b/antenna-workflow-steps/processors/validators/antenna-coordinates-validator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-coordinates-validator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/validators/antenna-license-validator/pom.xml
+++ b/antenna-workflow-steps/processors/validators/antenna-license-validator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-license-validator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/validators/antenna-match-state-validator/pom.xml
+++ b/antenna-workflow-steps/processors/validators/antenna-match-state-validator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-match-state-validator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/validators/antenna-security-issue-validator/pom.xml
+++ b/antenna-workflow-steps/processors/validators/antenna-security-issue-validator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-security-issue-validator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/antenna-workflow-steps/processors/validators/antenna-source-validator/pom.xml
+++ b/antenna-workflow-steps/processors/validators/antenna-source-validator/pom.xml
@@ -15,12 +15,11 @@
 	<parent>
 		<groupId>org.eclipse.sw360.antenna</groupId>
 		<artifactId>antenna-workflow-steps</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}${qualifier}</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>antenna-source-validator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/commit_version.sh
+++ b/commit_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2018.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+set -e
+
+git checkout $1
+mvn clean install -DskipTests -Dqualifier=-$(git describe --tags --abbrev=0 | cut -d"-" -f4-)-$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | wc -l)-$(git rev-parse --short HEAD)

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,31 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.eclipse.sw360.antenna</groupId>
     <artifactId>antenna-management</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>${revision}${qualifier}</version>
     <packaging>pom</packaging>
     <name>Antenna</name>
 
     <properties>
+        <!-- >This is the main version applied throughout the project. Change this to increase all versions<-->
+        <revision>1.0.0</revision>
+        <!-- >The qualifier can be set to any value and will set the corresponding qualifier in all projects except antenna-p2<-->
+        <qualifier>-SNAPSHOT</qualifier>
+        <!-- >
+        The antenna-p2 qualifier must be -SNAPSHOT or numeric.
+        Changing this qualifier changes all OSGI related versions in antenna-p2 (except for the independent dependencies project.
+        Changing this qualifier to a numeric version requires changing the "version" property from having ".qualifier"
+        to mirroring the content of the p2qualifier in the following files
+        - antenna-p2/bundles/antenna-p2-repository-manager/META-INF/MANIFEST.MF
+        - antenna-p2/tests/antenna-p2-repository-manager-tests/META-INF/MANIFEST.MF
+        - antenna-p2/features/feature.xml (only the version in the <feature> tag must change)
+        <-->
+        <p2qualifier>-SNAPSHOT</p2qualifier>
         <drools.version>7.17.0.Final</drools.version>
         <gradle.version>4.1</gradle.version>
         <jackson.version>2.9.8</jackson.version>
@@ -247,9 +262,9 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.spdx</groupId>
-              <artifactId>spdx-tools</artifactId>
-              <version>2.1.15</version>
+                <groupId>org.spdx</groupId>
+                <artifactId>spdx-tools</artifactId>
+                <version>2.1.15</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -372,7 +387,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>
@@ -441,6 +456,31 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
- Versions are 1.0.0-SNAPSHOT by default as before
- An explicit version can be created by `mvn package -Drevision=<some revision> -Dchangelist=<some changelist>`
- To also change the version for P2, a few files need to be modified. This is indicated in the top level pom.

Note that this versioning scheme breaks the maven release plugin. Releases now have to be done "by hand" modifying the four locations (top-level-pom + three p2 files) + example projects by hand.