### PR TITLE
Better error reporting for p2 project failure

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/p2-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/p2-resolver.md
@@ -37,5 +37,6 @@ The dependencies can currently be provided in two ways:
 
 ### Known limitations
 
-Currently, the resolver will unpack artifacts into a temporary folder and execute them.
-If executing files in temporary folders is prohibited by your OS, using the P2 Resolver is currently not possible.
+* The P2 executable uses a headless eclipse application under the hood.
+Its Linux launcher is linked against glibc, hence it will not work on Linux systems which are not shipped with glibc.
+The most prominent example of such a system is probably Alpine Linux commonly used for docker images.


### PR DESCRIPTION
The eclipse launcher is a shared library, which on Linux is explicitly linked against glibc. Some Linux/Unix distributions however are shipped without glibc but this is only visible during runtime.
This improves the error message shown to the user if the glibc might be missing.