### PR TITLE
modules(ort): Fix a double-quoting issue with Copyright statements

### DIFF
--- a/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/resolver/OrtScannerResultResolver.java
+++ b/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/resolver/OrtScannerResultResolver.java
@@ -74,7 +74,7 @@ public class OrtScannerResultResolver extends AbstractOrtResultResolver {
         return iterateOverLicenseFindingsFromJsonNode(result)
                 .flatMap(s -> s.flatMap(node -> Utils.iteratorToCollection(node.get("copyrights").elements())
                         .stream())
-                        .map(JsonNode::toString)
+                        .map(JsonNode::textValue)
                         .map(CopyrightStatement::new)
                         .reduce(CopyrightStatement::mergeWith)
                 );

--- a/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
+++ b/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
@@ -148,7 +148,7 @@ public class OrtResultAnalyzerTest {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .flatMap(s -> Stream.of(s.split("\n"))).toArray())
-                .contains("\"" + "Copyright (c) 2014-2017 Teist Peirson2 <teist.peirson@2.com>" + "\"");
+                .contains("Copyright (c) 2014-2017 Teist Peirson2 <teist.peirson@2.com>");
 
         assertThat(artifacts.stream()
                 .map(artifact -> artifact.askForGet(CopyrightStatement.class))


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>