### PR TITLE
fix(doc): fix md file for correct rendering

### DIFF
--- a/antenna-documentation/src/site/markdown/outputHandlers/add-to-archive-handler.md
+++ b/antenna-documentation/src/site/markdown/outputHandlers/add-to-archive-handler.md
@@ -5,6 +5,7 @@ The add to archive handler can add generated output (for instance disclosure doc
 ### How to use
 
 To add the output handler, add the following to the workflow.xml:
+
 ```xml
     <outputHandlers>
         <step>


### PR DESCRIPTION
Just adds a newline between text and code block in a MD file for correct rendering. 