### PR TITLE
fix(jsonreader): artifact filename is now set when only one file in pathnames

### DIFF
--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/JsonReader.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/util/JsonReader.java
@@ -112,7 +112,7 @@ public class JsonReader {
         JsonObject licenseDataObj = (JsonObject) obj.get("licenseData");
         JsonObject securityDataObj = (JsonObject) obj.get("securityData");
         Artifact a = new Artifact("JSON")
-                .addFact(new ArtifactFilename(null, (String) obj.get("hash")))
+                .addFact(mapFilename(obj))
                 .addFact(new ArtifactPathnames(mapPathNames(obj)))
                 .addFact(new ArtifactMatchingMetadata(mapMatchState(obj)))
                 .addFact(new DeclaredLicenseInformation(mapLicenses("declaredLicenses", licenseDataObj)))
@@ -182,6 +182,18 @@ public class JsonReader {
         } catch (NumberFormatException ex) {
             return 10.0;
         }
+    }
+
+    private ArtifactFilename mapFilename(JsonObject obj) {
+        final String hash = (String) obj.get("hash");
+        if(obj.containsKey("pathnames")) {
+            final JsonArray pathnames = (JsonArray) obj.get("pathnames");
+            if (pathnames.size() == 1) {
+                String filename = Paths.get(pathnames.getString(0)).getFileName().toString();
+                return new ArtifactFilename(filename, hash);
+            }
+        }
+        return new ArtifactFilename(null, hash);
     }
 
     private LicenseInformation mapLicenses(String identifier, JsonObject licenseDataObj) {
@@ -258,7 +270,6 @@ public class JsonReader {
         }
         return Optional.empty();
     }
-
 
     private Optional<ArtifactCoordinates> mapCoordinates(JsonObject object) {
         JsonObject objComponentIdentifier = (JsonObject) object.get("componentIdentifier");


### PR DESCRIPTION
Done:
- included mapFilename() function to set `ArtifactFilename `when pathnames only contains one file
- this then enabled the `GenericCoordinates `to be used and filed, so no null values were given to the `HttpRequest `in the `SW360Updater `anymore

Issue: bug was found when occupied with #19 