### PR TITLE
fix(log): add log4j2 config file and link it from log4j config file

### DIFF
--- a/antenna-core/src/main/resources/log4j.properties
+++ b/antenna-core/src/main/resources/log4j.properties
@@ -31,3 +31,6 @@ log4j.logger.org.apache.hadoop=WARN
 # set to INFO to enable infostream log messages
 log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF
 
+log4j.configurationFile=log4j2.properties
+
+

--- a/antenna-core/src/main/resources/log4j2.properties
+++ b/antenna-core/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2016.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+log4j2.simplelogStatusLoggerLevel=INFO


### PR DESCRIPTION
Added second config file to avoid the following log message:
`ERROR StatusLogger No log4j2 configuration file found`

Test: 
- checkout branch `git checkout neubs-bsi/log/698`
- do `mvn clean install`
- check that log message
`ERROR StatusLogger No log4j2 configuration file found`
isn't contained in log

Refers to #164 