### PR TITLE
chore(pom): remove eclipse snapshot repository from /pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,12 +300,6 @@
         </snapshots>
       </pluginRepository>
     </pluginRepositories>
-    <repositories>
-      <repository>
-        <id>eclipse-antenna-snapshot</id>
-        <url>https://download.eclipse.org/antenna/snapshots/</url>
-      </repository>
-    </repositories>
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
This is unnecessary and creates confusion and problems.