### PR TITLE
Document availability of adding plugins at runtime for all frontends

### DIFF
--- a/antenna-basic-assembly/antenna-cli/src/site/markdown/index.md.vm
+++ b/antenna-basic-assembly/antenna-cli/src/site/markdown/index.md.vm
@@ -21,7 +21,7 @@ must describe the original locations of your source artifacts.
 
 * For technical reasons variables / properties containing dots will in general not be rendered correctly
 
-    * No Maven variables can be used (except for `project.build.directory`, `project.build.outputDirectory` and `project.basedir`, since they have been added to the context).
+    * No Maven variables can be used except for those properties noted in [WorkflowConfiguration](../workflow-configuration.html)
 
     * Properties with a dot in them, like `${system.password}` should be changed to `${systemPassword}` in order to be rendered.
 
@@ -79,3 +79,16 @@ Alternatively ${docNameCap} can be run over the command line with this simple li
 ```
 java -jar path\to\ ${docName}.jar path\to\pom.xml
 ```
+
+#[[##]]# Adding workflow steps and plugins
+
+It is possible to use workflow steps, knowledge-bases, etc. also if they are not referenced in the assembly.
+To do this, the jars need to be added to the classpath.
+If you have a custom plugin `my-custom-plugin` where the jar can be found at `$MY_CUSTOM_PLUGIN_JAR`, then simply add
+```sh
+CLASSPATH=$ANTENNA_JAR:$MY_CUSTOM_PLUGIN_JAR
+java -cp %CLASSPATH% $${antennaCliJavaFilename} %POM_FILE%
+```
+in the script above.
+
+The same is true for bat scripts on Windows.

--- a/antenna-basic-assembly/antenna-gradle-plugin/src/site/markdown/index.md.vm
+++ b/antenna-basic-assembly/antenna-gradle-plugin/src/site/markdown/index.md.vm
@@ -51,3 +51,22 @@ If you choose to run ${docNameCap} with Maven, you need to set the maven environ
 
     * Properties with a dot in them, like `${system.password}` should be changed to `${systemPassword}` in order to be rendered.
 
+#[[##]]# Adding workflow steps and plugins
+
+It is possible to use workflow steps, knowledge-bases, etc. also if they are not referenced in the assembly.
+To do this, the jars need to be added as dependencies to the plugin step of Gradle.
+If you have a custom plugin `my-custom-plugin` with groupId `org.mycompany.plugin`, artifactId `my-custom-plugin` and version `VERSION`, modify the `buildscript` part within `build.gradle` as follows:
+
+```groovy
+buildscript{
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.eclipse.sw360.antenna:antenna-gradle-plugin:VERSION'
+        classpath 'org.mycompany.plugin:my-custom-plugin:VERSION'
+    }
+}
+```

--- a/antenna-basic-assembly/antenna-maven-plugin/src/site/markdown/index.md.vm
+++ b/antenna-basic-assembly/antenna-maven-plugin/src/site/markdown/index.md.vm
@@ -51,16 +51,16 @@ install the ${docNameCap} plugin, something like this:
 </dependency>
 ```
 
-#[[##]]# Adding a rules engine
+#[[##]]# Adding workflow steps and plugins
 
-If you want to use a rule engine to validate your artifacts, you can
-install a rule engine module by adding a dependency to your project's 
-pom.xml file where you install the ${docNameCap} plugin, something like this: 
+It is possible to use workflow steps, knowledge-bases, etc. also if they are not referenced in the assembly.
+To do this, the jars need to be added as a dependency for the build.
+If you have a custom plugin `my-custom-plugin` with groupId `org.mycompany.plugin`, artifactId `my-custom-plugin` and version `VERSION`, modify the `buildscript` part within `build.gradle` as follows:
 
 ```xml
 <dependency>
-    <groupId>org.eclipse.sw360.antenna.rules</groupId>
-    <artifactId>simple-rule-engine</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <groupId>org.mycompany.plugin</groupId>
+    <artifactId>my-custom-plugin</artifactId>
+    <version>VERSION</version>
 </dependency>
 ```

--- a/antenna-documentation/pom.xml
+++ b/antenna-documentation/pom.xml
@@ -28,7 +28,7 @@
         <docNameCap>Antenna</docNameCap>
         <docNameAllCap>ANTENNA</docNameAllCap>
         <skip.tests>true</skip.tests>
-        <antennaCliJavaFilename>org.eclipse.sw360.antenna.frontend.AntennaCLIFrontend</antennaCliJavaFilename>
+        <antennaCliJavaFilename>org.eclipse.sw360.antenna.frontend.AntennaBasicCLIFrontend</antennaCliJavaFilename>
         <antennaMavenGroupId>org.eclipse.sw360.antenna</antennaMavenGroupId>
         <antennaMavenPluginName>antenna-maven-plugin</antennaMavenPluginName>
         <antennaGradlePluginName>antenna-gradle-plugin</antennaGradlePluginName>


### PR DESCRIPTION
Test it:
* Remove `antenna-csv-analyzer` from `antenna-basic-configuration/pom.xml`.
* Rebuild and observe:
  * In `example-projects/example-project`, `mvn clean package` fails (can't find csv analyzer)
  * In `example-projects/example-project`, `gradle analyze` fails (can't find csv analyzer)
  * `java -cp /path/to/antenna.jar org.eclipse.sw360.antenna.frontend.AntennaBasicCLIFrontend example-projects/example-project/pom.xml` fails (can't find csv analyzer)
* Now do what is described in the documentation and observe:
  * `mvn clean package` works as expected after adding the dependency to the `pom.xml`.
  * `gradle analyze` works as expected after adding `classpath org.eclipse.sw360.antenna:antenna-csv-analyzer:1.0.0-SNAPSHOT` to the `buildscript` `dependencies`.
  * `java -cp /path/to/antenna-csv-analyzer-1.0.0-SNAPSHOT.jar:/path/to/antenna.jar org.eclipse.sw360.antenna.frontend.AntennaBasicCLIFrontend example-projects/example-project/pom.xml` works as expected