### PR TITLE
fix(model): final license calculation should also consider observed licenses

### DIFF
--- a/antenna/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactLicenseUtils.java
+++ b/antenna/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactLicenseUtils.java
@@ -14,9 +14,13 @@ package org.eclipse.sw360.antenna.model.util;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ConfiguredLicenseInformation;
 import org.eclipse.sw360.antenna.model.artifact.facts.DeclaredLicenseInformation;
+import org.eclipse.sw360.antenna.model.artifact.facts.ObservedLicenseInformation;
 import org.eclipse.sw360.antenna.model.artifact.facts.OverriddenLicenseInformation;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseOperator;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseStatement;
+
+import java.util.Optional;
 
 public class ArtifactLicenseUtils {
 
@@ -24,10 +28,39 @@ public class ArtifactLicenseUtils {
         // only static methods
     }
 
+    /*
+     * The final license is calculated as follows:
+     *   - if the configuration overwrites the license (represented by a ConfiguredLicenseInformation fact), that one is used
+     *   - if the tooling has provided an overridden (represented by an OverriddenLicenseInformation fact), that one is used
+     *   - if the tooling has provided
+     *     - a license declared by the package and/or
+     *     - a observed licenses (e.g. by scanners)
+     *     the resulting effective license is calculated as {declared licenses} AND {observed licenses}
+     *   - otherwise an empty license is returned
+     */
     public static LicenseInformation getFinalLicenses(Artifact artifact) {
-        return artifact.askForGet(ConfiguredLicenseInformation.class)
-                .orElse(artifact.askForGet(OverriddenLicenseInformation.class)
-                        .orElse(artifact.askForGet(DeclaredLicenseInformation.class)
-                                .orElse(new LicenseStatement())));
+        final Optional<LicenseInformation> configured = artifact.askForGet(ConfiguredLicenseInformation.class);
+
+        if(configured.isPresent()) {
+            return configured.get();
+        }
+
+        final Optional<LicenseInformation> overridden = artifact.askForGet(OverriddenLicenseInformation.class);
+
+        if(overridden.isPresent()) {
+            return overridden.get();
+        }
+
+        final Optional<LicenseInformation> declared = artifact.askForGet(DeclaredLicenseInformation.class);
+        final Optional<LicenseInformation> observed = artifact.askForGet(ObservedLicenseInformation.class);
+        if(declared.isPresent() && observed.isPresent()) {
+            final LicenseStatement effective = new LicenseStatement();
+            effective.setLeftStatement(declared.get());
+            effective.setRightStatement(observed.get());
+            effective.setOp(LicenseOperator.AND);
+            return effective;
+        }
+
+        return declared.orElse(observed.orElse(new LicenseStatement()));
     }
 }

--- a/antenna/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
+++ b/antenna/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
@@ -160,7 +160,7 @@ public class ArtifactTest {
 
         assertThat(observedLicenses.evaluate()).isEqualTo("( license2 AND license1 )");
         assertThat(observedLicenses.evaluateLong()).isEqualTo("( licenseNumber2 AND licenseNumber1 )");
-        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifact)).isEqualTo(declaredLicenses);
+        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifact).evaluate()).isEqualTo("( license1 AND ( license2 AND license1 ) )");
         assertThat(observedLicenses.getLicenses().equals(licenses)).isTrue();
 
         License configuredLicense = new License();


### PR DESCRIPTION
### The corrected logic is now:


The final license is calculated as follows:
- if the configuration overwrites the license (represented by a ConfiguredLicenseInformation fact), that one is used
- if the tooling has provided an overridden (represented by an OverriddenLicenseInformation fact), that one is used
- if the tooling has provided
   - a license declared by the package and/or
   - a observed licenses (e.g. by scanners)

  the resulting effective license is calculated as {declared licenses} AND {observed licenses}
- otherwise an empty license is returned