### PR TITLE
Proxy for sw360updater and sw360enricher

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
+++ b/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
@@ -25,6 +25,7 @@ Add the following step into the `<generators>` section of your workflow.xml
         <entry key="user.password" value="12345"/>
         <entry key="client.id" value="trusted-sw360-client"/>
         <entry key="client.password" value="sw360-secret"/>
+        <entry key="proxy.use" value="true"/>
     </configuration>
 </step>
 ```
@@ -36,3 +37,4 @@ Add the following step into the `<generators>` section of your workflow.xml
 * `user.password`: The password of the SW360 user.
 * `client.id`: The REST API uses a two step authentication, this is general client id used.
 * `client.password`: The password of the client id.
+* `proxy.use`: Enable proxy for communication to SW360.

--- a/antenna-documentation/src/site/markdown/processors/sw360-enricher.md
+++ b/antenna-documentation/src/site/markdown/processors/sw360-enricher.md
@@ -18,6 +18,7 @@ Add the following step into the `<processors>` section of your workflow.xml
         <entry key="user.password" value="12345"/>
         <entry key="client.id" value="trusted-sw360-client"/>
         <entry key="client.password" value="sw360-secret"/>
+        <entry key="proxy.use" value="true"/>
     </configuration>
 </step>
 ```
@@ -29,3 +30,4 @@ Add the following step into the `<processors>` section of your workflow.xml
 * `user.password`: The password of the SW360 user.
 * `client.id`: The REST API uses a two step authentication, this is general client id used.
 * `client.password`: The password of the client id.
+* `proxy.use`: Use proxy for communication to SW360.

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
@@ -130,6 +130,7 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
                     put("user.password", "12345");
                     put("client.id", "trusted-sw360-client");
                     put("client.password", "sw360-secret");
+                    put("proxy.use", "false");
                 }});
         generator.setDeactivated(true);
         result.add(generator);

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/MavenTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/MavenTestProject.java
@@ -124,6 +124,7 @@ public class MavenTestProject extends AbstractTestProjectWithExpectations implem
                     put("user.password", "12345");
                     put("client.id", "trusted-sw360-client");
                     put("client.password", "sw360-secret");
+                    put("proxy.use", "false");
                 }});
         generator.setDeactivated(true);
         result.add(generator);

--- a/example-projects/example-project/src/workflow.xml
+++ b/example-projects/example-project/src/workflow.xml
@@ -50,6 +50,7 @@
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>
                 <entry key="client.password" value="sw360-secret"/>
+                <entry key="proxy.use" value="false"/>
             </configuration>
             <deactivated>true</deactivated>
         </step>

--- a/example-projects/mvn-test-project/src/workflow.xml
+++ b/example-projects/mvn-test-project/src/workflow.xml
@@ -43,6 +43,7 @@
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>
                 <entry key="client.password" value="sw360-secret"/>
