### PR TITLE
debt(mvn): removing old variables in AbstractAntennaMojoFrontend

### DIFF
--- a/antenna-testing/antenna-sw360-integration-testing/src/test/resources/pom.xml
+++ b/antenna-testing/antenna-sw360-integration-testing/src/test/resources/pom.xml
@@ -66,7 +66,6 @@
                     <!-- Attach all build artifacts -->
                     <attachAll>true</attachAll>
 
-                    <disableP2Resolving>true</disableP2Resolving>
                     <!-- Here you configure the path on which Antenna will find the configuration files -->
                     <configFiles>
                         <param>${project.basedir}/src/antennaconf.xml</param>

--- a/antenna/frontend-stubs/maven-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/mojo/AbstractAntennaMojoFrontend.java
+++ b/antenna/frontend-stubs/maven-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/mojo/AbstractAntennaMojoFrontend.java
@@ -89,18 +89,6 @@ public abstract class AbstractAntennaMojoFrontend extends AbstractMojo implement
     @Parameter(property = "configFileUri")
     private List<URI> configFileUris;
 
-    @Parameter(property = "clmScanResultPath", defaultValue = "${project.build.outputDirectory}/clm-scan-result.json")
-    private String clmScanResultPath;
-
-    @Parameter(property = "reportDataUrl")
-    private String reportDataUrl;
-
-    @Parameter(property = "scanDir")
-    private String scanDir;
-
-    @Parameter(property = "disableP2Resolving", defaultValue = "true")
-    private boolean disableP2Resolving;
-
     @Parameter(property = "attachAll", defaultValue = "false")
     private boolean attachAll;
 
@@ -129,14 +117,8 @@ public abstract class AbstractAntennaMojoFrontend extends AbstractMojo implement
     @Parameter(property = "disclosureDocumentNotes")
     private String disclosureDocumentNotes;
 
-    @Parameter(property = "disclosureTemplatePath")
-    private String disclosureDocTemplatePath;
-
     @Parameter(property = "filesToAttach")
     private List<String> filesToAttach;
-
-    @Parameter(property = "sourcesRepositoryUrl")
-    private String sourcesRepositoryUrl;
 
     @Parameter(property = "workflowDefinitionFile")
     private String workflowDefinitionFile;
@@ -199,7 +181,6 @@ public abstract class AbstractAntennaMojoFrontend extends AbstractMojo implement
                     });
         }
     }
-
     /**
      * Start point of the Antenna maven-plugin.
      */
@@ -285,7 +266,7 @@ public abstract class AbstractAntennaMojoFrontend extends AbstractMojo implement
                 .setFilesToAttach(filesToAttach)
                 .setConfigFiles(configFiles).setConfigFileUris(configFileUris)
                 .setProductName(productName).setProductFullName(productFullname)
-                .setVersion(version).setScanDir(scanDir)
+                .setVersion(version)
                 .setSkipAntennaExecution(skip)
                 .setMavenInstalled(true)  // when using the maven plugin, maven is surely available
                 .setCopyrightHoldersName(copyrightHoldersName).setCopyrightNotice(copyrightNotice)

--- a/example-projects/example-project/pom.xml
+++ b/example-projects/example-project/pom.xml
@@ -67,7 +67,6 @@
                     <!-- Attach all build artifacts -->
                     <attachAll>true</attachAll>
 
-                    <disableP2Resolving>true</disableP2Resolving>
                     <!-- Here you configure the path on which Antenna will find the configuration files -->
                     <configFiles>
                         <param>${project.basedir}/src/antennaconf.xml</param>

--- a/example-projects/mvn-test-project/pom.xml
+++ b/example-projects/mvn-test-project/pom.xml
@@ -70,7 +70,6 @@
                     <!-- Attach all build artifacts -->
                     <attachAll>true</attachAll>
 
-                    <disableP2Resolving>true</disableP2Resolving>
                     <!-- Here you configure the path on which Antenna will find the configuration files -->
                     <configFiles>
                         <param>${project.basedir}/src/antennaconf.xml</param>


### PR DESCRIPTION
removes : 
- clmScanResultPaths
- reportDataUrl
- disableP2Resolving (also removed from test projects and antenna testing poms)
- disclosureDocTemplatePath
- sourceRepositoryUrl (moved to Maven Artifact Resolver) 

Example Project is still running, Build is green.

Issue: #173 