### PR TITLE
Allow ordering of workflowsteps

### DIFF
--- a/antenna-api/src/main/java/org/eclipse/sw360/antenna/api/workflow/ConfigurableWorkflowItem.java
+++ b/antenna-api/src/main/java/org/eclipse/sw360/antenna/api/workflow/ConfigurableWorkflowItem.java
@@ -26,6 +26,7 @@ public abstract class ConfigurableWorkflowItem implements IWorkflowable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurableWorkflowItem.class);
     protected IProcessingReporter reporter;
     protected AntennaContext context;
+    protected short workflowStepOrder = 1000;
 
     public void setAntennaContext(AntennaContext context) {
         this.context = context;
@@ -34,6 +35,10 @@ public abstract class ConfigurableWorkflowItem implements IWorkflowable {
 
     public void configure() throws AntennaConfigurationException {
         configure(Collections.emptyMap());
+    }
+
+    public short getWorkflowStepOrder() {
+        return workflowStepOrder;
     }
 
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {

--- a/antenna-basic-assembly/generators/antenna-sw360-disclosure-document-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SW360DisclosureDocumentGenerator.java
+++ b/antenna-basic-assembly/generators/antenna-sw360-disclosure-document-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SW360DisclosureDocumentGenerator.java
@@ -53,6 +53,10 @@ public class SW360DisclosureDocumentGenerator extends AbstractGenerator {
     private static final Set<String> outputFormats = Stream.of(DOCX_KEY, TXT_KEY, HTML_KEY).collect(Collectors.toSet());
     private Set<String> selectedOutputFormats;
 
+    public SW360DisclosureDocumentGenerator() {
+        this.workflowStepOrder = 1500;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         if(configMap.containsKey(DISCLOSURE_DOC_FORMATS_KEY)){

--- a/antenna-documentation/src/site/markdown/workflow-configuration.md.vm
+++ b/antenna-documentation/src/site/markdown/workflow-configuration.md.vm
@@ -99,6 +99,15 @@ The following example shows a workflow with one analyzer, one additional process
       </processors>
 </workflow>
 ```
+### Workflow order
+The order of workflow steps does not correspond to the order of definition in the workflow.
+Instead, each workflow step has a number assigned (`workflowStepOrder`), which determines their execution:
+Lower numbers will get executed first.
+
+The `workflowStepOrder` is a java short value. By default, a configurable workflow step will have a `workflowStepOrder` of 1000.
+A validator inheriting from `abstract-antenna-compliance-checker` will have a default `workflowStepOrder` of 10000 to ensure that validators run after enrichers.
+
+Warnings will be issued if two workflow steps have the same priority. In that case, the workflow steps will be executed in the order they were introduced in the workflow.
 
 #[[##]]# Configuring default workflow steps
 

--- a/antenna-workflow-steps/analyzers/antenna-conf-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/ConfigurationAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-conf-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/ConfigurationAnalyzer.java
@@ -29,6 +29,10 @@ import java.util.stream.Collectors;
  */
 public class ConfigurationAnalyzer extends AbstractAnalyzer {
 
+    public ConfigurationAnalyzer() {
+        this.workflowStepOrder = 100;
+    }
+
     private List<Artifact> getConfiguredArtifacts(Configuration configuration, IProcessingReporter reporter) {
         return configuration.getAddArtifact()
                 .stream()

--- a/antenna-workflow-steps/analyzers/antenna-csv-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-csv-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
@@ -42,6 +42,10 @@ public class CsvAnalyzer extends ManualAnalyzer {
     private static final String LICENSE_LONG_NAME = "License Long Name";
     private static final String PATH_NAME = "File Name";
 
+    public CsvAnalyzer() {
+        this.workflowStepOrder = 500;
+    }
+
     @Override
     public WorkflowStepResult yield() throws AntennaException {
         List<Artifact> artifacts = new ArrayList<>();

--- a/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-json-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/JsonAnalyzer.java
@@ -27,6 +27,11 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 
 public class JsonAnalyzer extends ManualAnalyzer {
+
+    public JsonAnalyzer() {
+        this.workflowStepOrder = 600;
+    }
+
     private void validate(ToolConfiguration toolConfig) throws AntennaException {
         // Check that JSON file is present
         if (!componentInfoFile.exists()) {

--- a/antenna-workflow-steps/analyzers/antenna-mvn-dependency-tree-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/MvnDependencyTreeAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-mvn-dependency-tree-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/MvnDependencyTreeAnalyzer.java
@@ -29,6 +29,10 @@ import java.util.stream.Collectors;
 
 public class MvnDependencyTreeAnalyzer extends AbstractAnalyzer {
 
+    public MvnDependencyTreeAnalyzer() {
+        this.workflowStepOrder = 400;
+    }
+
     @Override
     public WorkflowStepResult yield() {
 

--- a/antenna-workflow-steps/analyzers/antenna-ort-result-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/OrtResultAnalyzer.java
+++ b/antenna-workflow-steps/analyzers/antenna-ort-result-analyzer/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/OrtResultAnalyzer.java
@@ -36,6 +36,10 @@ import java.util.stream.StreamSupport;
 public class OrtResultAnalyzer extends ManualAnalyzer {
     private static final Logger LOGGER = LoggerFactory.getLogger(OrtResultAnalyzer.class);
 
+    public OrtResultAnalyzer() {
+        this.workflowStepOrder = 700;
+    }
+
     static private Optional<ArtifactCoordinates> mapCoordinates(String ortIdentifier) {
         String[] ortIdentifierSeparate = ortIdentifier.split(":");
         if (ortIdentifierSeparate.length < 3) {

--- a/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGenerator.java
+++ b/antenna-workflow-steps/generators/antenna-HTML-report-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGenerator.java
@@ -46,6 +46,10 @@ public class HTMLReportGenerator extends AbstractGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(HTMLReportGenerator.class);
     private Charset encoding;
 
+    public HTMLReportGenerator() {
+        this.workflowStepOrder = 600;
+    }
+
     @Override
     public Map<String, IAttachable> produce(Collection<Artifact> artifacts) throws AntennaExecutionException {
         LOGGER.info("Generating HTML report.");

--- a/antenna-workflow-steps/generators/antenna-csv-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/CSVGenerator.java
+++ b/antenna-workflow-steps/generators/antenna-csv-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/CSVGenerator.java
@@ -47,11 +47,14 @@ public class CSVGenerator extends AbstractGenerator {
     private Path targetDirectory;
     private Charset encoding;
 
+    public CSVGenerator() {
+        this.workflowStepOrder = 500;
+    }
+
     /**
      * Creates a csv file that contains artifact name, version and license. File
      * will be written to CsvFileWriter.ANTENNA_ARTIFACT_INFORMATION_CSV
      */
-
     private void writeFile(StringBuilder information, File csvFile) {
         try (PrintWriter out = new PrintWriter(csvFile, encoding.toString())) {
             out.write(information.toString());

--- a/antenna-workflow-steps/generators/antenna-source-zip-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriter.java
+++ b/antenna-workflow-steps/generators/antenna-source-zip-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriter.java
@@ -51,6 +51,10 @@ public class SourceZipWriter extends AbstractGenerator {
     private IProcessingReporter reporter;
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceZipWriter.class);
 
+    public SourceZipWriter() {
+        this.workflowStepOrder = 700;
+    }
+
     /**
      * Creates a zip file which contains the source jars of the artifacts, which
      * have passed all filters. Name of zip file :

--- a/antenna-workflow-steps/generators/antenna-sw360-update-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SW360Updater.java
+++ b/antenna-workflow-steps/generators/antenna-sw360-update-generator/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SW360Updater.java
@@ -38,6 +38,10 @@ public class SW360Updater extends AbstractGenerator {
     private String projectName;
     private String projectVersion;
 
+    public SW360Updater() {
+        this.workflowStepOrder = 1100;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         SW360ProjectCoordinates configuredSW360Project = context.getConfiguration().getConfiguredSW360Project();

--- a/antenna-workflow-steps/outputHandlers/antenna-add-to-archive-output-handler/src/main/java/org/eclipse/sw360/antenna/workflow/outputHandlers/FileToArchiveWriter.java
+++ b/antenna-workflow-steps/outputHandlers/antenna-add-to-archive-output-handler/src/main/java/org/eclipse/sw360/antenna/workflow/outputHandlers/FileToArchiveWriter.java
@@ -38,6 +38,10 @@ public class FileToArchiveWriter extends AbstractOutputHandler {
 
     private final List<FileToArchiveWriterInstruction> writeToArchiveInstructions = new ArrayList<>();
 
+    public FileToArchiveWriter() {
+        this.workflowStepOrder = 500;
+    }
+
     @Override
     public void handle(Map<String, IAttachable> generatedOutput) {
         for (FileToArchiveWriterInstruction instruction : writeToArchiveInstructions) {

--- a/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AbstractComplianceChecker.java
+++ b/antenna-workflow-steps/processors/abstract-antenna-compliance-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/checkers/AbstractComplianceChecker.java
@@ -31,6 +31,10 @@ public abstract class AbstractComplianceChecker extends AbstractProcessor {
     private IEvaluationResult.Severity failOn;
     protected static final String FAIL_ON_KEY = "failOn";
 
+    public AbstractComplianceChecker() {
+        this.workflowStepOrder = 10000;
+    }
+
     public abstract IPolicyEvaluation evaluate(Collection<Artifact> artifacts) throws AntennaException;
 
     public abstract String getRulesetDescription();

--- a/antenna-workflow-steps/processors/antenna-conf-processor/src/main/java/org/eclipse/sw360/antenna/workflow/processors/AntennaConfHandler.java
+++ b/antenna-workflow-steps/processors/antenna-conf-processor/src/main/java/org/eclipse/sw360/antenna/workflow/processors/AntennaConfHandler.java
@@ -24,6 +24,10 @@ public class AntennaConfHandler extends AbstractProcessor {
 
     private final List<AbstractProcessor> localProcessors = new ArrayList<>();
 
+    public AntennaConfHandler() {
+        this.workflowStepOrder = 0;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) {
         IProcessingReporter processingReporter = context.getProcessingReporter();

--- a/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/MavenArtifactResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/MavenArtifactResolver.java
@@ -46,6 +46,10 @@ public class MavenArtifactResolver extends AbstractProcessor {
     private String preferredSourceQualifier;
     private URL sourcesRepositoryUrl;
 
+    public MavenArtifactResolver() {
+        this.workflowStepOrder = 300;
+    }
+
     private boolean isIgnoredForSourceResolving(Artifact artifact) {
         return sourceResolvingBlacklist.stream()
                 .anyMatch(artifactSelector -> artifactSelector.matches(artifact));

--- a/antenna-workflow-steps/processors/enricher/antenna-child-jar-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/ChildJarResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-child-jar-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/ChildJarResolver.java
@@ -41,6 +41,10 @@ public class ChildJarResolver extends AbstractProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChildJarResolver.class);
     private Path targetDirectory;
 
+    public ChildJarResolver() {
+        this.workflowStepOrder = 400;
+    }
+
     /**
      * Resolves the given list of artifacts. Checks if a pathname contains more
      * than one jar/zip/war, if yes the inner jar/zip/war will be resolved.

--- a/antenna-workflow-steps/processors/enricher/antenna-license-knowledgebase-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/LicenseKnowledgeBaseResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-license-knowledgebase-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/LicenseKnowledgeBaseResolver.java
@@ -39,6 +39,7 @@ public class LicenseKnowledgeBaseResolver extends AbstractProcessor {
     private ILicenseManagementKnowledgeBase knowledgeBase;
 
     public LicenseKnowledgeBaseResolver() {
+        this.workflowStepOrder = 600;
     }
 
     public LicenseKnowledgeBaseResolver(ILicenseManagementKnowledgeBase knowledgeBase) {

--- a/antenna-workflow-steps/processors/enricher/antenna-license-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/LicenseResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-license-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/LicenseResolver.java
@@ -33,6 +33,10 @@ public class LicenseResolver extends AbstractProcessor {
     private Map<ArtifactSelector, LicenseInformation> configuredLicenses;
     private static final Logger LOGGER = LoggerFactory.getLogger(LicenseResolver.class);
 
+    public LicenseResolver() {
+        this.workflowStepOrder = 500;
+    }
+
     /**
      * Adds the license information from the license document to the artifacts
      * list.

--- a/antenna-workflow-steps/processors/enricher/antenna-manifest-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/ManifestResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-manifest-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/ManifestResolver.java
@@ -49,6 +49,10 @@ import java.util.zip.ZipInputStream;
 public class ManifestResolver extends AbstractProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestResolver.class);
 
+    public ManifestResolver() {
+        this.workflowStepOrder = 900;
+    }
+
     /**
      * Scans all file paths of the artifacts, if a jar file is found and
      * contains a Manifest file with bundle coordinates this coordinates are

--- a/antenna-workflow-steps/processors/enricher/antenna-p2-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/P2Resolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-p2-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/P2Resolver.java
@@ -41,6 +41,10 @@ public class P2Resolver extends AbstractProcessor {
 
     private List<String> repositories;
 
+    public P2Resolver() {
+        this.workflowStepOrder = 1100;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         repositories = Arrays.asList(getConfigValue(DEPENDENCY_REPOSITORY, configMap).split(";"));

--- a/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolver.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-source-url-resolver/src/main/java/org/eclipse/sw360/antenna/workflow/processors/enricher/SourceUrlResolver.java
@@ -34,6 +34,10 @@ public class SourceUrlResolver extends AbstractProcessor {
     private HttpHelper httpHelper;
     private Path dependencyTargetDirectory;
 
+    public SourceUrlResolver() {
+        this.workflowStepOrder = 1500;
+    }
+
     @Override
     public Collection<Artifact> process(Collection<Artifact> artifacts) {
         LOGGER.info("Resolve source urls...");

--- a/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SW360Enricher.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-sw360-enricher/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SW360Enricher.java
@@ -49,6 +49,10 @@ public class SW360Enricher extends AbstractProcessor {
 
     private SW360MetaDataReceiver connector;
 
+    public SW360Enricher() {
+        this.workflowStepOrder = 1300;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         super.configure(configMap);

--- a/antenna-workflow-steps/processors/validators/antenna-coordinates-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/CoordinatesValidator.java
+++ b/antenna-workflow-steps/processors/validators/antenna-coordinates-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/CoordinatesValidator.java
@@ -29,6 +29,10 @@ public class CoordinatesValidator extends AbstractComplianceChecker {
 
     private IEvaluationResult.Severity missingCoordinatesSeverity;
 
+    public CoordinatesValidator() {
+        this.workflowStepOrder = 10100;
+    }
+
     @Override
     public IPolicyEvaluation evaluate(Collection<Artifact> artifacts) {
         DefaultPolicyEvaluation policyEvaluation = new DefaultPolicyEvaluation();

--- a/antenna-workflow-steps/processors/validators/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/AntennaDroolsChecker.java
+++ b/antenna-workflow-steps/processors/validators/antenna-drools-checker/src/main/java/org/eclipse/sw360/antenna/workflow/processors/AntennaDroolsChecker.java
@@ -28,6 +28,10 @@ public class AntennaDroolsChecker extends AbstractComplianceChecker {
     private static final String POLICIES_FOLDER_PATH = "folder.paths";
     private static final String NO_VERSION = "no version string specified";
 
+    public AntennaDroolsChecker() {
+        this.workflowStepOrder = 20000;
+    }
+
     @Override
     public void configure(Map<String, String> configMap) throws AntennaConfigurationException {
         super.configure(configMap);

--- a/antenna-workflow-steps/processors/validators/antenna-license-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseValidator.java
+++ b/antenna-workflow-steps/processors/validators/antenna-license-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseValidator.java
@@ -52,6 +52,10 @@ public class LicenseValidator extends AbstractComplianceChecker {
     private List<String> forbiddenLicenseIds;
     private List<String> ignoredLicenseIds;
 
+    public LicenseValidator() {
+        this.workflowStepOrder = 10200;
+    }
+
     /**
      * Validates the licenses of the given list of artifacts. If a license is
      * not valid a ProcessingMessage is added to the reporter. If a license is

--- a/antenna-workflow-steps/processors/validators/antenna-match-state-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/MatchStateValidator.java
+++ b/antenna-workflow-steps/processors/validators/antenna-match-state-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/MatchStateValidator.java
@@ -35,6 +35,10 @@ public class MatchStateValidator extends AbstractComplianceChecker {
     private IEvaluationResult.Severity SIMILAR_Severity = IEvaluationResult.Severity.WARN;
     private IEvaluationResult.Severity UNKNOWN_Severity = IEvaluationResult.Severity.WARN;
 
+    public MatchStateValidator() {
+        this.workflowStepOrder = 10300;
+    }
+
     @Override
     public IPolicyEvaluation evaluate(Collection<Artifact> artifacts) {
         DefaultPolicyEvaluation policyEvaluation = new DefaultPolicyEvaluation();

--- a/antenna-workflow-steps/processors/validators/antenna-security-issue-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SecurityIssueValidator.java
+++ b/antenna-workflow-steps/processors/validators/antenna-security-issue-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SecurityIssueValidator.java
@@ -44,6 +44,10 @@ public class SecurityIssueValidator extends AbstractComplianceChecker {
     private Map<ArtifactSelector, Issues> configuredSecurityIssues;
     private Map<String, Map<ArtifactSelector, GregorianCalendar>> suppressedSecurityIssues;
 
+    public SecurityIssueValidator() {
+        this.workflowStepOrder = 10400;
+    }
+
     public List<IEvaluationResult> validate(Artifact artifact) {
         List<Issue> configuredIssueList = configuredSecurityIssues.entrySet().stream()
                 .filter(entry -> entry.getKey().matches(artifact))

--- a/antenna-workflow-steps/processors/validators/antenna-source-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SourceValidator.java
+++ b/antenna-workflow-steps/processors/validators/antenna-source-validator/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SourceValidator.java
@@ -46,6 +46,10 @@ public class SourceValidator extends AbstractComplianceChecker {
     private IEvaluationResult.Severity missingSourcesSeverity;
     private IEvaluationResult.Severity incompleteSourcesSeverity;
 
+    public SourceValidator() {
+        this.workflowStepOrder = 10500;
+    }
+
     private boolean isArtifactAllowedToHaveNoSourceJar(Artifact artifact) {
         return missingSourcesWhiteList.stream()
                 .anyMatch(artifactSelector -> artifactSelector.matches(artifact));


### PR DESCRIPTION
Resolves #139 

Very simple implementation:
- Every step has a number (java short) and the corresponding batches (analyzer, processor, generator, outputHandler) are executed in the order defined by these numbers.
- Warnings are written to the command line if steps have the same order number.
- A default number is given to any workflow step (obviously, this has to be overridden to avoid warnings).

Should we document and if yes, where should we document the numbers?