+                <entry key="proxy.use" value="false"/>
             </configuration>
             <deactivated>true</deactivated>
         </step>

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
@@ -42,16 +42,17 @@ public class SW360MetaDataReceiver {
     private String clientPassword;
 
     public SW360MetaDataReceiver(String restServerUrl, String authServerUrl, String userId, String password,
-                                 String clientId, String clientPassword) {
+                                 String clientId, String clientPassword,
+                                 boolean proxyEnable, String proxyHost, int proxyPort) {
         this.userId = userId;
         this.password = password;
         this.clientId = clientId;
         this.clientPassword = clientPassword;
 
-        authenticationClient = new SW360AuthenticationClient(authServerUrl);
-        componentClientAdapter = new SW360ComponentClientAdapter(restServerUrl);
-        releaseClientAdapter = new SW360ReleaseClientAdapter(restServerUrl);
-        licenseClientAdapter = new SW360LicenseClientAdapter(restServerUrl);
+        authenticationClient = new SW360AuthenticationClient(authServerUrl, proxyEnable, proxyHost, proxyPort);
+        componentClientAdapter = new SW360ComponentClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        releaseClientAdapter = new SW360ReleaseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        licenseClientAdapter = new SW360LicenseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
     }
 
     public Optional<SW360Release> findReleaseForArtifact(Artifact artifact) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -45,18 +45,20 @@ public class SW360MetaDataUpdater {
     private String clientId;
     private String clientPassword;
 
-    public SW360MetaDataUpdater(String restServerUrl, String authServerUrl, String userId, String password, String clientId, String clientPassword) {
+    public SW360MetaDataUpdater(String restServerUrl, String authServerUrl,
+                                String userId, String password, String clientId, String clientPassword,
+                                boolean proxyEnable, String proxyHost, int proxyPort) {
         this.userId = userId;
         this.password = password;
         this.clientId = clientId;
         this.clientPassword = clientPassword;
 
-        authenticationClient = new SW360AuthenticationClient(authServerUrl);
-        projectClientAdapter = new SW360ProjectClientAdapter(restServerUrl);
-        licenseClientAdapter = new SW360LicenseClientAdapter(restServerUrl);
-        componentClientAdapter = new SW360ComponentClientAdapter(restServerUrl);
-        releaseClientAdapter = new SW360ReleaseClientAdapter(restServerUrl);
-        userClientAdapter = new SW360UserClientAdapter(restServerUrl);
+        authenticationClient = new SW360AuthenticationClient(authServerUrl, proxyEnable, proxyHost, proxyPort);
+        projectClientAdapter = new SW360ProjectClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        licenseClientAdapter = new SW360LicenseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        componentClientAdapter = new SW360ComponentClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        releaseClientAdapter = new SW360ReleaseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+        userClientAdapter = new SW360UserClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
     }
 
     public Set<String> getOrCreateLicenses(Artifact artifact) throws IOException, AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -27,7 +27,9 @@ import java.util.stream.Collectors;
 public class SW360ComponentClientAdapter {
     private final SW360ComponentClient componentClient;
 
-    public SW360ComponentClientAdapter(String restUrl) { this.componentClient = new SW360ComponentClient(restUrl); }
+    public SW360ComponentClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        this.componentClient = new SW360ComponentClient(restUrl, proxyUse, proxyHost, proxyPort);
+    }
 
     public SW360Component addComponent(Artifact artifact, HttpHeaders header) throws AntennaException {
         SW360Component component = new SW360Component();

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
@@ -23,7 +23,9 @@ import java.util.Optional;
 public class SW360LicenseClientAdapter {
     private final SW360LicenseClient licenseClient;
 
-    public SW360LicenseClientAdapter(String restUrl) { this.licenseClient = new SW360LicenseClient(restUrl); }
+    public SW360LicenseClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        this.licenseClient = new SW360LicenseClient(restUrl, proxyUse, proxyHost, proxyPort);
+    }
 
     public boolean isLicenseOfArtifactAvailable(License license, HttpHeaders header) throws AntennaException {
         List<SW360SparseLicense> sw360Licenses = licenseClient.getLicenses(header);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
@@ -34,14 +34,13 @@ import java.util.stream.Collectors;
 public class SW360ProjectClientAdapter {
     private final SW360ProjectClient projectClient;
 
-    public SW360ProjectClientAdapter(String restUrl) {
-        this.projectClient = new SW360ProjectClient(restUrl);
+    public SW360ProjectClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        this.projectClient = new SW360ProjectClient(restUrl, proxyUse, proxyHost, proxyPort);
     }
 
     public Optional<String> getProjectIdByNameAndVersion(IProject project, HttpHeaders header) throws AntennaException {
         return getProjectIdByNameAndVersion(project.getProjectId(), project.getVersion(), header);
     }
-
 
     public Optional<String> getProjectIdByNameAndVersion(String projectName, String projectVersion, HttpHeaders header) throws AntennaException {
         List<SW360Project> projects = projectClient.searchByName(projectName, header);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -30,8 +30,8 @@ import java.util.Set;
 public class SW360ReleaseClientAdapter {
     private final SW360ReleaseClient releaseClient;
 
-    public SW360ReleaseClientAdapter(String restUrl) {
-        this.releaseClient = new SW360ReleaseClient(restUrl);
+    public SW360ReleaseClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        this.releaseClient = new SW360ReleaseClient(restUrl, proxyUse, proxyHost, proxyPort);
     }
 
     public SW360Release addRelease(Artifact artifact, SW360Component sw360Component, Set<String> sw360LicenseIds, HttpHeaders header) throws IOException, AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
@@ -17,14 +17,14 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.users.SW360User;
 import org.springframework.http.HttpHeaders;
 
 public class SW360UserClientAdapter {
-    private String restUrl;
 
-    public SW360UserClientAdapter(String backendURL) {
-        restUrl = backendURL;
+    private final SW360UserClient userClient;
+
+    public SW360UserClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        this.userClient= new SW360UserClient(restUrl, proxyUse, proxyHost, proxyPort);
     }
 
     public SW360User getUserByEmail(String userId, HttpHeaders header) throws AntennaException {
-        SW360UserClient userClient = new SW360UserClient(restUrl);
-            return userClient.getUserByEmail(userId, header);
+        return userClient.getUserByEmail(userId, header);
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Verifa Oy 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -19,10 +20,13 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,12 +34,23 @@ import java.util.List;
 public class SW360ComponentClient {
     private static final String COMPONENTS_ENDPOINT = "/components";
 
-    private final RestTemplate restTemplate = new RestTemplate();
-
     private final String componentsRestUrl;
+    private RestTemplate restTemplate;
 
-    public SW360ComponentClient(String restUrl) {
+    public SW360ComponentClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         this.componentsRestUrl = restUrl + COMPONENTS_ENDPOINT;
+        this.restTemplate = restTemplate(proxyUse, proxyHost, proxyPort);
+    }
+
+    private RestTemplate restTemplate(boolean proxyUse, String proxyHost, int proxyPort) {
+        if (proxyUse && proxyHost != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            requestFactory.setProxy(proxy);
+            return new RestTemplate(requestFactory);
+        } else {
+            return new RestTemplate();
+        }
     }
 
     public SW360Component getComponent(String componentId, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Verifa Oy 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,9 +19,12 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,12 +32,23 @@ import java.util.List;
 public class SW360LicenseClient {
     private static final String LICENSES_ENDPOINT = "/licenses";
 
-    private RestTemplate restTemplate = new RestTemplate();
-
     private String licensesRestUrl;
+    private RestTemplate restTemplate;
 
-    public SW360LicenseClient(String restUrl) {
+    public SW360LicenseClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         licensesRestUrl = restUrl + LICENSES_ENDPOINT;
+        this.restTemplate = restTemplate(proxyUse, proxyHost, proxyPort);
+    }
+
+    private RestTemplate restTemplate(boolean proxyUse, String proxyHost, int proxyPort) {
+        if (proxyUse && proxyHost != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            requestFactory.setProxy(proxy);
+            return new RestTemplate(requestFactory);
+        } else {
+            return new RestTemplate();
+        }
     }
     
     public List<SW360SparseLicense> getLicenses(HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+ * Copyright (c) Verifa Oy 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -21,9 +22,12 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,12 +35,23 @@ import java.util.List;
 public class SW360ProjectClient {
     private static final String PROJECTS_ENDPOINT = "/projects";
 
-    private RestTemplate restTemplate = new RestTemplate();
-
     private String projectsRestUrl;
+    private RestTemplate restTemplate;
 
-    public SW360ProjectClient(String restUrl) {
+    public SW360ProjectClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         projectsRestUrl = restUrl + PROJECTS_ENDPOINT;
+        this.restTemplate = restTemplate(proxyUse, proxyHost, proxyPort);
+    }
+
+    private RestTemplate restTemplate(boolean proxyUse, String proxyHost, int proxyPort) {
+        if (proxyUse && proxyHost != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            requestFactory.setProxy(proxy);
+            return new RestTemplate(requestFactory);
+        } else {
+            return new RestTemplate();
+        }
     }
 
     public List<SW360Project> searchByName(String name, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Verifa Oy 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,9 +19,12 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,11 +32,24 @@ import java.util.List;
 public class SW360ReleaseClient {
     private static final String RELEASES_ENDPOINT = "/releases";
 
-    private RestTemplate restTemplate = new RestTemplate();
-
     private String releasesRestUrl;
+    private RestTemplate restTemplate;
 
-    public SW360ReleaseClient(String restUrl) { releasesRestUrl = restUrl + RELEASES_ENDPOINT; }
+    public SW360ReleaseClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
+        releasesRestUrl = restUrl + RELEASES_ENDPOINT;
+        this.restTemplate = restTemplate(proxyUse, proxyHost, proxyPort);
+    }
+
+    private RestTemplate restTemplate(boolean proxyUse, String proxyHost, int proxyPort) {
+        if (proxyUse && proxyHost != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            requestFactory.setProxy(proxy);
+            return new RestTemplate(requestFactory);
+        } else {
+            return new RestTemplate();
+        }
+    }
 
     public SW360Release getRelease(String releaseId, HttpHeaders header) throws AntennaException {
         HttpEntity<String> httpEntity = RestUtils.getHttpEntity(Collections.emptyMap(), header);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+ * Copyright (c) Verifa Oy 2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,19 +18,33 @@ import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Collections;
 
 public class SW360UserClient {
     private static final String USERS_ENDPOINT = "/users";
 
-    private RestTemplate restTemplate = new RestTemplate();
-
     private final String usersRestUrl;
+    private RestTemplate restTemplate;
 
-    public SW360UserClient(String restUrl) {
+    public SW360UserClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         usersRestUrl = restUrl + USERS_ENDPOINT;
+        this.restTemplate = restTemplate(proxyUse, proxyHost, proxyPort);
+    }
+
+    private RestTemplate restTemplate(boolean proxyUse, String proxyHost, int proxyPort) {
+        if (proxyUse && proxyHost != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            requestFactory.setProxy(proxy);
+            return new RestTemplate(requestFactory);
+        } else {
+            return new RestTemplate();
+        }
     }
 
     public SW360User getUserByEmail(String email, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
@@ -31,6 +31,7 @@ public class SW360Updater extends AbstractGenerator {
     private static final String PASSWORD_KEY = "user.password";
     private static final String CLIENT_USER_KEY = "client.id";
     private static final String CLIENT_PASSWORD_KEY = "client.password";
+    private static final String PROXY_USE = "proxy.use";
 
     private String sw360RestServerUrl;
     private String sw360AuthServerUrl;
@@ -38,7 +39,9 @@ public class SW360Updater extends AbstractGenerator {
     private String sw360Password;
     private String sw360ClientId;
     private String sw360ClientPassword;
-
+    private String sw360ProxyHost;
+    private int sw360ProxyPort;
+    private boolean sw360ProxyUse;
 
     private String projectName;
     private String projectVersion;
@@ -66,12 +69,16 @@ public class SW360Updater extends AbstractGenerator {
         sw360Password = getConfigValue(PASSWORD_KEY, configMap);
         sw360ClientId = getConfigValue(CLIENT_USER_KEY, configMap);
         sw360ClientPassword = getConfigValue(CLIENT_PASSWORD_KEY, configMap);
+        sw360ProxyUse = Boolean.parseBoolean(getConfigValue(PROXY_USE, configMap, "false"));
+        sw360ProxyHost = context.getToolConfiguration().getProxyHost();
+        sw360ProxyPort = context.getToolConfiguration().getProxyPort();
     }
 
     @Override
     public Map<String, IAttachable> produce(Collection<Artifact> intermediates) throws AntennaException {
         SW360MetaDataUpdater sw360MetaDataUpdater = new SW360MetaDataUpdater(sw360RestServerUrl, sw360AuthServerUrl, sw360User,
-                sw360Password, sw360ClientId, sw360ClientPassword);
+                sw360Password, sw360ClientId, sw360ClientPassword,
+                sw360ProxyUse, sw360ProxyHost, sw360ProxyPort);
 
         try {
             List<SW360Release> releases = new ArrayList<>();

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -48,6 +48,7 @@ public class SW360Enricher extends AbstractProcessor {
     private static final String PASSWORD_KEY = "user.password";
     private static final String CLIENT_USER_KEY = "client.id";
     private static final String CLIENT_PASSWORD_KEY = "client.password";
+    private static final String PROXY_USE = "proxy.use";
 
     private SW360MetaDataReceiver connector;
 
@@ -67,7 +68,10 @@ public class SW360Enricher extends AbstractProcessor {
         String sw360Password = getConfigValue(PASSWORD_KEY, configMap);
         String sw360ClientUser = getConfigValue(CLIENT_USER_KEY, configMap);
         String sw360ClientPassword = getConfigValue(CLIENT_PASSWORD_KEY, configMap);
-        connector = new SW360MetaDataReceiver(sw360RestServerUrl, sw360AuthServerUrl, sw360User, sw360Password, sw360ClientUser, sw360ClientPassword);
+        boolean sw360ProxyUse = Boolean.parseBoolean(getConfigValue(PROXY_USE, configMap, "false"));
+        String sw360ProxyHost = context.getToolConfiguration().getProxyHost();
+        int sw360ProxyPort = context.getToolConfiguration().getProxyPort();
+        connector = new SW360MetaDataReceiver(sw360RestServerUrl, sw360AuthServerUrl, sw360User, sw360Password, sw360ClientUser, sw360ClientPassword, sw360ProxyUse, sw360ProxyHost, sw360ProxyPort);
     }
 
     @Override

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
@@ -42,6 +42,10 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 public class SW360ProjectClientTest {
     private static final String REST_URL = "http://localhost:8080/resource/api";
+    private static final boolean PROXY_ENABLE = false;
+    private static final String PROXY_HOST = "localhost";
+    private static final int PROXY_PORT = 3128;
+
     private static final String PROJECTS_ENDPOINT = REST_URL + "/projects";
     private static final String USERS_ENDPOINT = REST_URL + "/users";
     private static final String SEARCH_BY_NAME_ENDPOINT = PROJECTS_ENDPOINT + "?name=";
@@ -74,7 +78,7 @@ public class SW360ProjectClientTest {
     private static final String PROJECT_EMAIL_VALUE_2 = "testemail2@any.com";
 
 
-    private SW360ProjectClient client = new SW360ProjectClient(REST_URL);
+    private SW360ProjectClient client = new SW360ProjectClient(REST_URL, PROXY_ENABLE, PROXY_HOST, PROXY_PORT);
 
     private MockRestServiceServer mockedServer;
 

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/workflow/processors/SW360EnricherTest.java
@@ -28,6 +28,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseEmbedded;
 import org.eclipse.sw360.antenna.sw360.workflow.processors.SW360Enricher;
 import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -38,8 +39,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class SW360EnricherTest extends AntennaTestWithMockedContext {
     private List<Artifact> artifacts;
@@ -63,11 +63,21 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
         configMap.put("user.password", "password");
         configMap.put("client.id", "client_user");
         configMap.put("client.password", "client_password");
+        configMap.put("proxy.use", "false");
         sw360Enricher.configure(configMap);
 
         connector = Mockito.mock(SW360MetaDataReceiver.class);
         ReflectionTestUtils.setField(sw360Enricher, "connector", connector);
     }
+
+    @After
+    public void after(){
+        temporaryFolder.delete();
+
+        verify(toolConfigMock, atLeast(0)).getProxyHost();
+        verify(toolConfigMock, atLeast(0)).getProxyPort();
+    }
+
 
     @Test
     public void downloadUrlIsStoredAsFact() throws AntennaException {


### PR DESCRIPTION
This PR enables to use proxy with SW360Updater and SW360Enricher. Cofigurations are gained from workflow.xml. For example:

```xml
<generators>
  <step>
    <name>SW360 Updater</name>
    <classHint>org.eclipse.sw360.antenna.workflow.generators.SW360Updater</classHint>
    <configuration>
      <entry key="rest.server.url" value="https://sw360.org/resource/api"/>
      <entry key="auth.server.url" value="https://sw360.org/authorization"/>
      <entry key="username" value="---"/>
      <entry key="password" value="---"/>
      <entry key="proxy.enable" value="true"/>
      <entry key="proxy.host" value="${proxyHost}"/>
      <entry key="proxy.port" value="${proxyPort}"/>
    </configuration>
  </step>
</generators>

```

Tests for this PR are not implemented though... 