### PR TITLE
bindings: Do not use the deprecated "lang3" package for StringEscapeUtils

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -98,6 +98,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
         <dependency>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -38,6 +38,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
         </dependency>

--- a/core/model/src/main/resources/bindings.xjb
+++ b/core/model/src/main/resources/bindings.xjb
@@ -153,11 +153,11 @@
                  }
 
                  public String getLinkStr(){
-                    return String.format("<listitem><xref linkend=\"sect_%s\" endterm=\"sect_shortTitle_%s\"/></listitem>", org.apache.commons.lang3.StringEscapeUtils.escapeXml11(getName()), org.apache.commons.lang3.StringEscapeUtils.escapeXml11(getName()));
+                    return String.format("<listitem><xref linkend=\"sect_%s\" endterm=\"sect_shortTitle_%s\"/></listitem>", org.apache.commons.text.StringEscapeUtils.escapeXml11(getName()), org.apache.commons.text.StringEscapeUtils.escapeXml11(getName()));
                  }
 
                  public String getHTMLLinkStr(){
-                    return String.format("<li><a href=\"#%s\">%s</a></li>", org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(getName()), getLongName() != null ? org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(getLongName()) : org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(getName()));
+                    return String.format("<li><a href=\"#%s\">%s</a></li>", org.apache.commons.text.StringEscapeUtils.escapeHtml4(getName()), getLongName() != null ? org.apache.commons.text.StringEscapeUtils.escapeHtml4(getLongName()) : org.apache.commons.text.StringEscapeUtils.escapeHtml4(getName()));
                  }
                  ]]>
             </ci:code>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>1.5</version>
             </dependency>


### PR DESCRIPTION
StringEscapeUtils was moved to the "text" package. Use a version of
"text" that was released at about the same time as the used "lang3"
version.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>