### PR TITLE
sw360(bug): when run on windows, windows ascii was used instead of utf-8 in http-headers

### DIFF
--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
@@ -89,15 +89,15 @@ public class SW360AuthenticationClient {
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, AUTHORIZATION_BASIC_VALUE + base64ClientCredentials);
-        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON_UTF8));
         return headers;
     }
 
     public HttpHeaders getHeadersWithBearerToken(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, AUTHORIZATION_BEARER_VALUE + accessToken);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON_UTF8));
         return headers;
     }
 }

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -104,11 +105,17 @@ public class SW360ComponentClient {
     public SW360Component createComponent(SW360Component sw360Component, HttpHeaders header) throws AntennaException {
         HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360Component, header);
 
-        ResponseEntity<Resource<SW360Component>> response = this.restTemplate
-                .exchange(this.componentsRestUrl,
-                        HttpMethod.POST,
-                        httpEntity,
-                        new ParameterizedTypeReference<Resource<SW360Component>>() {});
+        ResponseEntity<Resource<SW360Component>> response;
+        try {
+            response = this.restTemplate
+                    .exchange(this.componentsRestUrl,
+                            HttpMethod.POST,
+                            httpEntity,
+                            new ParameterizedTypeReference<Resource<SW360Component>>() {});
+        } catch(HttpServerErrorException e) {
+            throw new AntennaException("Request to create component " + sw360Component.getName() + " failed with "
+                    + e.getStatusCode());
+        }
 
         if (response.getStatusCode() == HttpStatus.CREATED) {
             return response.getBody().getContent();

--- a/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/antenna-sw360-adapter/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -75,12 +76,16 @@ public class SW360LicenseClient {
 
     public SW360License createLicense(SW360License sw360License, HttpHeaders header) throws AntennaException {
         HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360License, header);
-
-        ResponseEntity<Resource<SW360License>> response =
-                this.restTemplate.exchange(this.licensesRestUrl,
-                        HttpMethod.POST,
-                        httpEntity,
-                        new ParameterizedTypeReference<Resource<SW360License>>() {});
+        ResponseEntity<Resource<SW360License>> response;
+        try {
+            response = this.restTemplate.exchange(this.licensesRestUrl,
+                            HttpMethod.POST,
+                            httpEntity,
+                            new ParameterizedTypeReference<Resource<SW360License>>() {});
+        } catch (HttpClientErrorException e) {
+            throw new AntennaException("Request to create license " + sw360License.getFullName() + " failed with "
+                    + e.getStatusCode());
+        }
 
         if (response.getStatusCode() == HttpStatus.CREATED) {
             return response.getBody().getContent();


### PR DESCRIPTION
Solution done in Pair Programming with @maxhbr.

License text was represented in Windows Ascii, since tina was executed on windows.
Http headers were changed to only accept APPLICATION_JSON_UTF8

Bug found while occupied with: https://github.com/eclipse/antenna/issues/19