### PR TITLE
Fix antenna rest and allow to upload attachments to SW360

### DIFF
--- a/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ConfigurableWorkflowItem.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ConfigurableWorkflowItem.java
@@ -76,6 +76,10 @@ public abstract class ConfigurableWorkflowItem {
         return result;
     }
 
+    public Boolean getBooleanConfigValue(String key, Map<String, String> configMap) throws AntennaConfigurationException {
+        return "true".equals(getConfigValue(key, configMap, "false").toLowerCase());
+    }
+
     public List<String> getCommaSeparatedConfigValue(String key, Map<String,String> configMap) throws  AntennaConfigurationException {
         final String configValue = getConfigValue(key, configMap, "");
         if ("".equals(configValue)) {

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
@@ -21,8 +21,12 @@ public class ProxySettings {
         this.proxyPort = proxyPort;
     }
 
+    public static ProxySettings empty() {
+        return new ProxySettings(false, null, -1);
+    }
+
     public boolean isProxyUse() {
-        return proxyUse;
+        return proxyUse && proxyHost != null && ! proxyHost.isEmpty();
     }
 
     public String getProxyHost() {

--- a/example-projects/mvn-test-project/pom.xml
+++ b/example-projects/mvn-test-project/pom.xml
@@ -129,7 +129,7 @@
                     <!-- The antenna mojo requires the kbase to fetch the license information -->
                     <dependency>
                         <groupId>org.eclipse.sw360.antenna</groupId>
-                        <artifactId>antenna-spdx-license-knowledge-base</artifactId>
+                        <artifactId>spdx-license-knowledge-base</artifactId>
                         <version>${org.eclipse.sw360.antenna.version}</version>
                     </dependency>
                 </dependencies>

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
@@ -16,43 +16,32 @@ import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ComponentClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
-import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
 import org.springframework.http.HttpHeaders;
 
 import java.util.Optional;
 
 public class SW360MetaDataReceiver {
     // rest service adapters
-    private SW360AuthenticationClient authenticationClient;
     private SW360ComponentClientAdapter componentClientAdapter;
     private SW360ReleaseClientAdapter releaseClientAdapter;
     private SW360LicenseClientAdapter licenseClientAdapter;
 
-    private String userId;
-    private String password;
-    private String clientId;
-    private String clientPassword;
+    private SW360ConnectionConfiguration sw360ConnectionConfiguration;
 
-    public SW360MetaDataReceiver(String restServerUrl, String authServerUrl, String userId, String password,
-                                 String clientId, String clientPassword,
-                                 boolean proxyEnable, String proxyHost, int proxyPort) {
-        this.userId = userId;
-        this.password = password;
-        this.clientId = clientId;
-        this.clientPassword = clientPassword;
-
-        authenticationClient = new SW360AuthenticationClient(authServerUrl, proxyEnable, proxyHost, proxyPort);
-        componentClientAdapter = new SW360ComponentClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
-        releaseClientAdapter = new SW360ReleaseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
-        licenseClientAdapter = new SW360LicenseClientAdapter(restServerUrl, proxyEnable, proxyHost, proxyPort);
+    public SW360MetaDataReceiver(SW360ConnectionConfiguration sw360ConnectionConfiguration) {
+        componentClientAdapter = sw360ConnectionConfiguration.getSW360ComponentClientAdapter();
+        releaseClientAdapter = sw360ConnectionConfiguration.getSW360ReleaseClientAdapter();
+        licenseClientAdapter = sw360ConnectionConfiguration.getSW360LicenseClientAdapter();
+        this.sw360ConnectionConfiguration = sw360ConnectionConfiguration;
     }
 
     public Optional<SW360Release> findReleaseForArtifact(Artifact artifact) throws AntennaException {
-        HttpHeaders headers = createHttpsHeaders(userId, password);
+        HttpHeaders headers = sw360ConnectionConfiguration.getHttpHeaders();
         Optional<SW360Component> component = componentClientAdapter.getComponentByArtifact(artifact, headers);
         if (component.isPresent()) {
             return releaseClientAdapter.getReleaseByArtifact(component.get(), artifact, headers);
@@ -61,11 +50,7 @@ public class SW360MetaDataReceiver {
     }
 
     public Optional<SW360License> getLicenseDetails(SW360SparseLicense sparseLicense) throws AntennaException {
-        HttpHeaders headers = createHttpsHeaders(userId, password);
+        HttpHeaders headers = sw360ConnectionConfiguration.getHttpHeaders();
         return licenseClientAdapter.getLicenseDetails(sparseLicense, headers);
-    }
-
-    private HttpHeaders createHttpsHeaders(String userId, String password) throws AntennaException {
-        return authenticationClient.getHeadersWithBearerToken(authenticationClient.getOAuth2AccessToken(userId, password, clientId, clientPassword));
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ComponentAdapterUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 import java.util.ArrayList;
@@ -27,8 +28,8 @@ import java.util.stream.Collectors;
 public class SW360ComponentClientAdapter {
     private final SW360ComponentClient componentClient;
 
-    public SW360ComponentClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        this.componentClient = new SW360ComponentClient(restUrl, proxyUse, proxyHost, proxyPort);
+    public SW360ComponentClientAdapter(String restUrl, ProxySettings proxySettings) {
+        this.componentClient = new SW360ComponentClient(restUrl, proxySettings);
     }
 
     public SW360Component addComponent(Artifact artifact, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -34,7 +34,9 @@ public class SW360ComponentClientAdapter {
     public SW360Component addComponent(Artifact artifact, HttpHeaders header) throws AntennaException {
         SW360Component component = new SW360Component();
         SW360ComponentAdapterUtils.prepareComponent(component, artifact);
-
+        if(!SW360ComponentAdapterUtils.isValidComponent(component)) {
+            throw new AntennaException("Can not write invalid component for " + artifact.toString());
+        }
         return componentClient.createComponent(component, header);
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -34,7 +34,7 @@ public class SW360ComponentClientAdapter {
     public SW360Component addComponent(Artifact artifact, HttpHeaders header) throws AntennaException {
         SW360Component component = new SW360Component();
         SW360ComponentAdapterUtils.prepareComponent(component, artifact);
-        if(!SW360ComponentAdapterUtils.isValidComponent(component)) {
+        if(! SW360ComponentAdapterUtils.isValidComponent(component)) {
             throw new AntennaException("Can not write invalid component for " + artifact.toString());
         }
         return componentClient.createComponent(component, header);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
@@ -15,6 +15,7 @@ import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.sw360.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 import java.util.List;
@@ -23,8 +24,8 @@ import java.util.Optional;
 public class SW360LicenseClientAdapter {
     private final SW360LicenseClient licenseClient;
 
-    public SW360LicenseClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        this.licenseClient = new SW360LicenseClient(restUrl, proxyUse, proxyHost, proxyPort);
+    public SW360LicenseClientAdapter(String restUrl, ProxySettings proxySettings) {
+        this.licenseClient = new SW360LicenseClient(restUrl, proxySettings);
     }
 
     public boolean isLicenseOfArtifactAvailable(License license, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ProjectAdapterUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 import java.io.IOException;
@@ -34,8 +35,8 @@ import java.util.stream.Collectors;
 public class SW360ProjectClientAdapter {
     private final SW360ProjectClient projectClient;
 
-    public SW360ProjectClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        this.projectClient = new SW360ProjectClient(restUrl, proxyUse, proxyHost, proxyPort);
+    public SW360ProjectClientAdapter(String restUrl, ProxySettings proxySettings) {
+        this.projectClient = new SW360ProjectClient(restUrl, proxySettings);
     }
 
     public Optional<String> getProjectIdByNameAndVersion(IProject project, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
@@ -55,6 +55,11 @@ public class SW360ProjectClientAdapter {
     public String addProject(String projectName, String projectVersion, HttpHeaders header) throws AntennaException, JsonProcessingException {
         SW360Project sw360Project = new SW360Project();
         SW360ProjectAdapterUtils.prepareProject(sw360Project, projectName, projectVersion);
+
+        if (! SW360ProjectAdapterUtils.isValidProject(sw360Project)) {
+            throw new AntennaException("Can not write invalid project with name=" + projectName + " and version=" + projectVersion);
+        }
+
         SW360Project responseProject = projectClient.createProject(sw360Project, header);
 
         return SW360HalResourceUtility.getLastIndexOfLinkObject(responseProject.get_Links()).orElse("");

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -35,7 +35,7 @@ public class SW360ReleaseClientAdapter {
         this.releaseClient = new SW360ReleaseClient(restUrl, proxyUse, proxyHost, proxyPort);
     }
 
-    public SW360Release addRelease(Artifact artifact, SW360Component sw360Component, Set<String> sw360LicenseIds, HttpHeaders header) throws AntennaException {
+    public SW360Release addRelease(Artifact artifact, SW360Component sw360Component, Set<String> sw360LicenseIds, boolean uploadSource, HttpHeaders header) throws AntennaException {
         SW360Release release = new SW360Release();
         SW360ReleaseAdapterUtils.prepareRelease(release, sw360Component, sw360LicenseIds, artifact);
 
@@ -47,7 +47,7 @@ public class SW360ReleaseClientAdapter {
         final SW360Release release1 = releaseClient.createRelease(release, header);
 
         final Optional<Path> sourceFile = artifact.askForGet(ArtifactSourceFile.class);
-        if (sourceFile.isPresent()) {
+        if (uploadSource && sourceFile.isPresent()) {
             return releaseClient.uploadAndAttachAttachment(release1, sourceFile.get(), "SOURCE", header);
         } else {
             return release1;

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 import java.nio.file.Path;
@@ -31,8 +32,8 @@ import java.util.Set;
 public class SW360ReleaseClientAdapter {
     private final SW360ReleaseClient releaseClient;
 
-    public SW360ReleaseClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        this.releaseClient = new SW360ReleaseClient(restUrl, proxyUse, proxyHost, proxyPort);
+    public SW360ReleaseClientAdapter(String restUrl, ProxySettings proxySettings) {
+        this.releaseClient = new SW360ReleaseClient(restUrl, proxySettings);
     }
 
     public SW360Release addRelease(Artifact artifact, SW360Component sw360Component, Set<String> sw360LicenseIds, boolean uploadSource, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
@@ -14,14 +14,15 @@ package org.eclipse.sw360.antenna.sw360.adapter;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.rest.SW360UserClient;
 import org.eclipse.sw360.antenna.sw360.rest.resource.users.SW360User;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 public class SW360UserClientAdapter {
 
     private final SW360UserClient userClient;
 
-    public SW360UserClientAdapter(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        this.userClient= new SW360UserClient(restUrl, proxyUse, proxyHost, proxyPort);
+    public SW360UserClientAdapter(String restUrl, ProxySettings proxySettings) {
+        this.userClient= new SW360UserClient(restUrl, proxySettings);
     }
 
     public SW360User getUserByEmail(String userId, HttpHeaders header) throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
+import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360Attachment;
+import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>> extends SW360Client {
+    private static final String ATTACHMENTS_ENDPOINT = "/attachments";
+
+    public SW360AttachmentAwareClient(boolean proxyUse, String proxyHost, int proxyPort) {
+        super(proxyUse, proxyHost, proxyPort);
+    }
+
+    public abstract Class<T> getHandledClassType();
+
+    private HttpEntity<String> buildJsonPart(SW360Attachment sw360Attachment) throws AntennaException {
+        HttpHeaders jsonHeader = new HttpHeaders();
+        jsonHeader.setContentType(MediaType.APPLICATION_JSON);
+        return RestUtils.convertSW360ResourceToHttpEntity(sw360Attachment, jsonHeader);
+    }
+
+    public T uploadAndAttachAttachment(T itemToModify, Path fileToAttach, String kindToAttach, HttpHeaders header) throws AntennaException {
+        if (!Files.exists(fileToAttach)) {
+            throw new AntennaException("The file=[" + fileToAttach + "], which should be attached to release, does not exist");
+        }
+
+        MultiValueMap<String, Object> multipartRequest = new LinkedMultiValueMap<>();
+
+        SW360Attachment sw360Attachment = new SW360Attachment(fileToAttach, kindToAttach);
+        multipartRequest.add("attachment", buildJsonPart(sw360Attachment));
+        multipartRequest.add("file", new FileSystemResource(fileToAttach));
+
+        HttpHeaders newHeaders = RestUtils.deepCopyHeaders(header);
+        newHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(multipartRequest, newHeaders);
+
+        return uploadAndAttachAttachment(itemToModify, fileToAttach, requestEntity);
+    }
+
+    private T uploadAndAttachAttachment(T itemToModify, Path fileToAttach, HttpEntity<MultiValueMap<String, Object>> requestEntity) throws AntennaException {
+        final String self = itemToModify.get_Links().getSelf().getHref();
+        ResponseEntity<T> response = restTemplate.postForEntity(self + ATTACHMENTS_ENDPOINT, requestEntity, getHandledClassType());
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            return Optional.ofNullable(response.getBody())
+                    .orElseThrow(() -> new AntennaException("Body was null"));
+        } else {
+            throw new AntennaException("Request to get attach " + fileToAttach + " to " + self + " failed with "
+                    + response.getStatusCode());
+        }
+    }
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360Attachment;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.util.LinkedMultiValueMap;
@@ -26,8 +27,8 @@ import org.springframework.util.MultiValueMap;
 public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>> extends SW360Client {
     private static final String ATTACHMENTS_ENDPOINT = "/attachments";
 
-    public SW360AttachmentAwareClient(boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360AttachmentAwareClient(ProxySettings proxySettings) {
+        super(proxySettings);
     }
 
     public abstract Class<T> getHandledClassType();

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
@@ -39,10 +39,13 @@ public class SW360AuthenticationClient extends SW360Client {
         this.authServerUrl = authServerUrl;
     }
 
+    @Override
+    public String getEndpoint() {
+        return authServerUrl + GET_ACCESS_TOKEN_ENDPOINT;
+    }
+
     public String getOAuth2AccessToken(String username, String password, String clientId, String clientPassword)
             throws AntennaException {
-        String requestUrl = authServerUrl + GET_ACCESS_TOKEN_ENDPOINT;
-
         String body = String.format("%s=%s&%s=%s&%s=%s", SW360Attributes.AUTHENTICATOR_GRANT_TYPE, GRANT_TYPE_VALUE,
                 SW360Attributes.AUTHENTICATOR_USERNAME, username, SW360Attributes.AUTHENTICATOR_PASSWORD, password);
 
@@ -51,7 +54,7 @@ public class SW360AuthenticationClient extends SW360Client {
         headers.add(HttpHeaders.CONTENT_TYPE, TOKEN_CONTENT_TYPE);
 
         HttpEntity<String> httpEntity = new HttpEntity<>(body, headers);
-        ResponseEntity<String> response = doRestCall(requestUrl, HttpMethod.POST, httpEntity, String.class);
+        ResponseEntity<String> response = doRestCall(getEndpoint(), HttpMethod.POST, httpEntity, String.class);
 
         if (response.getStatusCode() == HttpStatus.OK) {
             try {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
@@ -15,6 +15,7 @@ package org.eclipse.sw360.antenna.sw360.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Attributes;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.*;
 
 import java.io.IOException;
@@ -34,8 +35,8 @@ public class SW360AuthenticationClient extends SW360Client {
 
     private final String authServerUrl;
 
-    public SW360AuthenticationClient(String authServerUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360AuthenticationClient(String authServerUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.authServerUrl = authServerUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
@@ -30,6 +30,8 @@ public abstract class SW360Client {
     private final boolean proxyUse;
     protected RestTemplate restTemplate;
 
+    public abstract String getEndpoint();
+
     public SW360Client(boolean proxyUse, String proxyHost, int proxyPort) {
         this.proxyUse = proxyUse && proxyHost != null;
         if (proxyUse && proxyHost != null) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.sw360.rest;
 
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -32,11 +33,12 @@ public abstract class SW360Client {
 
     public abstract String getEndpoint();
 
-    public SW360Client(boolean proxyUse, String proxyHost, int proxyPort) {
-        this.proxyUse = proxyUse && proxyHost != null;
-        if (proxyUse && proxyHost != null) {
+
+    public SW360Client(ProxySettings proxySettings) {
+        proxyUse = proxySettings.isProxyUse();
+        if (proxyUse) {
             SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxySettings.getProxyHost(), proxySettings.getProxyPort()));
             requestFactory.setProxy(proxy);
             this.restTemplate = new RestTemplate(requestFactory);
         } else {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
@@ -33,8 +34,8 @@ public class SW360ComponentClient extends SW360Client {
     private static final String COMPONENTS_ENDPOINT = "/components";
     private final String restUrl;
 
-    public SW360ComponentClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360ComponentClient(String restUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360LicenseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
@@ -29,8 +30,8 @@ public class SW360LicenseClient extends SW360Client {
     private static final String LICENSES_ENDPOINT = "/licenses";
     private final String restUrl;
 
-    public SW360LicenseClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360LicenseClient(String restUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -27,19 +27,23 @@ import java.util.Optional;
 
 public class SW360LicenseClient extends SW360Client {
     private static final String LICENSES_ENDPOINT = "/licenses";
-
-    private String licensesRestUrl;
+    private final String restUrl;
 
     public SW360LicenseClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         super(proxyUse, proxyHost, proxyPort);
-        licensesRestUrl = restUrl + LICENSES_ENDPOINT;
+        this.restUrl = restUrl;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return restUrl + LICENSES_ENDPOINT;
     }
 
     public List<SW360SparseLicense> getLicenses(HttpHeaders header) throws AntennaException {
-        ResponseEntity<Resource<SW360LicenseList>> response = doRestGET(this.licensesRestUrl, header,
+        ResponseEntity<Resource<SW360LicenseList>> response = doRestGET(getEndpoint(), header,
                 new ParameterizedTypeReference<Resource<SW360LicenseList>>() {});
 
-        if (response.getStatusCode() == HttpStatus.OK) {
+        if (response.getStatusCode().is2xxSuccessful()) {
             SW360LicenseList resource = Optional.ofNullable(response.getBody())
                     .orElseThrow(() -> new AntennaException("Body was null"))
                     .getContent();
@@ -55,10 +59,10 @@ public class SW360LicenseClient extends SW360Client {
     }
 
     public SW360License getLicenseByName(String name, HttpHeaders header) throws AntennaException {
-        ResponseEntity<Resource<SW360License>> response = doRestGET(this.licensesRestUrl + "/" + name, header,
+        ResponseEntity<Resource<SW360License>> response = doRestGET(getEndpoint() + "/" + name, header,
                 new ParameterizedTypeReference<Resource<SW360License>>() {});
 
-        if (response.getStatusCode() == HttpStatus.OK) {
+        if (response.getStatusCode().is2xxSuccessful()) {
             return Optional.ofNullable(response.getBody())
                     .orElseThrow(() -> new AntennaException("Body was null"))
                     .getContent();
@@ -72,7 +76,7 @@ public class SW360LicenseClient extends SW360Client {
         HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360License, header);
         ResponseEntity<Resource<SW360License>> response;
         try {
-            response = doRestPOST(this.licensesRestUrl, httpEntity,
+            response = doRestPOST(getEndpoint(), httpEntity,
                 new ParameterizedTypeReference<Resource<SW360License>>() {});
         } catch (HttpClientErrorException e) {
             throw new AntennaException("Request to create license " + sw360License.getFullName() + " failed with "

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360ProjectList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
@@ -34,8 +35,8 @@ public class SW360ProjectClient extends SW360Client {
     private static final String PROJECTS_ENDPOINT = "/projects";
     private final String restUrl;
 
-    public SW360ProjectClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360ProjectClient(String restUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
@@ -29,8 +30,8 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
     private static final String RELEASES_ENDPOINT_APPENDIX = "/releases";
     private final String restUrl;
 
-    public SW360ReleaseClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360ReleaseClient(String restUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
@@ -22,19 +22,23 @@ import java.util.Optional;
 
 public class SW360UserClient extends SW360Client {
     private static final String USERS_ENDPOINT = "/users";
-
-    private final String usersRestUrl;
+    private final String restUrl;
 
     public SW360UserClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
         super(proxyUse, proxyHost, proxyPort);
-        usersRestUrl = restUrl + USERS_ENDPOINT;
+        this.restUrl = restUrl;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return restUrl + USERS_ENDPOINT;
     }
 
     public SW360User getUserByEmail(String email, HttpHeaders header) throws AntennaException {
-        ResponseEntity<Resource<SW360User>> response = doRestGET(this.usersRestUrl + "/" + email, header,
+        ResponseEntity<Resource<SW360User>> response = doRestGET(getEndpoint() + "/" + email, header,
                 new ParameterizedTypeReference<Resource<SW360User>>() {});
 
-        if (response.getStatusCode() == HttpStatus.OK) {
+        if (response.getStatusCode().is2xxSuccessful()) {
             return Optional.ofNullable(response.getBody())
                     .orElseThrow(() -> new AntennaException("Body was null"))
                     .getContent();

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.antenna.sw360.rest;
 
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.users.SW360User;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.*;
@@ -24,8 +25,8 @@ public class SW360UserClient extends SW360Client {
     private static final String USERS_ENDPOINT = "/users";
     private final String restUrl;
 
-    public SW360UserClient(String restUrl, boolean proxyUse, String proxyHost, int proxyPort) {
-        super(proxyUse, proxyHost, proxyPort);
+    public SW360UserClient(String restUrl, ProxySettings proxySettings) {
+        super(proxySettings);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
@@ -50,7 +50,6 @@ public class SW360Attributes {
     public static final String RELEASE_COMPONENT_ID = "componentId";
     public static final String RELEASE_NAME = "name";
     public static final String RELEASE_VERSION = "version";
-    public static final String RELEASE_CLEARINGSTATE = "clearingState";
     public static final String RELEASE_CPE_ID = "cpeid";
     public static final String RELEASE_SOURCES = "downloadurl";
     public static final String RELEASE_MAIN_LICENSE_IDS = "mainLicenseIds";
@@ -63,6 +62,7 @@ public class SW360Attributes {
     public static final String RELEASE_EXTERNAL_ID_HASHES = "hash_";
     public static final String RELEASE_EXTERNAL_ID_CHANGESTATUS = "change_status";
     public static final String RELEASE_EXTERNAL_ID_COPYRIGHTS = "copyrights";
+    public static final String RELEASE_EXTERNAL_ID_CLEARINGSTATE = "clearingState";
 
     // Attributes of Sw360Attachment
     public static final String ATTACHMENT_ATTACHMENT_TYPE = "attachmentType";

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360Attachment.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360Attachment.java
@@ -10,27 +10,32 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resource.attachments;
 
+import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.Embedded;
 import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
 import java.nio.file.Path;
+import java.util.Optional;
 
 public class SW360Attachment extends SW360HalResource<LinkObjects, Embedded> {
     private final String filename;
     private final String attachmentType;
 
     public SW360Attachment(Path path, String attachmentType) {
-        this(path.getFileName().toString(), attachmentType);
+        this(Optional.ofNullable(path)
+                .map(Path::getFileName)
+                .orElseThrow(() -> new AntennaExecutionException("Tried to add null path.")).toString(),
+                attachmentType);
     }
 
     public SW360Attachment(String filename, String attachmentType) {
-        this.filename = filename;
+        this.filename = Optional.ofNullable(filename)
+                .orElseThrow(() -> new AntennaExecutionException("Filename is not allowed to be null."));
         this.attachmentType = attachmentType;
     }
 
     public SW360Attachment(String filename) {
-        this.filename = filename;
-        this.attachmentType = "DOCUMENT";
+        this(filename, "DOCUMENT");
     }
 
     public String getFilename() {
@@ -41,4 +46,18 @@ public class SW360Attachment extends SW360HalResource<LinkObjects, Embedded> {
         return attachmentType;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        if (!super.equals(object)) return false;
+        SW360Attachment that = (SW360Attachment) object;
+        return filename.equals(that.filename) &&
+                java.util.Objects.equals(attachmentType, that.attachmentType);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(super.hashCode(), filename, attachmentType);
+    }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360Attachment.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360Attachment.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resource.attachments;
+
+import org.eclipse.sw360.antenna.sw360.rest.resource.Embedded;
+import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
+import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
+import java.nio.file.Path;
+
+public class SW360Attachment extends SW360HalResource<LinkObjects, Embedded> {
+    private final String filename;
+    private final String attachmentType;
+
+    public SW360Attachment(Path path, String attachmentType) {
+        this(path.getFileName().toString(), attachmentType);
+    }
+
+    public SW360Attachment(String filename, String attachmentType) {
+        this.filename = filename;
+        this.attachmentType = attachmentType;
+    }
+
+    public SW360Attachment(String filename) {
+        this.filename = filename;
+        this.attachmentType = "DOCUMENT";
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public String getAttachmentType() {
+        return attachmentType;
+    }
+
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -215,7 +215,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
                 && this.version.equals(Optional.of(releaseCompare.getVersion()).orElse(""));
     }
 
-    private SW360Release mapExternalIdsOnVariable() {
+    private void mapExternalIdsOnVariable() {
         externalIds.forEach((key, value) -> {
             switch (key) {
                 case SW360Attributes.RELEASE_EXTERNAL_ID_FLICENSES:
@@ -239,6 +239,9 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
                 case SW360Attributes.RELEASE_EXTERNAL_ID_COPYRIGHTS:
                     copyrights = value;
                     break;
+                case SW360Attributes.RELEASE_EXTERNAL_ID_CLEARINGSTATE:
+                    clearingState = value;
+                    break;
                 default:
                     if (key.startsWith(SW360Attributes.RELEASE_EXTERNAL_ID_HASHES)) {
                         if(hashes == null) {
@@ -256,7 +259,6 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
                     }
             }
         });
-        return this;
     }
 
     public SW360Release mergeWith(SW360Release releaseWithPrecedence) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
@@ -44,7 +44,8 @@ public class SW360ComponentAdapterUtils {
     public static String createComponentName(Artifact artifact) {
         return getMostDominantArtifactCoordinates(artifact)
                 .map(ArtifactCoordinates::getName)
-                .orElse("");
+                .filter(n -> ! n.isEmpty())
+                .orElse(artifact.toString()); // TODO: ugly hack
     }
 
     public static String createComponentVersion(Artifact artifact) {
@@ -53,30 +54,17 @@ public class SW360ComponentAdapterUtils {
                 .orElse("-");
     }
 
-    public static void setCreatedOn(SW360Component component) {
+    private static void setCreatedOn(SW360Component component) {
         final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         final String createdOn = dateFormat.format(new Date());
         component.setCreatedOn(createdOn);
     }
 
-    public static void setCreatedOn(SW360Component component, String date) {
-        if (date != null && !date.isEmpty()) {
-            component.setCreatedOn(date);
-        } else {
-            setCreatedOn(component);
-        }
-    }
-
     public static void setName(SW360Component component, Artifact artifact) {
-        final String name = createComponentName(artifact);
-        if (!name.isEmpty()) {
-            component.setName(name);
-        } else {
-            component.setName(artifact.toString()); // TODO: ugly hack
-        }
+        component.setName(createComponentName(artifact));
     }
 
-    public static void setComponentType(SW360Component component, Artifact artifact) {
+    private static void setComponentType(SW360Component component, Artifact artifact) {
         if (artifact.isProprietary()) {
             component.setComponentType(SW360ComponentType.INTERNAL);
         } else {
@@ -84,7 +72,7 @@ public class SW360ComponentAdapterUtils {
         }
     }
 
-    public static void setHomePage(SW360Component component, Artifact artifact) {
+    private static void setHomePage(SW360Component component, Artifact artifact) {
         artifact.askForGet(ArtifactSourceUrl.class)
                 .ifPresent(component::setHomepage);
     }
@@ -97,9 +85,6 @@ public class SW360ComponentAdapterUtils {
     }
 
     public static boolean isValidComponent(SW360Component component) {
-        if(component.getName() == null || component.getName().isEmpty()) {
-            return false;
-        }
-        return true;
+        return component.getName() != null && !component.getName().isEmpty();
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
@@ -71,6 +71,8 @@ public class SW360ComponentAdapterUtils {
         final String name = createComponentName(artifact);
         if (!name.isEmpty()) {
             component.setName(name);
+        } else {
+            component.setName(artifact.toString()); // TODO: ugly hack
         }
     }
 
@@ -92,5 +94,12 @@ public class SW360ComponentAdapterUtils {
         SW360ComponentAdapterUtils.setName(component, artifact);
         SW360ComponentAdapterUtils.setComponentType(component, artifact);
         SW360ComponentAdapterUtils.setHomePage(component, artifact);
+    }
+
+    public static boolean isValidComponent(SW360Component component) {
+        if(component.getName() == null || component.getName().isEmpty()) {
+            return false;
+        }
+        return true;
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
@@ -50,4 +50,14 @@ public class SW360ProjectAdapterUtils {
         sw360Project.setProjectType(SW360ProjectType.PRODUCT);
         sw360Project.setVisibility(SW360Visibility.BUISNESSUNIT_AND_MODERATORS);
     }
+
+    public static boolean isValidProject(SW360Project project) {
+        if(project.getName() == null || project.getName().isEmpty()) {
+            return false;
+        }
+        if(project.getVersion() == null || project.getVersion().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
@@ -46,6 +46,16 @@ public class SW360ReleaseAdapterUtils {
         SW360ReleaseAdapterUtils.setCopyrights(release, artifact);
     }
 
+    public static boolean isValidRelease(SW360Release release) {
+        if(release.getName() == null || release.getName().isEmpty()) {
+            return false;
+        }
+        if(release.getVersion() == null || release.getVersion().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
     public static String createSW360ReleaseVersion(Artifact artifact) {
         return SW360ComponentAdapterUtils.createComponentVersion(artifact);
     }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
@@ -1,0 +1,92 @@
+package org.eclipse.sw360.antenna.sw360.workflow;
+
+import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ComponentClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ProjectClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
+import org.springframework.http.HttpHeaders;
+
+public class SW360ConnectionConfiguration {
+    public static final String REST_SERVER_URL_KEY = "rest.server.url";
+    public static final String AUTH_SERVER_URL_KEY = "auth.server.url";
+    public static final String USERNAME_KEY = "user.id";
+    public static final String PASSWORD_KEY = "user.password";
+    public static final String CLIENT_USER_KEY = "client.id";
+    public static final String CLIENT_PASSWORD_KEY = "client.password";
+    public static final String PROXY_USE = "proxy.use";
+
+    private final String restServerUrl;
+    private final String authServerUrl;
+    private final String user;
+    private final String password;
+    private final String clientId;
+    private final String clientPassword;
+    private final String proxyHost;
+    private final int proxyPort;
+    private final boolean proxyUse;
+    private final SW360AuthenticationClient authenticationClient;
+
+    public SW360ConnectionConfiguration(Getter<String> getConfigValue, Getter<Boolean> getBooleanConfigValue, String proxyHost, int proxyPort) throws AntennaConfigurationException {
+        // SW360 Connection configuration
+        restServerUrl = getConfigValue.apply(SW360ConnectionConfiguration.REST_SERVER_URL_KEY);
+        authServerUrl = getConfigValue.apply(SW360ConnectionConfiguration.AUTH_SERVER_URL_KEY);
+        user = getConfigValue.apply(SW360ConnectionConfiguration.USERNAME_KEY);
+        password = getConfigValue.apply(SW360ConnectionConfiguration.PASSWORD_KEY);
+        clientId = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_USER_KEY);
+        clientPassword = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY);
+
+        // Proxy configuration
+        proxyUse = getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE);
+
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+
+        this.authenticationClient = getSW360AuthenticationClient();
+    }
+
+    public SW360ConnectionConfiguration(String restServerUrl, String authServerUrl, String user, String password, String clientId, String clientPassword, String proxyHost, int proxyPort, boolean proxyUse) {
+        this.restServerUrl = restServerUrl;
+        this.authServerUrl = authServerUrl;
+        this.user = user;
+        this.password = password;
+        this.clientId = clientId;
+        this.clientPassword = clientPassword;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.proxyUse = proxyUse;
+
+        this.authenticationClient = getSW360AuthenticationClient();
+    }
+
+    public SW360AuthenticationClient getSW360AuthenticationClient() {
+        return new SW360AuthenticationClient(authServerUrl, proxyUse, proxyHost, proxyPort);
+    }
+
+    public SW360ComponentClientAdapter getSW360ComponentClientAdapter() {
+        return new SW360ComponentClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+    }
+
+    public SW360ReleaseClientAdapter getSW360ReleaseClientAdapter() {
+        return new SW360ReleaseClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+    }
+
+    public SW360LicenseClientAdapter getSW360LicenseClientAdapter() {
+        return new SW360LicenseClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+    }
+
+    public SW360ProjectClientAdapter getSW360ProjectClientAdapter() {
+        return new SW360ProjectClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+    }
+
+    public HttpHeaders getHttpHeaders() throws AntennaException {
+        return authenticationClient.getHeadersWithBearerToken(authenticationClient.getOAuth2AccessToken(user, password, clientId, clientPassword));
+    }
+
+    @FunctionalInterface
+    public interface Getter<T> {
+        T apply(String s) throws AntennaConfigurationException;
+    }
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.antenna.sw360.workflow;
 
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
@@ -7,6 +17,7 @@ import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ProjectClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 public class SW360ConnectionConfiguration {
@@ -24,9 +35,7 @@ public class SW360ConnectionConfiguration {
     private final String password;
     private final String clientId;
     private final String clientPassword;
-    private final String proxyHost;
-    private final int proxyPort;
-    private final boolean proxyUse;
+    private final ProxySettings proxySettings;
     private final SW360AuthenticationClient authenticationClient;
 
     public SW360ConnectionConfiguration(Getter<String> getConfigValue, Getter<Boolean> getBooleanConfigValue, String proxyHost, int proxyPort) throws AntennaConfigurationException {
@@ -39,10 +48,8 @@ public class SW360ConnectionConfiguration {
         clientPassword = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY);
 
         // Proxy configuration
-        proxyUse = getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE);
-
-        this.proxyHost = proxyHost;
-        this.proxyPort = proxyPort;
+        boolean proxyUse = getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE);
+        proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
 
         this.authenticationClient = getSW360AuthenticationClient();
     }
@@ -54,31 +61,29 @@ public class SW360ConnectionConfiguration {
         this.password = password;
         this.clientId = clientId;
         this.clientPassword = clientPassword;
-        this.proxyHost = proxyHost;
-        this.proxyPort = proxyPort;
-        this.proxyUse = proxyUse;
+        proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
 
         this.authenticationClient = getSW360AuthenticationClient();
     }
 
     public SW360AuthenticationClient getSW360AuthenticationClient() {
-        return new SW360AuthenticationClient(authServerUrl, proxyUse, proxyHost, proxyPort);
+        return new SW360AuthenticationClient(authServerUrl, proxySettings);
     }
 
     public SW360ComponentClientAdapter getSW360ComponentClientAdapter() {
-        return new SW360ComponentClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+        return new SW360ComponentClientAdapter(restServerUrl, proxySettings);
     }
 
     public SW360ReleaseClientAdapter getSW360ReleaseClientAdapter() {
-        return new SW360ReleaseClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+        return new SW360ReleaseClientAdapter(restServerUrl, proxySettings);
     }
 
     public SW360LicenseClientAdapter getSW360LicenseClientAdapter() {
-        return new SW360LicenseClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+        return new SW360LicenseClientAdapter(restServerUrl, proxySettings);
     }
 
     public SW360ProjectClientAdapter getSW360ProjectClientAdapter() {
-        return new SW360ProjectClientAdapter(restServerUrl, proxyUse, proxyHost, proxyPort);
+        return new SW360ProjectClientAdapter(restServerUrl, proxySettings);
     }
 
     public HttpHeaders getHttpHeaders() throws AntennaException {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
@@ -14,38 +14,25 @@ package org.eclipse.sw360.antenna.sw360.workflow.generators;
 import org.eclipse.sw360.antenna.api.IAttachable;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractGenerator;
 import org.eclipse.sw360.antenna.model.SW360ProjectCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.sw360.SW360MetaDataUpdater;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
 
 import java.io.IOException;
 import java.util.*;
 
 public class SW360Updater extends AbstractGenerator {
-    private static final String REST_SERVER_URL_KEY = "rest.server.url";
-    private static final String AUTH_SERVER_URL_KEY = "auth.server.url";
-    private static final String USERNAME_KEY = "user.id";
-    private static final String PASSWORD_KEY = "user.password";
-    private static final String CLIENT_USER_KEY = "client.id";
-    private static final String CLIENT_PASSWORD_KEY = "client.password";
-    private static final String PROXY_USE = "proxy.use";
-
-    private String sw360RestServerUrl;
-    private String sw360AuthServerUrl;
-    private String sw360User;
-    private String sw360Password;
-    private String sw360ClientId;
-    private String sw360ClientPassword;
-    private String sw360ProxyHost;
-    private int sw360ProxyPort;
-    private boolean sw360ProxyUse;
+    private static final String UPDATE_RELEASES = "update_releases";
+    private static final String UPLOAD_SOURCES = "upload_sources";
 
     private String projectName;
     private String projectVersion;
-    private boolean updateReleases = false;
+    private SW360MetaDataUpdater sw360MetaDataUpdater;
 
     public SW360Updater() {
         this.workflowStepOrder = 1100;
@@ -58,31 +45,32 @@ public class SW360Updater extends AbstractGenerator {
         projectName = retrieveName(configuredSW360Project);
         projectVersion = retrieveVersion(configuredSW360Project);
 
-        sw360RestServerUrl = getConfigValue(REST_SERVER_URL_KEY, configMap);
-        sw360AuthServerUrl = getConfigValue(AUTH_SERVER_URL_KEY, configMap);
-        sw360User = getConfigValue(USERNAME_KEY, configMap);
-        sw360Password = getConfigValue(PASSWORD_KEY, configMap);
-        sw360ClientId = getConfigValue(CLIENT_USER_KEY, configMap);
-        sw360ClientPassword = getConfigValue(CLIENT_PASSWORD_KEY, configMap);
-        sw360ProxyUse = Boolean.parseBoolean(getConfigValue(PROXY_USE, configMap, "false"));
-        sw360ProxyHost = context.getToolConfiguration().getProxyHost();
-        sw360ProxyPort = context.getToolConfiguration().getProxyPort();
+        // Proxy configuration
+        final String sw360ProxyHost = context.getToolConfiguration().getProxyHost();
+        final int sw360ProxyPort = context.getToolConfiguration().getProxyPort();
+
+        SW360ConnectionConfiguration sw360ConnectionConfiguration = new SW360ConnectionConfiguration(key -> getConfigValue(key, configMap),
+                key -> getBooleanConfigValue(key, configMap),
+                sw360ProxyHost, sw360ProxyPort);
+
+        // General configuration
+        final boolean updateReleases = getBooleanConfigValue(UPDATE_RELEASES, configMap);
+        if (updateReleases) {
+            throw new AntennaExecutionException("The functionality to update releases, activated with the " + UPDATE_RELEASES + " is not yet supported.");
+        }
+        Boolean uploadSources = getBooleanConfigValue(UPLOAD_SOURCES, configMap);
+
+        sw360MetaDataUpdater = new SW360MetaDataUpdater(sw360ConnectionConfiguration, updateReleases, uploadSources);
     }
 
     @Override
     public Map<String, IAttachable> produce(Collection<Artifact> intermediates) throws AntennaException {
-        SW360MetaDataUpdater sw360MetaDataUpdater = new SW360MetaDataUpdater(sw360RestServerUrl, sw360AuthServerUrl, sw360User,
-                sw360Password, sw360ClientId, sw360ClientPassword,
-                sw360ProxyUse, sw360ProxyHost, sw360ProxyPort);
 
         try {
             List<SW360Release> releases = new ArrayList<>();
             for (Artifact artifact : intermediates) {
                 Set<String> licenses = sw360MetaDataUpdater.getOrCreateLicenses(artifact);
                 SW360Component component = sw360MetaDataUpdater.getOrCreateComponent(artifact);
-                if(updateReleases) {
-                    sw360MetaDataUpdater.setUpdateReleases(updateReleases);
-                }
                 releases.add(sw360MetaDataUpdater.getOrCreateRelease(artifact, licenses, component));
             }
             sw360MetaDataUpdater.createProject(projectName, projectVersion, releases);
@@ -93,13 +81,14 @@ public class SW360Updater extends AbstractGenerator {
     }
 
     private String retrieveName(Optional<SW360ProjectCoordinates> sw360ProjectCoordinates) {
-        return sw360ProjectCoordinates.map(SW360ProjectCoordinates::getName).orElse(context.getProject().getProjectId());
+        return sw360ProjectCoordinates.map(SW360ProjectCoordinates::getName)
+                .orElse(context.getProject()
+                        .getProjectId());
     }
 
     private String retrieveVersion(Optional<SW360ProjectCoordinates> sw360ProjectCoordinates) {
-        return sw360ProjectCoordinates.map(SW360ProjectCoordinates::getVersion).orElse(context.getProject().getVersion());
-    }
-    public void setUpdateReleases(boolean updateReleases) {
-        this.updateReleases = updateReleases;
+        return sw360ProjectCoordinates.map(SW360ProjectCoordinates::getVersion)
+                .orElse(context.getProject()
+                        .getVersion());
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -219,7 +219,7 @@ public class SW360Enricher extends AbstractProcessor {
         List<SW360SparseLicense> releaseLicenses = embedded.getLicenses();
 
         if (!artifactLicenses.isEmpty()) {
-            if (releaseLicenses.isEmpty()) {
+            if (releaseLicenses == null || releaseLicenses.isEmpty()) {
                 LOGGER.info("License information available in antenna but not in SW360.");
             } else {
                 if (hasDifferentLicenses(artifactLicenses, releaseLicenses)) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -29,6 +29,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseEmbedded;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,14 +39,6 @@ import java.util.stream.Collectors;
 public class SW360Enricher extends AbstractProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(SW360Enricher.class);
     private IProcessingReporter reporter;
-
-    private static final String REST_SERVER_URL_KEY = "rest.server.url";
-    private static final String AUTH_SERVER_URL_KEY = "auth.server.url";
-    private static final String USERNAME_KEY = "user.id";
-    private static final String PASSWORD_KEY = "user.password";
-    private static final String CLIENT_USER_KEY = "client.id";
-    private static final String CLIENT_PASSWORD_KEY = "client.password";
-    private static final String PROXY_USE = "proxy.use";
 
     private SW360MetaDataReceiver connector;
 
@@ -59,16 +52,15 @@ public class SW360Enricher extends AbstractProcessor {
 
         reporter = context.getProcessingReporter();
 
-        String sw360RestServerUrl = getConfigValue(REST_SERVER_URL_KEY, configMap);
-        String sw360AuthServerUrl = getConfigValue(AUTH_SERVER_URL_KEY, configMap);
-        String sw360User = getConfigValue(USERNAME_KEY, configMap);
-        String sw360Password = getConfigValue(PASSWORD_KEY, configMap);
-        String sw360ClientUser = getConfigValue(CLIENT_USER_KEY, configMap);
-        String sw360ClientPassword = getConfigValue(CLIENT_PASSWORD_KEY, configMap);
-        boolean sw360ProxyUse = Boolean.parseBoolean(getConfigValue(PROXY_USE, configMap, "false"));
+        // Proxy configuration
         String sw360ProxyHost = context.getToolConfiguration().getProxyHost();
         int sw360ProxyPort = context.getToolConfiguration().getProxyPort();
-        connector = new SW360MetaDataReceiver(sw360RestServerUrl, sw360AuthServerUrl, sw360User, sw360Password, sw360ClientUser, sw360ClientPassword, sw360ProxyUse, sw360ProxyHost, sw360ProxyPort);
+
+        SW360ConnectionConfiguration sw360ConnectionConfiguration = new SW360ConnectionConfiguration(key -> getConfigValue(key, configMap),
+                key -> getBooleanConfigValue(key, configMap),
+                sw360ProxyHost, sw360ProxyPort);
+
+        connector = new SW360MetaDataReceiver(sw360ConnectionConfiguration);
     }
 
     @Override
@@ -97,7 +89,6 @@ public class SW360Enricher extends AbstractProcessor {
 
     private void mapExternalIdsOnSW360Release(SW360Release sw360Release, Artifact artifact) {
         if (!sw360Release.getExternalIds().isEmpty()) {
-
             mapCoordinates(sw360Release, artifact);
             mapDeclaredLicense(sw360Release, artifact);
             mapObservedLicense(sw360Release, artifact);

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
@@ -16,6 +16,7 @@ import com.github.cliftonlabs.json_simple.JsonObject;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360ProjectType;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
@@ -42,9 +43,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 public class SW360ProjectClientTest {
     private static final String REST_URL = "http://localhost:8080/resource/api";
-    private static final boolean PROXY_ENABLE = false;
-    private static final String PROXY_HOST = "localhost";
-    private static final int PROXY_PORT = 3128;
 
     private static final String PROJECTS_ENDPOINT = REST_URL + "/projects";
     private static final String USERS_ENDPOINT = REST_URL + "/users";
@@ -59,8 +57,6 @@ public class SW360ProjectClientTest {
     private static final String PROJECT_NAME_KEY = "name";
     private static final String PROJECT_PROJECT_TYPE_KEY = "projectType";
     private static final String PROJECT_VERSION_KEY = "version";
-    private static final String PROJECT_TYPE_KEY = "type";
-    private static final String PROJECT_CREATED_ON_KEY = "createdOn";
     private static final String PROJECT_CREATED_BY_KEY = "createdBy";
     private static final String PROJECT_EMAIL_KEY = "email";
 
@@ -75,10 +71,9 @@ public class SW360ProjectClientTest {
     private static final String PROJECT_NAME_VALUE_2 = "test.project.name2";
     private static final String PROJECT_PROJECT_TYPE_VALUE_2 = "SERVICE";
     private static final String PROJECT_VERSION_VALUE_2 = "2.5-RELEASE";
-    private static final String PROJECT_EMAIL_VALUE_2 = "testemail2@any.com";
 
 
-    private SW360ProjectClient client = new SW360ProjectClient(REST_URL, PROXY_ENABLE, PROXY_HOST, PROXY_PORT);
+    private SW360ProjectClient client = new SW360ProjectClient(REST_URL, ProxySettings.empty());
 
     private MockRestServiceServer mockedServer;
 


### PR DESCRIPTION
works with SW360 at `0178441f3bacd41fd6528d779b17c4e4acf87789`.

This fixes some things:
- prevents obviously invalid objects from being sent
- replaces `  == HttpStatus.OK` by `.is2xxSuccessful()`
- moves the clearing state to `externalIds`
- prevents empty license from being added to the request
- prevents empty externalIds from being added to the request
- prevents `null` in the hash map
- adds `component.setName(artifact.toString());` if no better name was found

This adds functionallity:
- upload of source to SW360

TODO:
- [x] make upload of attachments optional
- [ ] find a better alternative to the ugly `component.setName(artifact.toString());` hack