### PR TITLE
fix(sw360): move non-id fields to additionalData

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
@@ -55,14 +55,15 @@ public class SW360Attributes {
     public static final String RELEASE_SOURCES = "downloadurl";
     public static final String RELEASE_MAIN_LICENSE_IDS = "mainLicenseIds";
     public static final String RELEASE_EXTERNAL_IDS = "externalIds";
-    public static final String RELEASE_EXTERNAL_ID_FLICENSES = "license";
-    public static final String RELEASE_EXTERNAL_ID_DLICENSES = "declared_license";
-    public static final String RELEASE_EXTERNAL_ID_OLICENSES = "observed_license";
     public static final String RELEASE_EXTERNAL_ID_OREPO = "orig_repo";
     public static final String RELEASE_EXTERNAL_ID_SWHID = "swh";
     public static final String RELEASE_EXTERNAL_ID_HASHES = "hash_";
-    public static final String RELEASE_EXTERNAL_ID_CHANGESTATUS = "change_status";
-    public static final String RELEASE_EXTERNAL_ID_COPYRIGHTS = "copyrights";
+    public static final String RELEASE_ADDITIONAL_DATA = "additionalData";
+    public static final String RELEASE_ADDITIONAL_DATA_FLICENSES = "license";
+    public static final String RELEASE_ADDITIONAL_DATA_DLICENSES = "declared_license";
+    public static final String RELEASE_ADDITIONAL_DATA_OLICENSES = "observed_license";
+    public static final String RELEASE_ADDITIONAL_DATA_CHANGESTATUS = "change_status";
+    public static final String RELEASE_ADDITIONAL_DATA_COPYRIGHTS = "copyrights";
 
     // Attributes of Sw360Attachment
     public static final String ATTACHMENT_ATTACHMENT_TYPE = "attachmentType";

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -36,6 +36,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     private String copyrights;
 
     private Map<String, String> externalIds;
+    private Map<String, String> additionalData;
 
 
     public String getComponentId() {
@@ -182,6 +183,15 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
         return this;
     }
 
+    public Map<String, String> getAdditionalData() {
+        return additionalData;
+    }
+
+    public SW360Release setAdditionalData(Map<String,String> additionalData) {
+        this.additionalData = additionalData;
+        return this;
+    }
+
     public String getCopyrights() {
         return copyrights;
     }
@@ -211,6 +221,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
         changeStatus = Optional.of(releaseWithPrecedence.getChangeStatus()).orElse(changeStatus);
         copyrights = Optional.of(releaseWithPrecedence.getCopyrights()).orElse(copyrights);
         externalIds = Optional.of(releaseWithPrecedence.getExternalIds()).orElse(externalIds);
+        additionalData = Optional.of(releaseWithPrecedence.getAdditionalData()).orElse(additionalData);
 
         return this;
     }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
@@ -81,6 +81,7 @@ public class RestUtils {
         release.put(SW360Attributes.RELEASE_CLEARINGSTATE, sw360Release.getClearingState());
         release.put(SW360Attributes.RELEASE_MAIN_LICENSE_IDS, sw360Release.getMainLicenseIds());
         release.put(SW360Attributes.RELEASE_EXTERNAL_IDS, convertSW360ExternalIdsToMapOfStrings(sw360Release));
+        release.put(SW360Attributes.RELEASE_ADDITIONAL_DATA, convertSW360AdditionalDataToMapOfStrings(sw360Release));
         return getHttpEntity(release, header);
     }
 
@@ -98,15 +99,6 @@ public class RestUtils {
     private static Map<String, String> convertSW360ExternalIdsToMapOfStrings(SW360Release sw360Release) {
         Map<String, String> externalIds = new HashMap<>(sw360Release.getCoordinates());
 
-        if(sw360Release.getFinalLicense() != null) {
-            externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_FLICENSES, sw360Release.getFinalLicense());
-        }
-        if(sw360Release.getDeclaredLicense() != null) {
-            externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_DLICENSES, sw360Release.getDeclaredLicense());
-        }
-        if(sw360Release.getObservedLicense() != null) {
-            externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_OLICENSES, sw360Release.getObservedLicense());
-        }
         if(sw360Release.getReleaseTagUrl() != null) {
             externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_OREPO, sw360Release.getReleaseTagUrl());
         }
@@ -115,12 +107,6 @@ public class RestUtils {
         }
         if(sw360Release.getHashes() != null) {
             externalIds.putAll(convertSetOfStringsOfHashesToMapOfStrings(sw360Release.getHashes()));
-        }
-        if(sw360Release.getChangeStatus() != null) {
-            externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_CHANGESTATUS, sw360Release.getChangeStatus());
-        }
-        if(sw360Release.getCopyrights() != null) {
-            externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_COPYRIGHTS, sw360Release.getCopyrights());
         }
 
         return externalIds;
@@ -135,5 +121,25 @@ public class RestUtils {
             i++;
         }
         return setMap;
