### PR TITLE
Infrastructure: Remove plexus-utils dependency

### DIFF
--- a/antenna-core/pom.xml
+++ b/antenna-core/pom.xml
@@ -72,11 +72,6 @@
         </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -89,6 +84,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-core-common-testing</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- ################################ compliance dependency ########################### -->

--- a/antenna-core/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
+++ b/antenna-core/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
@@ -16,7 +16,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
@@ -36,6 +35,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sw360.antenna.testing.util.AntennaTestingUtils.setVariableValueInObject;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -67,7 +67,7 @@ public class HttpHelperTest {
                 .thenReturn(toolConfigMock);
 
         httpHelper = new HttpHelper(antennaContextMock);
-        ReflectionUtils.setVariableValueInObject(httpHelper, "httpClient", httpClientMock);
+        setVariableValueInObject(httpHelper, "httpClient", httpClientMock);
     }
 
     @Test

--- a/antenna-testing/antenna-core-common-testing/src/main/java/org/eclipse/sw360/antenna/testing/util/AntennaTestingUtils.java
+++ b/antenna-testing/antenna-core-common-testing/src/main/java/org/eclipse/sw360/antenna/testing/util/AntennaTestingUtils.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.testing.util;
 
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Optional;
@@ -44,5 +45,25 @@ public class AntennaTestingUtils {
     public static void assumeToBeConnectedToTheInternet() {
         checkInternetConnection(testUrl)
                 .ifPresent(e -> assumeTrue("Can not reach the internet (due to " + e.getClass().getSimpleName() + ")", false));
+    }
+
+    public static void setVariableValueInObject(Object object, String variable, Object value) throws IllegalAccessException {
+        Field field = getFieldIncludingSuperclasses(variable, object.getClass());
+        field.setAccessible(true);
+        field.set(object, value);
+    }
+
+    private static Field getFieldIncludingSuperclasses(String fieldName, Class<?> clazz) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException var5) {
+            Class<?> superclass = clazz.getSuperclass();
+            if (superclass != null) {
+                return getFieldIncludingSuperclasses(fieldName, superclass);
+            } else {
+                // This is only a testing util, so it's okay to throw a runtime exception here.
+                throw new RuntimeException("Could not find field " + fieldName);
+            }
+        }
     }
 }

--- a/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/test/java/org/eclipse/sw360/antenna/bundle/HttpRequesterTest.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/test/java/org/eclipse/sw360/antenna/bundle/HttpRequesterTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.sw360.antenna.bundle;
 
-import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
@@ -30,6 +29,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.eclipse.sw360.antenna.testing.util.AntennaTestingUtils.setVariableValueInObject;
 import static org.mockito.Mockito.*;
 
 @RunWith(Parameterized.class)
@@ -55,6 +55,7 @@ public class HttpRequesterTest extends AntennaTestWithMockedContext {
         this.isSource = isSource;
     }
 
+
     @Before
     public void before() throws Exception {
         String sourceRepositoryUrl = "http://test.repo" 
@@ -73,7 +74,7 @@ public class HttpRequesterTest extends AntennaTestWithMockedContext {
                 .thenReturn(toolConfigMock);
 
         hr = new HttpRequester(antennaContextMock);
-        ReflectionUtils.setVariableValueInObject(hr, "httpHelper", httpHelperMock);
+        setVariableValueInObject(hr, "httpHelper", httpHelperMock);
     }
         
     @Test

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/pom.xml
@@ -42,11 +42,6 @@
 		</dependency>
 		<!-- ################################ testing dependencies ################################ -->
 		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
-			<artifactId>plexus-utils</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.sw360.antenna</groupId>
 			<artifactId>antenna-core-common-testing</artifactId>
 			<version>${project.version}</version>

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/test/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolverTest.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/test/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolverTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.sw360.antenna.workflow.processors.enricher;
 
-import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
@@ -27,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sw360.antenna.testing.util.AntennaTestingUtils.setVariableValueInObject;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -41,7 +41,7 @@ public class SourceUrlResolverTest {
     @Before
     public void setUp() throws Exception {
         resolver = new SourceUrlResolver();
-        ReflectionUtils.setVariableValueInObject(resolver, "httpHelper", httpHelper);
+        setVariableValueInObject(resolver, "httpHelper", httpHelper);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -260,12 +260,6 @@
             </dependency>
             <!-- ################################ testing dependencies ################################ -->
             <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>3.1.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>


### PR DESCRIPTION
Get rid of plexus-utils dependency as it is only used for a very tiny method.