### PR TITLE
csv(copyrights): copyrights now represented through new row, excel format stable

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
@@ -184,7 +184,7 @@ public class CsvAnalyzer extends ManualAnalyzer {
             artifact.addFact(new ObservedLicenseInformation(license));
         }
         if (record.isMapped(COPYRIGHTS) && !record.get(COPYRIGHTS).isEmpty()) {
-            artifact.addFact(createCopyrightStatement(record.get(COPYRIGHTS)));
+            artifact.addFact(new CopyrightStatement(record.get(COPYRIGHTS)));
         }
         if (record.isMapped(HASH) && !record.get(HASH).isEmpty()) {
             artifact.addFact(new ArtifactFilename(null, record.get(HASH)));
@@ -220,21 +220,5 @@ public class CsvAnalyzer extends ManualAnalyzer {
                     : baseDir.resolve(Paths.get(pathName)).toAbsolutePath().toString();
             artifact.addFact(new ArtifactPathnames(absolutePathName));
         }
-    }
-
-    private CopyrightStatement createCopyrightStatement(String csvCopyrights) {
-        String[] copyrights = csvCopyrights.split("\\+");
-
-        CopyrightStatement copyrightStatement = null;
-        
-        for (String copyright : copyrights) {
-            if(copyrightStatement == null) {
-                copyrightStatement = new CopyrightStatement(copyright);
-            } else {
-                copyrightStatement = copyrightStatement.mergeWith(new CopyrightStatement(copyright));
-            }
-        }
-        
-        return copyrightStatement;
     }
 }

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
@@ -116,15 +116,33 @@ public class CsvAnalyzerTest extends AntennaTestWithMockedContext {
 
         commonsCsvFullDependencyCheck(foundArtifact);
 
-        assertThat(foundArtifact.askForGet(CopyrightStatement.class).get())
+        assertThat(foundArtifact.askFor(CopyrightStatement.class).get())
                 .isEqualTo(new CopyrightStatement("Copyright 2005-2016 The Apache Software Foundation")
-                        .mergeWith(new CopyrightStatement("Copyright 2020 the fake")).get());
+                        .mergeWith(new CopyrightStatement("Copyright, 2020 the fake"))
+                        .mergeWith(new CopyrightStatement("Copyright fake; the third")));
 
         List<String> hashes = foundArtifact.askFor(ArtifactFilename.class).get().
                 getArtifactFilenameEntries().stream()
                 .map(ArtifactFilename.ArtifactFilenameEntry::getHash)
                 .collect(Collectors.toList());
         assertThat(hashes).hasSize(2);
+
+        Artifact cliArtifact = artifacts.stream()
+                .filter(artifact -> artifact.askFor(MavenCoordinates.class).get().getArtifactId().equals("commons-cli"))
+                .findFirst().get();
+
+        assertThat(cliArtifact.askFor(CopyrightStatement.class).get()).isEqualTo(
+                new CopyrightStatement("Copyright 2005-2016 The Apache Software Foundation")
+                        .mergeWith(new CopyrightStatement("copy & paste"))
+                        .mergeWith(new CopyrightStatement("this is $ it"))
+                        .mergeWith(new CopyrightStatement("!nevermind"))
+                        .mergeWith(new CopyrightStatement("§copsright"))
+                        .mergeWith(new CopyrightStatement("%gsp"))
+                        .mergeWith(new CopyrightStatement("?"))
+                        .mergeWith(new CopyrightStatement("`wer`"))
+                        .mergeWith(new CopyrightStatement("#wtewp"))
+                        .mergeWith(new CopyrightStatement("~fjd"))
+        );
     }
 
     @Override

--- a/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependenciesWithExcelFormat.csv
+++ b/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependenciesWithExcelFormat.csv
@@ -1,4 +1,14 @@
 Artifact Id;Group Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Change Status;CPE;File Name
-commons-csv;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 2005-2016 The Apache Software Foundation+Copyright 2020 the fake;620580a88953cbcf4528459e485054e7c27c0889;http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip;https://github.com/apache/commons-csv/tree/csv-1.4;swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;commons-csv.jar
-commons-csv;org.apache.commons;1.4;mvn;;;;;b0060ed8397bfec39b397807f63e778618f324ce;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;;Copyright 2005-2016 The Apache Software Foundation+Copyright 2010 The Other Fake;2a26e60c745cdeb99a96f21adec508f43b5d25a5;http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip;https://github.com/apache/commons-cli/tree/cli-1.4;swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;commons-cli.jar
+commons-csv;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 2005-2016 The Apache Software Foundation;620580a88953cbcf4528459e485054e7c27c0889;http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip;https://github.com/apache/commons-csv/tree/csv-1.4;swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;commons-csv.jar
+commons-csv;org.apache.commons;1.4;mvn;;;;Copyright, 2020 the fake;1,23E+16;;;;;;;
+commons-csv;org.apache.commons;1.4;mvn;;;;"Copyright fake; the third";;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;;Copyright 2005-2016 The Apache Software Foundation;2a26e60c745cdeb99a96f21adec508f43b5d25a5;http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip;https://github.com/apache/commons-cli/tree/cli-1.4;swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;commons-cli.jar
+commons-cli;org.apache.commons;1.4;mvn;;;;copy & paste;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;this is $ it;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;!nevermind;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;§copsright;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;%gsp;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;?;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;`wer`;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;#wtewp;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;~fjd;;;;;;;;

--- a/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencyWithMultipleCopyrights.csv
+++ b/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencyWithMultipleCopyrights.csv
@@ -1,3 +1,5 @@
 "Artifact Id","Group Id","Version","Coordinate Type","Copyrights","File Name"
-commons-csv,org.apache.commons,1.4,mvn,"Copyright 2005-2016 The Apache Software Foundation+Copyright 2020 Fake Company+Copyright 2020 Fake the 2nd",commons-csv.jar
+commons-csv,org.apache.commons,1.4,mvn,"Copyright 2005-2016 The Apache Software Foundation",commons-csv.jar
+commons-csv,org.apache.commons,1.4,mvn,"Copyright 2020 Fake Company",
+commons-csv,org.apache.commons,1.4,mvn,"Copyright 2020 Fake the 2nd",
 commons-cli,org.apache.commons,1.4,mvn,"Copyright 2005-2016 The Apache Software Foundation",commons-cli.jar


### PR DESCRIPTION
As discussed this morning:

- Copyrights are read in with new line entries. The same way as Hashes. 
- An csv file was created with Excel that included several special case characters. All are working with the csv parser. So use case of creating csv file via Excel and have saved format be interpreted correctly is fullfilled. 
