### PR TITLE
bug(log): move log message about m2 home variable

### DIFF
--- a/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/main/java/org/eclipse/sw360/antenna/bundle/MavenInvokerRequester.java
+++ b/antenna-workflow-steps/processors/enricher/antenna-artifact-resolver/src/main/java/org/eclipse/sw360/antenna/bundle/MavenInvokerRequester.java
@@ -62,8 +62,6 @@ public class MavenInvokerRequester extends IArtifactRequester {
         this.defaultInvoker = defaultInvoker;
         if (System.getenv("M2_HOME") != null) {
             defaultInvoker.setMavenExecutable(new File(System.getenv("M2_HOME")));
-        } else {
-            LOGGER.warn("Variable M2_HOME is undefined. If you have any problems using the MavenInvokerRequester, please set this variable.");
         }
         this.sourceRepositoryUrl = sourceRepositoryUrl;
     }


### PR DESCRIPTION
Warning was deleted, since no problem could be found with and without the variable being set. 
Warning isn't useful. 

Should there be issues discovered later we will address them then directly instead of avoiding them now by throwing a warning.