### PR TITLE
feat(fact): introduce possibility to have multiple filenames

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/CSVGenerator.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/CSVGenerator.java
@@ -69,7 +69,9 @@ public class CSVGenerator extends AbstractGenerator {
         StringBuilder information = new StringBuilder();
         information.append("artifactName;artifactId;groupId;mavenVersion;bundleVersion;license \n");
         for (Artifact artifact : artifacts) {
-            appendInformation(information, artifact.askFor(ArtifactFilename.class).map(ArtifactFilename::getFilename).orElse(""));
+            appendInformation(information, artifact.askFor(ArtifactFilename.class)
+                    .flatMap(ArtifactFilename::getBestFilenameGuess)
+                    .orElse(""));
             final Optional<MavenCoordinates> mavenCoordinates = artifact.askFor(MavenCoordinates.class); // TODO
             appendInformation(information, mavenCoordinates.map(MavenCoordinates::getArtifactId).orElse(""));
             appendInformation(information, mavenCoordinates.map(MavenCoordinates::getGroupId).orElse(""));

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriter.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriter.java
@@ -108,7 +108,7 @@ public class SourceZipWriter extends AbstractGenerator {
                 return;
             }
             String entryName = artifact.askFor(ArtifactFilename.class)
-                    .map(ArtifactFilename::getFilename)
+                    .flatMap(ArtifactFilename::getBestFilenameGuess)
                     .orElse(sourceFile.get().toFile().getName())
                     .replaceAll(".jar", "");
             try {

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/ConfigurationAnalyzerTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/ConfigurationAnalyzerTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.sw360.antenna.workflow.analyzers;
 
-import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactMatchingMetadata;
@@ -69,7 +68,7 @@ public class ConfigurationAnalyzerTest extends AntennaTestWithMockedContext {
     }
 
     @Test
-    public void testAddArtifact() throws AntennaException {
+    public void testAddArtifact() {
         ConfigurationAnalyzer handler = new ConfigurationAnalyzer();
         handler.setAntennaContext(antennaContextMock);
 
@@ -79,7 +78,7 @@ public class ConfigurationAnalyzerTest extends AntennaTestWithMockedContext {
         Artifact processedArtifact = artifacts.stream()
                 .filter(a -> {
                     final Optional<ArtifactFilename> artifactFilename = a.askFor(ArtifactFilename.class);
-                    return artifactFilename.isPresent() && FILENAME.equals(artifactFilename.get().getFilename());
+                    return artifactFilename.isPresent() && FILENAME.equals(artifactFilename.get().getBestFilenameGuess().orElse(null));
                 })
                 .findAny()
                 .orElseThrow(() -> new RuntimeException("should not happen"));

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/ConfigurationResolverTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/ConfigurationResolverTest.java
@@ -89,7 +89,7 @@ public class ConfigurationResolverTest extends AntennaTestWithMockedContext {
         resolver.process(artifacts);
 
         assertThat(artifact.askFor(ArtifactFilename.class)
-                .map(ArtifactFilename::getFilename)
+                .flatMap(ArtifactFilename::getBestFilenameGuess)
                 .orElse(""))
                 .isEqualTo("director-ant.jar");
         assertThat(artifact1.getFlag(Artifact.IS_IGNORE_FOR_DOWNLOAD_KEY)).isTrue();

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactFilename.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactFilename.java
@@ -14,62 +14,154 @@ package org.eclipse.sw360.antenna.model.artifact.facts;
 import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactPathnames;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.antenna.model.artifact.ArtifactSelectorHelper.compareStringsAsWildcard;
 
-public class ArtifactFilename implements ArtifactFact, ArtifactIdentifier {
-    private final String filename;
-    private final String hash;
-    private final String hashAlgorithm;
+public class ArtifactFilename implements ArtifactFact<ArtifactFilename>, ArtifactIdentifier<ArtifactFilename> {
+    private final Set<ArtifactFilenameEntry> artifactFilenameEntries = new HashSet<>();
+
+    public static class ArtifactFilenameEntry {
+        private final String filename;
+        private final String hash;
+        private final String hashAlgorithm;
+
+        public ArtifactFilenameEntry(String filename) {
+            this.filename = sanitizeString(filename);
+            this.hash = null;
+            this.hashAlgorithm = "UNKNOWN";
+        }
+
+        public ArtifactFilenameEntry(String filename, String hash) {
+            this.filename = sanitizeString(filename);
+            this.hash = sanitizeString(hash);
+            this.hashAlgorithm = "UNKNOWN";
+        }
+
+        public ArtifactFilenameEntry(String filename, String hash, String hashAlgorithm) {
+            this.filename = sanitizeString(filename);
+            this.hash = sanitizeString(hash);
+            this.hashAlgorithm = hashAlgorithm;
+        }
+
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public String getHash() {
+            return hash;
+        }
+
+        public String getHashAlgorithm() {
+            return hashAlgorithm;
+        }
+
+        private String sanitizeString(String input) {
+            return Optional.ofNullable(input)
+                    .map(String::trim)
+                    .filter(string -> !string.isEmpty())
+                    .orElse(null);
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ArtifactFilenameEntry that = (ArtifactFilenameEntry) o;
+            return Objects.equals(filename, that.filename) &&
+                    Objects.equals(hash, that.hash) &&
+                    Objects.equals(hashAlgorithm, that.hashAlgorithm);
+        }
+
+        public boolean matches(ArtifactFilenameEntry artifactFilenameEntry) {
+            return compareStringsAsWildcard(filename, artifactFilenameEntry.filename) &&
+                    compareStringsAsWildcard(hash, artifactFilenameEntry.hash) &&
+                    (hash == null || Objects.equals(hashAlgorithm, artifactFilenameEntry.hashAlgorithm));
+
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(filename, hash, hashAlgorithm);
+        }
+
+        public boolean isEmpty() {
+            return filename == null && hash == null;
+        }
+
+        @Override
+        public String toString() {
+            return filename + " (hash='" + hash + '\'' + ", hashAlgorithm='" + hashAlgorithm + '\'' + ')';
+        }
+    }
 
     public ArtifactFilename(String filename) {
-        this.filename = Optional.ofNullable(filename).map(String::trim).orElse(null);
-        this.hash = null;
-        this.hashAlgorithm = "UNKNOWN";
+        artifactFilenameEntries.add(new ArtifactFilenameEntry(filename));
     }
 
     public ArtifactFilename(String filename, String hash) {
-        this.filename = Optional.ofNullable(filename).map(String::trim).orElse(null);
-        this.hash = Optional.ofNullable(hash).map(String::trim).orElse(null);
-        this.hashAlgorithm = "UNKNOWN";
+        artifactFilenameEntries.add(new ArtifactFilenameEntry(filename, hash));
     }
 
     public ArtifactFilename(String filename, String hash, String hashAlgorithm) {
-        this.filename = Optional.ofNullable(filename).map(String::trim).orElse(null);
-        this.hash = Optional.ofNullable(hash).map(String::trim).orElse(null);
-        this.hashAlgorithm = hashAlgorithm;
+        artifactFilenameEntries.add(new ArtifactFilenameEntry(filename, hash, hashAlgorithm));
+    }
+
+    public Set<ArtifactFilenameEntry> getArtifactFilenameEntries() {
+        return Collections.unmodifiableSet(artifactFilenameEntries);
+    }
+
+    public List<String> getFilenames() {
+        return artifactFilenameEntries.stream()
+                .map(ArtifactFilenameEntry::getFilename)
+                .collect(Collectors.toList());
+    }
+
+    public Optional<String> getBestFilenameGuess() {
+        return artifactFilenameEntries.stream()
+                .map(ArtifactFilenameEntry::getFilename)
+                .filter(Objects::nonNull)
+                .max(Comparator.comparing(String::length));
     }
 
     @Override
-    public boolean matches(ArtifactIdentifier artifactIdentifier) {
-        if(artifactIdentifier instanceof ArtifactFilename) {
-            ArtifactFilename artifactFilename = (ArtifactFilename) artifactIdentifier;
-            return compareStringsAsWildcard(filename, artifactFilename.filename) &&
-                    compareStringsAsWildcard(hash, artifactFilename.hash) &&
-                    (hash == null || Objects.equals(hashAlgorithm, artifactFilename.hashAlgorithm));
+    public ArtifactFilename mergeWith(ArtifactFilename resultWithPrecedence) {
+        if (resultWithPrecedence != null) {
+            artifactFilenameEntries.addAll(resultWithPrecedence.getArtifactFilenameEntries());
         }
-        if(artifactIdentifier instanceof ArtifactPathnames && filename != null) {
+        return this;
+    }
+
+
+    @Override
+    public boolean matches(ArtifactIdentifier artifactIdentifier) {
+        if (artifactIdentifier instanceof ArtifactFilename) {
+            ArtifactFilename artifactFilename = (ArtifactFilename) artifactIdentifier;
+
+            return artifactFilenameEntries.stream()
+                    .anyMatch(artifactFilenameEntry ->
+                            artifactFilename.getArtifactFilenameEntries().stream()
+                                    .anyMatch(artifactFilenameEntry1 ->
+                                            artifactFilenameEntry.matches(artifactFilenameEntry1)
+                                                    || artifactFilenameEntry1.matches(artifactFilenameEntry)
+                                    )
+                    );
+        }
+        if (artifactIdentifier instanceof ArtifactPathnames) {
             List<String> artifactPathnames = ((ArtifactPathnames) artifactIdentifier).get();
             return artifactPathnames.stream()
                     .filter(Objects::nonNull)
-                    .anyMatch(pn -> pn.equals(filename) || pn.endsWith("/" + filename) || pn.endsWith("\\" + filename));
+                    .anyMatch(pn ->
+                            artifactFilenameEntries.stream()
+                                    .map(ArtifactFilenameEntry::getFilename)
+                                    .filter(Objects::nonNull)
+                                    .anyMatch(filename -> pn.equals(filename) || pn.endsWith("/" + filename) || pn.endsWith("\\" + filename))
+                    );
         }
         return false;
-    }
-
-    public String getFilename() {
-        return filename;
-    }
-
-    public String getHash() {
-        return hash;
-    }
-
-    public String getHashAlgorithm() {
-        return hashAlgorithm;
     }
 
     @Override
@@ -77,9 +169,24 @@ public class ArtifactFilename implements ArtifactFact, ArtifactIdentifier {
         return "Filename";
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArtifactFilename that = (ArtifactFilename) o;
+        return Objects.equals(artifactFilenameEntries, that.artifactFilenameEntries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(artifactFilenameEntries);
+    }
+
     @Override
     public boolean isEmpty() {
-        return filename == null && hash == null;
+        return artifactFilenameEntries.stream()
+                .allMatch(ArtifactFilenameEntry::isEmpty);
     }
 
     @Override
@@ -87,23 +194,11 @@ public class ArtifactFilename implements ArtifactFact, ArtifactIdentifier {
         return "Set " + getFactContentName() + " to " + toString();
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArtifactFilename that = (ArtifactFilename) o;
-        return Objects.equals(filename, that.filename) &&
-                Objects.equals(hash, that.hash) &&
-                Objects.equals(hashAlgorithm, that.hashAlgorithm);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(filename, hash, hashAlgorithm);
-    }
 
     @Override
     public String toString() {
-        return  filename + " (hash='" + hash + '\'' + ", hashAlgorithm='" + hashAlgorithm + '\'' + ')';
+        return artifactFilenameEntries.stream()
+                .map(Objects::toString)
+                .collect(Collectors.joining(",", "[", "]"));
     }
 }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
@@ -60,7 +60,7 @@ public class ArtifactUtils {
         return getMostDominantFact(ArtifactCoordinates.class,
                 preferedCoordinatesTypes,
                 a -> a.askFor(ArtifactFilename.class)
-                        .map(ArtifactFilename::getFilename)
+                        .flatMap(ArtifactFilename::getBestFilenameGuess)
                         .map(fn -> new GenericArtifactCoordinates(fn, "-")),
                 artifact);
     }

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
@@ -26,8 +26,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,6 +88,16 @@ public class ArtifactTest {
         assertThat(artifact.askFor(MavenCoordinates.class).get().getVersion()).isEqualTo("version");
         assertThat(artifact.askFor(ArtifactFile.class).isPresent()).isTrue();
         assertThat(artifact.getFlag(Artifact.IS_IGNORE_FOR_DOWNLOAD_KEY)).isTrue();
+    }
+
+    @Test
+    public void artifactFilenameTest() {
+        artifact.addFact(new ArtifactFilename("test1", "12345Test1"));
+        artifact.addFact(new ArtifactFilename("test2", "12345Test2"));
+        artifact.addFact(new ArtifactFilename("test1", "12345Test1"));
+
+        assertThat(artifact.askFor(ArtifactFilename.class).get().getArtifactFilenameEntries()).hasSize(2);
+        assertThat(artifact.askFor(ArtifactFilename.class).get().getFilenames()).isEqualTo(Arrays.asList("test1", "test2"));
     }
 
     @Test

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
@@ -110,8 +110,8 @@ public class ConfigurationTest {
                 .getName()
         ).isEqualTo("testLicense");
 
-        assertThat(generatedArtifact.askFor(ArtifactFilename.class).get().getFilename())
-                .isEqualTo("overrideName.jar");
+        assertThat(generatedArtifact.askFor(ArtifactFilename.class).get().getFilenames())
+                .contains("overrideName.jar");
         assertThat(generatedArtifact.askFor(MavenCoordinates.class).get().getArtifactId())
                 .isEqualTo("testID");
         assertThat(generatedArtifact.askFor(MavenCoordinates.class).get().getGroupId())
@@ -130,8 +130,8 @@ public class ConfigurationTest {
 
         assertThat(artifact.askForGet(DeclaredLicenseInformation.class).get().getLicenses().get(0).getName())
                 .isEqualTo("Apache");
-        assertThat(artifact.askFor(ArtifactFilename.class).get().getFilename())
-                .isEqualTo("addArtifact.jar");
+        assertThat(artifact.askFor(ArtifactFilename.class).get().getFilenames())
+                .contains("addArtifact.jar");
         assertThat(artifact.askFor(MavenCoordinates.class).get().getArtifactId())
                 .isEqualTo("addArtifactId");
         assertThat(artifact.askFor(MavenCoordinates.class).get().getGroupId())

--- a/modules/p2/antenna-p2-enricher/src/main/java/org/eclipse/sw360/antenna/p2/workflow/processors/enricher/ChildJarResolver.java
+++ b/modules/p2/antenna-p2-enricher/src/main/java/org/eclipse/sw360/antenna/p2/workflow/processors/enricher/ChildJarResolver.java
@@ -100,7 +100,7 @@ public class ChildJarResolver extends AbstractProcessor {
 
     private Optional<String> getArtifactFileName(Artifact artifact) {
         final Optional<String> artifactFilename = artifact.askFor(ArtifactFilename.class)
-                .map(ArtifactFilename::getFilename);
+                .flatMap(ArtifactFilename::getBestFilenameGuess);
         if(! artifactFilename.isPresent()) {
             reporter.add(MessageType.PROCESSING_FAILURE, "No filename available as ArtifactIdentifier of '" + artifact + "' is null.");
         }


### PR DESCRIPTION
Corresponding Issue: #19 

### Background:
##### Current Solution: 
- `ArtifactHashes` with Set of Strings with hashes is desired, but only one can be taken from `ArtifactFilename`

##### Improvement:
- Use the hash from `ArtifactFileName`
- Make it possible to have several `ArtifactFileNames` within one artifact
- redo mapping from response to artifact 
- redo mapping from artifact to sw360release
- update `SW360EnricherTest` and `SW360UpdaterTest`