+    }
+
+    public static Map<String, String>  convertSW360AdditionalDataToMapOfStrings(SW360Release sw360Release) {
+        Map<String, String> additionalData = new HashMap<>();
+        if(sw360Release.getFinalLicense() != null) {
+            additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_FLICENSES, sw360Release.getFinalLicense());
+        }
+        if(sw360Release.getDeclaredLicense() != null) {
+            additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_DLICENSES, sw360Release.getDeclaredLicense());
+        }
+        if(sw360Release.getObservedLicense() != null) {
+            additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_OLICENSES, sw360Release.getObservedLicense());
+        }
+        if(sw360Release.getChangeStatus() != null) {
+            additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_CHANGESTATUS, sw360Release.getChangeStatus());
+        }
+        if(sw360Release.getCopyrights() != null) {
+            additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_COPYRIGHTS, sw360Release.getCopyrights());
+        }
+        return additionalData;
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -110,16 +110,16 @@ public class SW360Enricher extends AbstractProcessor {
     }
 
     private void mapCopyrights(SW360Release sw360Release, Artifact artifact) {
-        if (sw360Release.getExternalIds().containsKey(SW360Attributes.RELEASE_EXTERNAL_ID_COPYRIGHTS)) {
-            String copyrights = sw360Release.getExternalIds().get(SW360Attributes.RELEASE_EXTERNAL_ID_COPYRIGHTS);
+        if (sw360Release.getAdditionalData().containsKey(SW360Attributes.RELEASE_ADDITIONAL_DATA_COPYRIGHTS)) {
+            String copyrights = sw360Release.getAdditionalData().get(SW360Attributes.RELEASE_ADDITIONAL_DATA_COPYRIGHTS);
 
             artifact.addFact(new CopyrightStatement(copyrights));
         }
     }
 
     private void mapChangeStatus(SW360Release sw360Release, Artifact artifact) {
-        if (sw360Release.getExternalIds().containsKey(SW360Attributes.RELEASE_EXTERNAL_ID_CHANGESTATUS)) {
-            String string_change_status = sw360Release.getExternalIds().get(SW360Attributes.RELEASE_EXTERNAL_ID_CHANGESTATUS);
+        if (sw360Release.getAdditionalData().containsKey(SW360Attributes.RELEASE_ADDITIONAL_DATA_CHANGESTATUS)) {
+            String string_change_status = sw360Release.getAdditionalData().get(SW360Attributes.RELEASE_ADDITIONAL_DATA_CHANGESTATUS);
 
             ArtifactChangeStatus.ChangeStatus changeStatus = ArtifactChangeStatus.ChangeStatus.valueOf(string_change_status);
 
@@ -160,18 +160,18 @@ public class SW360Enricher extends AbstractProcessor {
     }
 
     private void mapObservedLicense(SW360Release sw360Release, Artifact artifact) {
-        if (sw360Release.getExternalIds().containsKey(SW360Attributes.RELEASE_EXTERNAL_ID_OLICENSES)) {
+        if (sw360Release.getAdditionalData().containsKey(SW360Attributes.RELEASE_ADDITIONAL_DATA_OLICENSES)) {
             License licenseStatement = makeLicenseStatementFromString(
-                    sw360Release.getExternalIds().get(SW360Attributes.RELEASE_EXTERNAL_ID_OLICENSES));
+                    sw360Release.getAdditionalData().get(SW360Attributes.RELEASE_ADDITIONAL_DATA_OLICENSES));
 
             artifact.addFact(new ObservedLicenseInformation(licenseStatement));
         }
     }
 
     private void mapDeclaredLicense(SW360Release sw360Release, Artifact artifact) {
-        if (sw360Release.getExternalIds().containsKey(SW360Attributes.RELEASE_EXTERNAL_ID_DLICENSES)) {
+        if (sw360Release.getAdditionalData().containsKey(SW360Attributes.RELEASE_ADDITIONAL_DATA_DLICENSES)) {
             License licenseStatement = makeLicenseStatementFromString(
-                    sw360Release.getExternalIds().get(SW360Attributes.RELEASE_EXTERNAL_ID_DLICENSES));
+                    sw360Release.getAdditionalData().get(SW360Attributes.RELEASE_ADDITIONAL_DATA_DLICENSES));
 
             artifact.addFact(new DeclaredLicenseInformation(licenseStatement));
         }

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/workflow/processors/SW360EnricherTest.java
@@ -239,16 +239,22 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
 
         Map<String, String> externalIds = new HashMap<>();
 
-        externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_DLICENSES, "Apache-2.0");
-        externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_OLICENSES, "A Test License");
         externalIds.put(SW360CoordinateKeysToArtifactCoordinates.get(MavenCoordinates.class), "test:test1:1.2.3");
         externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_OREPO, releaseTagUrl);
         externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_SWHID, swhID);
         externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_HASHES + "1", hashString);
-        externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_CHANGESTATUS, "AS_IS");
-        externalIds.put(SW360Attributes.RELEASE_EXTERNAL_ID_COPYRIGHTS, copyrights);
 
         sw360Release.setExternalIds(externalIds);
+
+
+        Map<String, String> additionalData = new HashMap<>();
+
+        additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_DLICENSES, "Apache-2.0");
+        additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_OLICENSES, "A Test License");
+        additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_CHANGESTATUS, "AS_IS");
+        additionalData.put(SW360Attributes.RELEASE_ADDITIONAL_DATA_COPYRIGHTS, copyrights);
+
+        sw360Release.setAdditionalData(additionalData);
 
         return sw360Release;
     }


### PR DESCRIPTION
This modifies the sw360 adapter to work with the most recent api changes in SW360 which introduced the `additionalData` map for storing arbitrary data.

resolves https://github.com/bsinno/osm-antenna/issues/796