### PR TITLE
OrtResultAnalyzer: Generalize an exception message

### DIFF
--- a/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzer.java
+++ b/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzer.java
@@ -39,7 +39,7 @@ public class OrtResultAnalyzer extends ManualAnalyzer {
         try {
             return new WorkflowStepResult(createArtifactList(componentInfoFile));
         } catch (IOException e) {
-            throw new AntennaException("Error reading or parsing the ort result yaml file: " + e.getMessage());
+            throw new AntennaException("Error parsing the ORT result file: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
As ORT result files can now also be read in JSON format.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>