### PR TITLE
fix(p2): correct versioning in antenna-p2

### DIFF
--- a/antenna-p2/dependencies/antenna-p2-osgi-dependencies/pom.xml
+++ b/antenna-p2/dependencies/antenna-p2-osgi-dependencies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>dependencies</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>antenna-p2-osgi-dependencies</artifactId>
     <packaging>eclipse-repository</packaging>

--- a/antenna-p2/dependencies/antenna-repackaged-dependencies/pom.xml
+++ b/antenna-p2/dependencies/antenna-repackaged-dependencies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>dependencies</artifactId>
         <groupId>org.eclipse.sw360.antenna</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${revision}${p2qualifier}</version>
     </parent>
     <artifactId>antenna-repackaged-dependencies</artifactId>
     <packaging>eclipse-repository</packaging>

--- a/antenna-p2/dependencies/pom.xml
+++ b/antenna-p2/dependencies/pom.xml
@@ -16,7 +16,7 @@
 
     <artifactId>dependencies</artifactId>
     <groupId>org.eclipse.sw360.antenna</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>${revision}${p2qualifier}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -25,6 +25,8 @@
     </modules>
 
     <properties>
+        <revision>1.0.0</revision>
+        <p2qualifier>-SNAPSHOT</p2qualifier>
         <tycho.version>1.3.0</tycho.version>
     </properties>
 </project>


### PR DESCRIPTION
Get rid of `<version>1.0.0-SNAPSHOT</version>` in antenna-p2/dependencies module for correct versioning. 