### PR TITLE
fix(sw360): wrong function called when updating fixed

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -88,7 +88,7 @@ public class SW360MetaDataUpdater {
             Optional<SW360Release> release = releaseClientAdapter.getReleaseByArtifact(component, artifact, header);
             if (release.isPresent()) {
                 if(updateReleases) {
-                    return releaseClientAdapter.addRelease(artifact, component, licenseIds, header);
+                    return releaseClientAdapter.updateRelease(release.get(), artifact, component, licenseIds, header);
                 } else {
                     return release.get();
                 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -41,7 +41,7 @@ public class SW360ReleaseClientAdapter {
 
     public SW360Release updateRelease(SW360Release release, Artifact artifact, SW360Component sw360Component, Set<String> sw360LicenseIds, HttpHeaders header) throws AntennaException {
         SW360Release sw360ReleaseFromArtifact = new SW360Release();
-        SW360ReleaseAdapterUtils.prepareRelease(release, sw360Component, sw360LicenseIds, artifact);
+        SW360ReleaseAdapterUtils.prepareRelease(sw360ReleaseFromArtifact, sw360Component, sw360LicenseIds, artifact);
 
         if (release.equals(sw360ReleaseFromArtifact)) {
             return release;

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
@@ -18,10 +18,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 
 import java.util.List;
 import java.util.Optional;

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360CoordinateKeysToArtifactCoordinates.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360CoordinateKeysToArtifactCoordinates.java
@@ -64,6 +64,12 @@ public enum SW360CoordinateKeysToArtifactCoordinates {
                 .collect(Collectors.toSet());
     }
 
+    public static Set<String> getValues() {
+        return VALUES.stream()
+                .map(e -> e.value)
+                .collect(Collectors.toSet());
+    }
+
     public static ArtifactCoordinates createArtifactCoordinates(String group, String name, String version, Class<?extends ArtifactCoordinates> coordinateClass) {
         try {
             Object object = null;

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseTest.java
@@ -1,0 +1,47 @@
+package org.eclipse.sw360.antenna.sw360.rest;
+
+import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SW360ReleaseTest {
+
+    @Test
+    public void testReleaseMergeWithNonDominantNull() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+        sw360Release1.setCpeid(null);
+        sw360Release2.setCpeid("cpe:ishere");
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.getCpeid()).isEqualTo(sw360Release2.getCpeid());
+    }
+
+    @Test
+    public void testReleaseMergeWithBothNull() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.setCpeid(null);
+        sw360Release2.setCpeid(null);
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.getCpeid()).isEqualTo(sw360Release2.getCpeid());
+    }
+
+    @Test
+    public void testReleaseMergeWithDominantNull() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.setCpeid("cpe:ishere");
+        sw360Release2.setCpeid(null);
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.getCpeid()).isNotEqualTo(sw360Release2.getCpeid());
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generator/SW360UpdaterTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generator/SW360UpdaterTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.sw360.antenna.workflow.generator;
+package org.eclipse.sw360.antenna.sw360.workflow.generator;
 
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.sw360.antenna.sw360.rest.workflow.processors;
+package org.eclipse.sw360.antenna.sw360.workflow.processors;
 
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;


### PR DESCRIPTION
Instead of calling `updateRelease`, `addRelease` was called and hence created a 409 Conflict Response when running same project twice. 

Error isn't occuring anymore. There's a new one now. Patch isn't functioning still. But normal getOrCreateRelease is (which is relevant for antenna users)