### PR TITLE
feat(envVar): included environment variables in template renderer and gradle reads properties file

### DIFF
--- a/assembly/cli/src/site/markdown/index.md.vm
+++ b/assembly/cli/src/site/markdown/index.md.vm
@@ -92,3 +92,18 @@ java -cp %CLASSPATH% $${antennaCliJavaFilename} %POM_FILE%
 in the script above.
 
 The same is true for bat scripts on Windows.
+
+#[[##]]# Adding entry values over system environment variables
+
+Sometimes a workflow step contains entries with variables that are credentials or should remain secret due to other reasons.
+
+You can use system environment variables that you have either set in the environment or when executing the analyze command:
+
+```
+SECRET=password12345 java -jar path\to\ ${docName}.jar path\to\pom.xml
+```
+
+Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
+${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
+
+Within both, your `pom.xml` or the `workflow.xml`, you can then reference the variables.

--- a/assembly/gradle-plugin/src/site/markdown/index.md.vm
+++ b/assembly/gradle-plugin/src/site/markdown/index.md.vm
@@ -70,3 +70,43 @@ buildscript{
     }
 }
 ```
+
+#[[##]]# Adding entry values over a properties file or environment variables
+
+Sometimes a workflow step contains entries with variables that are credentials or should remain secret due to other reasons.
+
+#[[####]]# Properties file
+
+For that ${docNameCap} provides the possibility to give a properties file that can be stored outside of your project.
+To use this functionality one can give the properties file in the `${docNameCap}Configuration` of the build file, like this:
+
+```groovy
+${docNameCap}Configuration{
+    pomPath 'pom.xml'
+    propertiesFilePath '/path/to/antenna.properties'
+}
+```
+
+The properties file can be the normal gradle.properties file.
+It should be written in the standard properties format:
+
+```
+ExampleUsername=maxMustermann
+ExamplePassword=12345password
+```
+
+Within your `pom.xml` or the `workflow.xml` you can then reference variables by the usual xml standard `${ExampleUsername}`.
+This will get rendered by the `TemplateRenderer` according to the value you assigned to the key in the secrets file.
+
+Note: You should still refrain from using key names containing dots, as the `TemplateRenderer` will not render them correctly.
+
+#[[####]]# System environment variables
+
+Additionally you can use system environment variables that you have either set in the environment or when executing the analyze command:
+
+```
+SECRET=password12345 gradle analyze
+```
+
+Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
+${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.

--- a/assembly/gradle-plugin/src/test/java/org/eclipse/sw360/antenna/frontend/gradle/AntennaGradlePluginTest.java
+++ b/assembly/gradle-plugin/src/test/java/org/eclipse/sw360/antenna/frontend/gradle/AntennaGradlePluginTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.frontend.gradle;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.frontend.stub.gradle.AntennaImpl;
 import org.eclipse.sw360.antenna.frontend.testing.testProjects.AbstractTestProject;
 import org.eclipse.sw360.antenna.frontend.testing.testProjects.ExampleTestProject;
@@ -23,7 +24,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.sw360.antenna.testing.util.AntennaTestingUtils.checkInternetConnectionAndAssume;
@@ -42,7 +45,7 @@ public class AntennaGradlePluginTest {
 
         System.setProperty("user.dir", projectRoot.toAbsolutePath().toString());
 
-        String buildGradle = "plugins {\nid 'org.eclipse.sw360.antenna'\n}\n"+
+        String buildGradle = "plugins {\nid 'org.eclipse.sw360.antenna'\n}\n" +
                 "AntennaConfiguration{\npomPath '" + exampleTestProject.getProjectPom() + "'\n}";
         FileUtils.writeStringToFile(projectRoot.resolve("build.gradle").toFile(), buildGradle);
     }
@@ -79,5 +82,21 @@ public class AntennaGradlePluginTest {
         assertThat(projectRoot.resolve("build/antenna").toFile()).exists();
         assertThat(projectRoot.resolve("build/antenna/3rdparty-licenses.html").toFile()).exists();
         assertThat(projectRoot.resolve("build/antenna/sources.zip").toFile()).exists();
+    }
+
+    @Test
+    public void testWithoutGradleSetSystemEnvironmentVariables() throws AntennaException {
+        URL pom = AntennaGradlePluginTest.class.getClassLoader().getResource("pom.xml");
+        URL propertiesFile = AntennaGradlePluginTest.class.getClassLoader().getResource("antennaTestVariable.properties");
+
+        AntennaImpl runner = new AntennaImpl("antenna-maven-plugin",
+                Paths.get(pom.getPath()),
+                Paths.get(propertiesFile.getPath()));
+
+        runner.execute();
+
+        Path root = Paths.get(AntennaGradlePluginTest.class.getClassLoader().getResource("build").getPath());
+
+        assertThat(root.resolve("antenna")).exists();
     }
 }

--- a/assembly/gradle-plugin/src/test/resources/antennaTestVariable.properties
+++ b/assembly/gradle-plugin/src/test/resources/antennaTestVariable.properties
@@ -1,0 +1,10 @@
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+ANTENNATESTVARIABLE=org.eclipse.sw360.antenna.workflow.generators.HTMLReportGenerator

--- a/assembly/gradle-plugin/src/test/resources/pom.xml
+++ b/assembly/gradle-plugin/src/test/resources/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.sw360.antenna</groupId>
+                <artifactId>antenna-maven-plugin</artifactId>
+                <version>${org.eclipse.sw360.antenna.version}</version>
+                <configuration>
+                    <!-- The short name of the application -->
+                    <productName>Antenna mvn EP</productName>
+
+                    <!-- The full name of the application -->
+                    <productFullname>Antenna Maven Test Project</productFullname>
+
+                    <version>${version_to_scan}</version>
+
+                    <!-- Attach all build artifacts -->
+                    <attachAll>true</attachAll>
+
+                    <workflow>
+                        <processors>
+                            <step>
+                                <name>Source Validator</name>
+                                <classHint>org.eclipse.sw360.antenna.validators.workflow.processors.SourceValidator</classHint>
+                                <configuration>
+                                    <entry>
+                                        <entryKey>missingSourcesSeverity</entryKey>
+                                        <entryValue>FAIL</entryValue>
+                                    </entry>
+                                    <entry>
+                                        <entryKey>incompleteSourcesSeverity</entryKey>
+                                        <entryValue>WARN</entryValue>
+                                    </entry>
+                                </configuration>
+                                <deactivated>true</deactivated>
+                            </step>
+                        </processors>
+                        <generators>
+                            <step>
+                                <name>HTML Report Writer</name>
+                                <classHint>${ANTENNATESTVARIABLE}</classHint>
+                            </step>
+                            <step>
+                                <name>CSV Report Writer</name>
+                                <classHint>org.eclipse.sw360.antenna.workflow.generators.CSVGenerator</classHint>
+                            </step>
+                        </generators>
+                    </workflow>
+
+                    <copyrightHoldersName>Antenna Company</copyrightHoldersName>
+                    <copyrightNotice>All rights reserved</copyrightNotice>
+
+                    <skip>false</skip>
+
+                    <!--
+                    <proxyHost>${proxyHost}</proxyHost>
+                    <proxyPort>${proxyPort}</proxyPort>
+                    -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>analyze</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- The antenna mojo requires the kbase to fetch the license information -->
+                    <dependency>
+                        <groupId>org.eclipse.sw360.antenna</groupId>
+                        <artifactId>antenna-spdx-license-knowledge-base</artifactId>
+                        <version>${org.eclipse.sw360.antenna.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/assembly/maven-plugin/src/site/markdown/index.md.vm
+++ b/assembly/maven-plugin/src/site/markdown/index.md.vm
@@ -64,3 +64,37 @@ If you have a custom plugin `my-custom-plugin` with groupId `org.mycompany.plugi
     <version>VERSION</version>
 </dependency>
 ```
+
+#[[##]]# Adding entry values over maven properties or environment variables
+
+Sometimes a workflow step contains entries with variables that are credentials or should remain secret due to other reasons.
+
+#[[####]]# Maven Properties
+
+Maven has a standard way of reading in properties, which can also be used for a ${docNameCap} run.
+One way is setting them in a separate `settings.xml` or via the command line:
+
+```sh
+mvn clean install -Dpassword=password12345
+```
+
+Withing your `pom.xml` variables will get rendered correctly.
+Should you have a separate `workflow.xml` file that will not be the case.
+The property variables are limited to the `pom.xml`.
+Should you choose this way, you would have to include a workflow section in your pom ${docName} configuration,
+ as described in the [Workflow configuration](../workflow-configuration.html).
+Alternatively, you could use system environment variables.
+
+
+#[[####]]# System environment variables
+
+Additionally you can use system environment variables that you have either set in the environment or when executing the analyze command:
+
+```
+SECRET=password12345 mvn clean install
+```
+
+Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
+${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
+
+Within both, your `pom.xml` or the `workflow.xml`, you can then reference the variables.

--- a/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AbstractAntennaCLIFrontend.java
+++ b/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AbstractAntennaCLIFrontend.java
@@ -37,7 +37,10 @@ public abstract class AbstractAntennaCLIFrontend implements AntennaFrontend {
     private DefaultProject project;
     private final String pluginDescendantArtifactIdName;
 
-    protected abstract String getPluginDescendantArtifactIdName();
+    public AbstractAntennaCLIFrontend(File pomFilePath, File propertiesFile) {
+        this(pomFilePath);
+        project.setPropertiesFile(propertiesFile);
+    }
 
     public AbstractAntennaCLIFrontend(File pomFile) {
         this.pluginDescendantArtifactIdName = getPluginDescendantArtifactIdName();
@@ -45,6 +48,8 @@ public abstract class AbstractAntennaCLIFrontend implements AntennaFrontend {
         Path sourceDir = getSourceDirFromPomFile(pomFile);
         project = new DefaultProject(pomFile, buildDir.toString(), sourceDir.toString());
     }
+
+    protected abstract String getPluginDescendantArtifactIdName();
 
     private Path getSourceDirFromPomFile(File pomFile) {
         Path parent = pomFile.toPath().getParent();

--- a/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/DefaultProject.java
+++ b/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/DefaultProject.java
@@ -25,6 +25,8 @@ public class DefaultProject implements IProject {
     private String projectVersion = "1.0";
     private String artifactId = projectId + ":" + projectVersion;
 
+    private File propertiesFile;
+
     public DefaultProject(File configFile, String buildDir, String sourceDir) {
         this.configFile = configFile;
         this.buildDir = buildDir;
@@ -75,6 +77,14 @@ public class DefaultProject implements IProject {
 
     public String getBaseUri() {
         return baseUri;
+    }
+
+    public File getPropertiesFile() {
+        return propertiesFile;
+    }
+
+    public void setPropertiesFile(File propertiesFile) {
+        this.propertiesFile = propertiesFile;
     }
 
     public class Build {

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AnalyzeTask.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AnalyzeTask.java
@@ -30,7 +30,15 @@ public abstract class AnalyzeTask extends DefaultTask {
 
         Path pomPath = Paths.get(System.getProperty("user.dir")).resolve(extension.getPomPath()).toAbsolutePath();
 
-        AntennaImpl osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), pomPath);
+        AntennaImpl osmRunner;
+
+        if(extension.getPropertiesFilePath() != null) {
+            Path propertiesFilePath = Paths.get(System.getProperty("user.dir")).resolve(extension.getPropertiesFilePath()).toAbsolutePath();
+            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), pomPath, propertiesFilePath);
+        } else {
+            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), pomPath);
+        }
+
         osmRunner.execute();
     }
 

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaExtension.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaExtension.java
@@ -13,11 +13,21 @@ package org.eclipse.sw360.antenna.frontend.stub.gradle;
 public class AntennaExtension {
     private String pomPath;
 
+    private String propertiesFilePath;
+
     public String getPomPath() {
         return pomPath;
     }
 
     public void setPomPath(String pomPath) {
         this.pomPath = pomPath;
+    }
+
+    public String getPropertiesFilePath() {
+        return propertiesFilePath;
+    }
+
+    public void setPropertiesFilePath(String propertiesFilePath) {
+        this.propertiesFilePath = propertiesFilePath;
     }
 }

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaImpl.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaImpl.java
@@ -20,9 +20,29 @@ public class AntennaImpl {
     private final AbstractAntennaCLIFrontend antennaCLIFrontend;
     private final File pomFilePath;
 
+    private File propertiesFilePath;
+
     public AntennaImpl(String pluginDescendantArtifactIdName, Path pomFilePath) {
+        this(pluginDescendantArtifactIdName, pomFilePath, null);
+    }
+
+    public AntennaImpl(String pluginDescendantArtifactIdName, Path pomFilePath, Path propertiesFilePath) {
         this.pomFilePath = pomFilePath.toFile();
-        antennaCLIFrontend = new AbstractAntennaCLIFrontend(this.pomFilePath) {
+
+        if (!this.pomFilePath.exists()) {
+            throw new IllegalArgumentException("Cannot find " + pomFilePath.toString());
+        }
+
+        if (propertiesFilePath != null) {
+            this.propertiesFilePath = propertiesFilePath.toFile();
+            if(!this.propertiesFilePath.exists()) {
+                throw new IllegalArgumentException("Cannot find " + propertiesFilePath.toString());
+            }
+        } else {
+            this.propertiesFilePath = null;
+        }
+
+        antennaCLIFrontend = new AbstractAntennaCLIFrontend(this.pomFilePath, this.propertiesFilePath) {
             @Override
             protected String getPluginDescendantArtifactIdName() {
                 return pluginDescendantArtifactIdName;
@@ -33,15 +53,9 @@ public class AntennaImpl {
                 return folder.resolve("build");
             }
         };
-
     }
 
     public void execute() throws AntennaException {
-
-        if (!pomFilePath.exists()) {
-            throw new IllegalArgumentException("Cannot find " + pomFilePath.toString());
-        }
-
         antennaCLIFrontend.execute();
     }
 }

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- ################################ compliance dependency ########################### -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/TemplateRenderer.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/TemplateRenderer.java
@@ -39,6 +39,12 @@ public class TemplateRenderer {
 
     public TemplateRenderer() {
         this.renderContext = new VelocityContext();
+
+        System.getenv()
+                .entrySet()
+                .stream()
+                .filter(e -> e.getKey().equals(e.getKey().toUpperCase()))
+                .forEach(e -> this.renderContext.put(e.getKey(),e.getValue()));
     }
 
     public TemplateRenderer(Map<String, Object> initMap) {
@@ -61,7 +67,7 @@ public class TemplateRenderer {
         return ve;
     }
 
-    public String renderTemplateFile(File templateFile) {
+    private VelocityEngine prepareVelocityEngine(File templateFile) {
         Map<String,String> veProperties = new HashMap<>();
         veProperties.put(RuntimeConstants.RESOURCE_LOADER, "file");
         veProperties.put(RuntimeConstants.FILE_RESOURCE_LOADER_PATH,
@@ -69,7 +75,11 @@ public class TemplateRenderer {
                         ? templateFile.getParentFile().getAbsolutePath()
                         : templateFile.getAbsoluteFile().getParentFile().getAbsolutePath());
 
-        VelocityEngine ve = getVelocityEngine(veProperties);
+        return getVelocityEngine(veProperties);
+    }
+
+    public String renderTemplateFile(File templateFile) {
+        VelocityEngine ve = prepareVelocityEngine(templateFile);
         Template template = ve.getTemplate(templateFile.getName());
         return renderTemplate(template);
     }

--- a/core/runtime/src/test/resources/workflow.xml
+++ b/core/runtime/src/test/resources/workflow.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<workflow>
+    <processors>
+        <step>
+            <name>Source Validator</name>
+            <classHint>org.eclipse.sw360.antenna.validators.workflow.processors.SourceValidator</classHint>
+            <configuration>
+                <entry key="missingSourcesSeverity" value="FAIL"/>
+                <entry key="incompleteSourcesSeverity" value="${ANTENNATESTVARIABLE}"/>
+            </configuration>
+            <deactivated>false</deactivated>
+        </step>
+    </processors>
+</workflow>

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,12 @@
                 <version>3.3.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.19.0</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- Added the possibilities to give a properties file via gradle that contains variable names and values that can be credentials. File is given via the gradle build file and added as a map to TemplateRenderer
- TemplateRenderer can now handle System environment variables in all frontends, either given when command is executed or already in system.
- Documentation was updated for each frontend
- Test were written
   - GradleTest: reads in properties file containing variable ANTENNATESTVARIABLE
   - AbstractAntennaFrontendTest: includes System variable and tests whether it is set or not and normal tests check if rendering is correct, otherwise tests would fail due to non-existing enum {ANTENNATESTVARIABLE}