### PR TITLE
Infrastructure: Fix a few warnings in build

### DIFF
--- a/antenna-p2/dependencies/pom.xml
+++ b/antenna-p2/dependencies/pom.xml
@@ -27,4 +27,41 @@
     <properties>
         <tycho.version>1.3.0</tycho.version>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <environments>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
+                            <arch>x86</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                    </environments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/antenna-p2/pom.xml
+++ b/antenna-p2/pom.xml
@@ -101,6 +101,14 @@
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-compiler-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <useProjectSettings>false</useProjectSettings>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-p2-plugin</artifactId>
                 <version>${tycho.version}</version>
                 <executions>


### PR DESCRIPTION
p2 builds now run without any warnings.

The only build problems I have left are:
- warnings for the maven assembly plugin when overwriting the assembly (don't know how to fix this)
- warnings for skipped frontend-tests
- warnings from the maven shade plugin (no way to fix those)
- errors for antenna-documentation where there is a problem with the maven-jar-plugin