### PR TITLE
chore(commit_version.sh): make deterministic

### DIFF
--- a/commit_version.sh
+++ b/commit_version.sh
@@ -16,4 +16,4 @@
 set -e
 
 git checkout $1
-mvn clean install -DskipTests -Dqualifier=-$(git describe --tags | cut -d"-" -f2-)
+mvn clean install -DskipTests -Dqualifier=-$(git describe --tags --abbrev=7 | cut -d"-" -f2-)


### PR DESCRIPTION
fix the number of characters taken from the hash to `7` to prevent errors like building 
- `1.0.0-RC4-25-g377e23e` on some systems and
- `1.0.0-RC4-25-g377e23e2` on other systems.