### PR TITLE
core(log4j): Reduce the wire logging to warnings

### DIFF
--- a/core/runtime/src/main/resources/log4j.properties
+++ b/core/runtime/src/main/resources/log4j.properties
@@ -23,7 +23,8 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m%n
 
-
+log4j.logger.httpclient.wire.header=WARN
+log4j.logger.httpclient.wire.content=WARN
 
 log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.org.apache.hadoop=WARN
@@ -32,5 +33,3 @@ log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF
 
 log4j.configurationFile=log4j2.properties
-
-


### PR DESCRIPTION
See https://stackoverflow.com/a/6099704/1127485. This should help to
reduce the log size on CI so Travis does not abort jobs anymore because
the maximum log length was exceeded, see e.g.
https://travis-ci.com/eclipse/antenna/jobs/225552439#L13210.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>