### PR TITLE
fix(sw360): check for empty license information

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -12,10 +12,13 @@ package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
 
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW360ReleaseEmbedded> {
     private String componentId;
@@ -175,7 +178,13 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     }
 
     public Map<String, String> getExternalIds() {
-        return externalIds;
+        return Optional.ofNullable(externalIds)
+                .map(Map::entrySet)
+                .map(Collection::stream)
+                .orElse(Stream.empty())
+                .filter(entry -> !entry.getValue().equals(""))
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        Map.Entry::getValue));
     }
 
     public SW360Release setExternalIds(Map<String, String> externalIds) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
@@ -78,9 +78,9 @@ public class SW360ReleaseAdapterUtils {
 
     private static void setFinalLicense(SW360Release release, Artifact artifact) {
         LicenseInformation licenseInformation = ArtifactLicenseUtils.getFinalLicenses(artifact);
-
-        release.setFinalLicense(licenseInformation.evaluate());
-
+        Optional.of(licenseInformation.evaluate())
+                .filter(evaluatedLicenseInformation -> !"".equals(evaluatedLicenseInformation))
+                .ifPresent(release::setFinalLicense);
     }
 
     private static void setDeclaredLicense(SW360Release release, Artifact artifact) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -96,7 +96,7 @@ public class SW360Enricher extends AbstractProcessor {
     }
 
     private void mapExternalIdsOnSW360Release(SW360Release sw360Release, Artifact artifact) {
-        if (sw360Release.getExternalIds() != null) {
+        if (!sw360Release.getExternalIds().isEmpty()) {
 
             mapCoordinates(sw360Release, artifact);
             mapDeclaredLicense(sw360Release, artifact);

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/workflow/generator/SW360UpdaterTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/workflow/generator/SW360UpdaterTest.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.antenna.model.artifact.facts.*;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseStatement;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
@@ -127,6 +128,22 @@ public class SW360UpdaterTest extends AntennaTestWithMockedContext {
         artifact.addFact(new CopyrightStatement(copyrights));
 
         return artifact;
+    }
+
+    @Test
+    public void testMainLicenseIsEmptyAndFinalLicenseNull() {
+        Artifact artifact = new Artifact("JSON");
+        artifact.setProprietary(false);
+        artifact.addFact(new MavenCoordinates("artifactId(test)", "org.group.id", "1.2.3"));
+        artifact.addFact(new DeclaredLicenseInformation(new LicenseStatement()));
+
+        SW360Release release = new SW360Release();
+        SW360Component sw360Component = new SW360Component();
+        sw360Component.setName("artifactId(test)");
+        SW360ReleaseAdapterUtils.prepareRelease(release, sw360Component, Collections.EMPTY_SET, artifact);
+
+        assertThat(release.getFinalLicense()).isNull();
+        assertThat(release.getMainLicenseIds().isEmpty()).isTrue();
     }
 
 }


### PR DESCRIPTION
Resolves issue of having empty externalId value with key "license"