### PR TITLE
arch(maven): reduce context usage to maven resolver

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SourceUrlResolver.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/SourceUrlResolver.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.sw360.antenna.workflow.processors;
 
+import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor;
 import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
@@ -18,6 +19,7 @@ import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl;
 import org.eclipse.sw360.antenna.util.HttpHelper;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +65,9 @@ public class SourceUrlResolver extends AbstractProcessor {
     @Override
     public void configure(Map<String,String> configMap) throws AntennaConfigurationException {
         super.configure(configMap);
-        httpHelper = new HttpHelper(context);
-        dependencyTargetDirectory = context.getToolConfiguration().getDependenciesDirectory();
+        ToolConfiguration toolConfig = context.getToolConfiguration();
+        ProxySettings proxySettings = new ProxySettings(toolConfig.useProxy(), toolConfig.getProxyHost(), toolConfig.getProxyPort());
+        httpHelper = new HttpHelper(proxySettings);
+        dependencyTargetDirectory = toolConfig.getDependenciesDirectory();
     }
 }

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016-2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.util;
+
+public class ProxySettings {
+    private final boolean proxyUse;
+    private final String proxyHost;
+    private final int proxyPort;
+
+    public ProxySettings(boolean proxyUse, String proxyHost, int proxyPort) {
+        this.proxyUse = proxyUse;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+    }
+
+    public boolean isProxyUse() {
+        return proxyUse;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+
+}

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/HttpHelperTest.java
@@ -44,10 +44,6 @@ public class HttpHelperTest {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Mock
-    private ToolConfiguration toolConfigMock;
-    @Mock
-    private AntennaContext antennaContextMock;
-    @Mock
     private CloseableHttpClient httpClientMock;
     @Mock
     private CloseableHttpResponse httpResponseMock;
@@ -60,18 +56,15 @@ public class HttpHelperTest {
 
     @Before
     public void setUp() throws Exception {
-        when(toolConfigMock.getAntennaTargetDirectory())
-                .thenReturn(temporaryFolder.newFolder("target").toPath());
-        when(antennaContextMock.getToolConfiguration())
-                .thenReturn(toolConfigMock);
+        ProxySettings proxySettings = new ProxySettings(false, null, 0);
 
-        httpHelper = new HttpHelper(antennaContextMock);
+        httpHelper = new HttpHelper(proxySettings);
         setVariableValueInObject(httpHelper, "httpClient", httpClientMock);
     }
 
     @Test
     public void downloadFileWritesTheFileToDisk() throws Exception {
-        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+        Path targetDirectory = temporaryFolder.newFolder("target").toPath();
         File expectedJarFile = new File(targetDirectory.toFile(), "archive.zip");
 
         when(httpResponseMock.getStatusLine())
@@ -95,7 +88,7 @@ public class HttpHelperTest {
 
     @Test(expected = FailedToDownloadException.class)
     public void downloadFileThrowsExceptionOn404StatusCode() throws Exception {
-        Path targetDirectory = toolConfigMock.getAntennaTargetDirectory();
+        Path targetDirectory = temporaryFolder.newFolder("target").toPath();
 
         when(httpResponseMock.getStatusLine())
                 .thenReturn(statusLine);

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/ArtifactRequesterFactory.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/ArtifactRequesterFactory.java
@@ -14,10 +14,9 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
-import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
-import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
-import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 
+import java.io.File;
 import java.net.URL;
 import java.util.Optional;
 
@@ -25,39 +24,50 @@ import java.util.Optional;
  * Returns classes for requesting the jars of Artifacts.
  */
 public class ArtifactRequesterFactory {
-    public static IArtifactRequester getArtifactRequester(AntennaContext context, URL sourcesRepositoryUrl) throws AntennaException {
-        ToolConfiguration toolConfig = context.getToolConfiguration();
-
-        if (toolConfig.isMavenInstalled()) {
-            return useMavenIfRunning(context, Optional.of(sourcesRepositoryUrl)).orElse(new MavenInvokerRequester(context, sourcesRepositoryUrl));
+    public static IArtifactRequester getArtifactRequester(Optional<RepositorySystem> optionalRepositorySystem,
+                                                          Optional<MavenProject> optionalMavenProject,
+                                                          Optional<LegacySupport> optionalLegacySupport,
+                                                          File basedir,
+                                                          ProxySettings proxySettings,
+                                                          boolean isMavenInstalled,
+                                                          URL sourcesRepositoryUrl) {
+        if (isMavenInstalled) {
+            return useMavenIfRunning(optionalRepositorySystem, optionalMavenProject, optionalLegacySupport, Optional.of(sourcesRepositoryUrl))
+                    .orElse(new MavenInvokerRequester(basedir, sourcesRepositoryUrl));
         }
-        return new HttpRequester(context, sourcesRepositoryUrl);
+        return new HttpRequester(proxySettings, sourcesRepositoryUrl);
     }
 
-    public static IArtifactRequester getArtifactRequester(AntennaContext context) throws AntennaException {
-        ToolConfiguration toolConfig = context.getToolConfiguration();
-
-        if (toolConfig.isMavenInstalled()) {
-            return useMavenIfRunning(context, Optional.empty()).orElse(new MavenInvokerRequester(context));
+    public static IArtifactRequester getArtifactRequester(Optional<RepositorySystem> optionalRepositorySystem,
+                                                          Optional<MavenProject> optionalMavenProject,
+                                                          Optional<LegacySupport> optionalLegacySupport,
+                                                          File basedir,
+                                                          ProxySettings proxySettings,
+                                                          boolean isMavenInstalled) {
+        if (isMavenInstalled) {
+            return useMavenIfRunning(optionalRepositorySystem, optionalMavenProject, optionalLegacySupport, Optional.empty())
+                    .orElse(new MavenInvokerRequester(basedir));
         }
-        return new HttpRequester(context);
+        return new HttpRequester(proxySettings);
     }
 
     /*
      * Must only be used if Maven installation can be found on system, will result in ClassNotFoundError otherwise
      */
-    private static Optional<IArtifactRequester> useMavenIfRunning(AntennaContext context, Optional<URL> sourcesRepositoryUrl) {
-        Optional<RepositorySystem> optionalRepositorySystem = context.getGeneric(RepositorySystem.class);
-        Optional<MavenProject> optionalMavenProject = context.getGeneric(MavenProject.class);
-        Optional<LegacySupport> optionalLegacySupport = context.getGeneric(LegacySupport.class);
+    private static Optional<IArtifactRequester> useMavenIfRunning(Optional<RepositorySystem> optionalRepositorySystem,
+                                                                  Optional<MavenProject> optionalMavenProject,
+                                                                  Optional<LegacySupport> optionalLegacySupport,
+                                                                  Optional<URL> sourcesRepositoryUrl) {
         if (optionalRepositorySystem.isPresent() &&
                 optionalMavenProject.isPresent() &&
                 optionalLegacySupport.isPresent()) {
             ArtifactRepository localRepository = optionalLegacySupport.get().getSession().getLocalRepository();
             if (localRepository != null) {
-                return Optional.of(new MavenRuntimeRequester(context, optionalRepositorySystem.get(), localRepository, optionalMavenProject.get().getRemoteArtifactRepositories(), sourcesRepositoryUrl));
+                return Optional.of(new MavenRuntimeRequester(optionalRepositorySystem.get(), localRepository, optionalMavenProject.get().getRemoteArtifactRepositories(), sourcesRepositoryUrl));
             }
         }
         return Optional.empty();
     }
+
+
 }

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/ClassifierInformation.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/ClassifierInformation.java
@@ -8,7 +8,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 package org.eclipse.sw360.antenna.maven;
 
 public class ClassifierInformation {

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
@@ -10,10 +10,10 @@
  */
 package org.eclipse.sw360.antenna.maven;
 
-import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.exceptions.FailedToDownloadException;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.util.HttpHelper;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,15 +36,15 @@ public class HttpRequester extends IArtifactRequester {
     private HttpHelper httpHelper;
     private Optional<URL> sourceRepositoryUrl;
 
-    public HttpRequester(AntennaContext context, URL sourceRepositoryUrl) {
-        super(context);
-        httpHelper = new HttpHelper(context);
+    public HttpRequester(ProxySettings proxySettings, URL sourceRepositoryUrl) {
+        super();
+        httpHelper = new HttpHelper(proxySettings);
         this.sourceRepositoryUrl = Optional.of(sourceRepositoryUrl);
     }
 
-    public HttpRequester(AntennaContext context) {
-        super(context);
-        httpHelper = new HttpHelper(context);
+    public HttpRequester(ProxySettings proxySettings) {
+        super();
+        httpHelper = new HttpHelper(proxySettings);
         this.sourceRepositoryUrl = Optional.empty();
     }
 

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/IArtifactRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/IArtifactRequester.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.sw360.antenna.maven;
 
-import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 
 import java.io.File;
@@ -21,10 +20,8 @@ import java.util.Optional;
 public abstract class IArtifactRequester {
 
     public static final String JAR_EXTENSION = ".jar";
-    protected AntennaContext context;
 
-    public IArtifactRequester(AntennaContext context) {
-        this.context = context;
+    public IArtifactRequester() {
     }
 
     /**

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/MavenInvokerRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/MavenInvokerRequester.java
@@ -14,7 +14,6 @@ import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.MavenInvocationException;
-import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.slf4j.Logger;
@@ -44,20 +43,22 @@ public class MavenInvokerRequester extends IArtifactRequester {
     private static final String MVN_ARG_CLASSIFIER = "\"-Dclassifier=%s\"";
     private static final String MVN_ARG_REPOS = "\"-DremoteRepositories=%s\"";
     private static final String MVN_DOWNLOAD_CMD = "dependency:get --quiet";
+    private final File basedir;
 
     private DefaultInvoker defaultInvoker;
     private Optional<URL> sourceRepositoryUrl;
 
-    public MavenInvokerRequester(AntennaContext context) {
-        this(context, new DefaultInvoker(), Optional.empty());
+    public MavenInvokerRequester(File basedir) {
+        this(basedir, new DefaultInvoker(), Optional.empty());
     }
 
-    public MavenInvokerRequester(AntennaContext context, URL sourceRepositoryUrl) {
-        this(context, new DefaultInvoker(), Optional.of(sourceRepositoryUrl));
+    public MavenInvokerRequester(File basedir, URL sourceRepositoryUrl) {
+        this(basedir, new DefaultInvoker(), Optional.of(sourceRepositoryUrl));
     }
 
-    public MavenInvokerRequester(AntennaContext context, DefaultInvoker defaultInvoker, Optional<URL> sourceRepositoryUrl) {
-        super(context);
+    public MavenInvokerRequester(File basedir, DefaultInvoker defaultInvoker, Optional<URL> sourceRepositoryUrl) {
+        super();
+        this.basedir = basedir;
         this.defaultInvoker = defaultInvoker;
         if (System.getenv("M2_HOME") != null) {
             defaultInvoker.setMavenExecutable(new File(System.getenv("M2_HOME")));
@@ -116,7 +117,6 @@ public class MavenInvokerRequester extends IArtifactRequester {
     }
 
     protected File getPomFileFromContext() {
-        final File basedir = context.getProject().getBasedir();
         return new File(basedir, POM_FILENAME);
     }
 

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/MavenRuntimeRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/MavenRuntimeRequester.java
@@ -20,7 +20,6 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.repository.RepositorySystem;
-import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.slf4j.Logger;
@@ -43,8 +42,8 @@ public class MavenRuntimeRequester extends IArtifactRequester {
     private final ArtifactRepository localRepository;
     private final List<ArtifactRepository> remoteRepositories;
 
-    public MavenRuntimeRequester(AntennaContext context, RepositorySystem repositorySystem, ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories, Optional<URL> sourcesRepositoryUrl) {
-        super(context);
+    public MavenRuntimeRequester(RepositorySystem repositorySystem, ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories, Optional<URL> sourcesRepositoryUrl) {
+        super();
         if (sourcesRepositoryUrl.isPresent()) {
             List<ArtifactRepository> repositories = new ArrayList<>();
             ArtifactRepository droolsRepo = new MavenArtifactRepository(

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolver.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolver.java
@@ -11,35 +11,25 @@
 
 package org.eclipse.sw360.antenna.maven.workflow.processors.enricher;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor;
-import org.eclipse.sw360.antenna.maven.ArtifactRequesterFactory;
-import org.eclipse.sw360.antenna.maven.ClassifierInformation;
-import org.eclipse.sw360.antenna.maven.IArtifactRequester;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.ArtifactSelector;
-import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactJar;
-import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactSourceJar;
-import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
-import org.eclipse.sw360.antenna.model.reporting.MessageType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.sw360.antenna.util.ProxySettings;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class MavenArtifactResolver extends AbstractProcessor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MavenArtifactResolver.class);
     private static final String PREFERRED_SOURCE_QUALIFIER = "preferredSourceClassifier";
     private static final String SOURCES_REPOSITORY_URL = "sourcesRepositoryUrl";
     private Path dependencyTargetDirectory;
@@ -51,82 +41,25 @@ public class MavenArtifactResolver extends AbstractProcessor {
         this.workflowStepOrder = 300;
     }
 
-    private boolean isIgnoredForSourceResolving(Artifact artifact) {
-        return sourceResolvingBlacklist.stream()
-                .anyMatch(artifactSelector -> artifactSelector.matches(artifact));
-    }
-
-    /**
-     * Downloads the maven artifacts for the given lists, if possible.
-     *
-     * @param artifacts to be resolved
-     */
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
-    private void resolveArtifacts(Collection<Artifact> artifacts) throws AntennaException {
-        // Check directory exists
-        File dir = dependencyTargetDirectory.toFile();
-        if (!dir.exists()) {
-            dir.mkdirs();
-        }
-
-        List<Artifact> filteredArtifacts = artifacts.stream()
-                .filter(getFilterPredicate())
-                .filter(artifact -> !isIgnoredForSourceResolving(artifact))
-                .collect(Collectors.toList());
-        for (Artifact artifact : filteredArtifacts) {
-            resolve(artifact, dependencyTargetDirectory);
-        }
-    }
-
-    private Predicate<Artifact> getFilterPredicate() {
-        return artifact -> {
-            final Optional<MavenCoordinates> mavenCoordinates = artifact.askFor(MavenCoordinates.class);
-            return !artifact.getFlag(Artifact.IS_PROPRIETARY_FLAG_KEY) &&
-                    mavenCoordinates.isPresent() &&
-                    mavenCoordinates.get().getGroupId() != null &&
-                    mavenCoordinates.get().getArtifactId() != null;
-        };
-    }
-
-    private void resolve(Artifact artifact, Path dependencyTargetDirectory) throws AntennaException {
-        Optional<MavenCoordinates> oCoordinates = artifact.askFor(MavenCoordinates.class);
-        if (!oCoordinates.isPresent()) {
-            return;
-        }
-        MavenCoordinates coordinates = oCoordinates.get();
-
-        IArtifactRequester artifactRequester = sourcesRepositoryUrl != null
-                ? ArtifactRequesterFactory.getArtifactRequester(context, sourcesRepositoryUrl)
-                : ArtifactRequesterFactory.getArtifactRequester(context);
-
-        // Try to download source with preferred qualifier first
-        if (!artifact.getSourceFile().isPresent() && preferredSourceQualifier != null) {
-            Optional<File> sourceJar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, new ClassifierInformation(preferredSourceQualifier, true));
-            sourceJar.ifPresent(sourceJarFile -> artifact.addFact(new ArtifactSourceJar(sourceJarFile.toPath())));
-        }
-
-        if (!artifact.getSourceFile().isPresent()) {
-            Optional<File> sourceJar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, ClassifierInformation.DEFAULT_SOURCE_JAR);
-            sourceJar.ifPresent(sourceJarFile -> artifact.addFact(new ArtifactSourceJar(sourceJarFile.toPath())));
-        }
-
-        if (!artifact.getFile().isPresent()) {
-            Optional<File> jar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, ClassifierInformation.DEFAULT_JAR);
-            jar.ifPresent(jarFile -> artifact.addFact(new ArtifactJar(jarFile.toPath())));
-        }
-
-        if (!artifact.getSourceFile().isPresent() && !artifact.getFile().isPresent()) {
-            reporter.add(artifact, MessageType.MISSING_SOURCES, "Maven Artifact Coordinates present but non resolvable sources (maybe sources are available using P2).");
-        }
-    }
 
     @Override
     public Collection<Artifact> process(Collection<Artifact> artifacts) throws AntennaException {
-        LOGGER.info("Resolve maven artifacts, be patient... this could take a long time");
-        resolveArtifacts(artifacts);
-        LOGGER.info("Resolve maven artifacts... done");
-        return artifacts;
-
+        ToolConfiguration toolConfig = context.getToolConfiguration();
+        ProxySettings proxySettings = new ProxySettings(
+                toolConfig.useProxy(), toolConfig.getProxyHost(), toolConfig.getProxyPort());
+        return new MavenArtifactResolverImpl(
+                proxySettings,
+                context.getGeneric(RepositorySystem.class),
+                context.getGeneric(MavenProject.class),
+                context.getGeneric(LegacySupport.class),
+                dependencyTargetDirectory,
+                sourceResolvingBlacklist,
+                preferredSourceQualifier,
+                sourcesRepositoryUrl,
+                context.getProcessingReporter(),
+                toolConfig.isMavenInstalled(),
+                context.getProject().getBasedir())
+                .process(artifacts);
     }
 
     @Override

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolverImpl.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolverImpl.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016-2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.maven.workflow.processors.enricher;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.eclipse.sw360.antenna.api.IProcessingReporter;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
+import org.eclipse.sw360.antenna.maven.ArtifactRequesterFactory;
+import org.eclipse.sw360.antenna.maven.ClassifierInformation;
+import org.eclipse.sw360.antenna.maven.IArtifactRequester;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactSelector;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactJar;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.ArtifactSourceJar;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.reporting.MessageType;
+import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class MavenArtifactResolverImpl {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenArtifactResolverImpl.class);
+
+    private final IProcessingReporter processingReporter;
+    private final Path dependencyTargetDirectory;
+    private final List<ArtifactSelector> sourceResolvingBlacklist;
+    private final String preferredSourceQualifier;
+    private final URL sourcesRepositoryUrl;
+    private final ProxySettings proxySettings;
+    private final Optional<RepositorySystem> optionalRepositorySystem;
+    private final Optional<MavenProject> optionalMavenProject;
+    private final Optional<LegacySupport> optionalLegacySupport;
+    private final boolean isMavenInstalled;
+    private final File basedir;
+
+    public MavenArtifactResolverImpl(ProxySettings proxySettings,
+                                     Optional<RepositorySystem> optionalRepositorySystem,
+                                     Optional<MavenProject> optionalMavenProject,
+                                     Optional<LegacySupport> optionalLegacySupport,
+                                     Path dependencyTargetDirectory,
+                                     List<ArtifactSelector> sourceResolvingBlacklist,
+                                     String preferredSourceQualifier,
+                                     URL sourcesRepositoryUrl,
+                                     IProcessingReporter processingReporter,
+                                     boolean isMavenInstalled,
+                                     File basedir) {
+        this.dependencyTargetDirectory = dependencyTargetDirectory;
+        this.sourceResolvingBlacklist = sourceResolvingBlacklist;
+        this.sourcesRepositoryUrl = sourcesRepositoryUrl;
+        this.preferredSourceQualifier = preferredSourceQualifier;
+        this.processingReporter = processingReporter;
+        this.proxySettings = proxySettings;
+        this.optionalRepositorySystem = optionalRepositorySystem;
+        this.optionalMavenProject = optionalMavenProject;
+        this.optionalLegacySupport = optionalLegacySupport;
+        this.isMavenInstalled = isMavenInstalled;
+        this.basedir = basedir;
+    }
+
+    public Collection<Artifact> process(Collection<Artifact> artifacts) throws AntennaException {
+        LOGGER.info("Resolve maven artifacts, be patient... this could take a long time");
+        resolveArtifacts(artifacts);
+        LOGGER.info("Resolve maven artifacts... done");
+        return artifacts;
+
+    }
+
+    /**
+     * Downloads the maven artifacts for the given lists, if possible.
+     *
+     * @param artifacts to be resolved
+     */
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+    private void resolveArtifacts(Collection<Artifact> artifacts) throws AntennaException {
+        // Check directory exists
+        File dir = dependencyTargetDirectory.toFile();
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        List<Artifact> filteredArtifacts = artifacts.stream()
+                .filter(getFilterPredicate())
+                .filter(artifact -> !isIgnoredForSourceResolving(artifact))
+                .collect(Collectors.toList());
+        for (Artifact artifact : filteredArtifacts) {
+            resolve(artifact, dependencyTargetDirectory);
+        }
+    }
+
+
+    private void resolve(Artifact artifact, Path dependencyTargetDirectory) throws AntennaException {
+        Optional<MavenCoordinates> oCoordinates = artifact.askFor(MavenCoordinates.class);
+        if (!oCoordinates.isPresent()) {
+            return;
+        }
+        MavenCoordinates coordinates = oCoordinates.get();
+
+        IArtifactRequester artifactRequester = sourcesRepositoryUrl != null
+                ? ArtifactRequesterFactory.getArtifactRequester(
+                        optionalRepositorySystem, optionalMavenProject, optionalLegacySupport,
+                        basedir, proxySettings, isMavenInstalled, sourcesRepositoryUrl)
+                : ArtifactRequesterFactory.getArtifactRequester(
+                        optionalRepositorySystem, optionalMavenProject, optionalLegacySupport,
+                        basedir, proxySettings, isMavenInstalled);
+
+        // Try to download source with preferred qualifier first
+        if (!artifact.getSourceFile().isPresent() && preferredSourceQualifier != null) {
+            Optional<File> sourceJar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, new ClassifierInformation(preferredSourceQualifier, true));
+            sourceJar.ifPresent(sourceJarFile -> artifact.addFact(new ArtifactSourceJar(sourceJarFile.toPath())));
+        }
+
+        if (!artifact.getSourceFile().isPresent()) {
+            Optional<File> sourceJar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, ClassifierInformation.DEFAULT_SOURCE_JAR);
+            sourceJar.ifPresent(sourceJarFile -> artifact.addFact(new ArtifactSourceJar(sourceJarFile.toPath())));
+        }
+
+        if (!artifact.getFile().isPresent()) {
+            Optional<File> jar = artifactRequester.requestFile(coordinates, dependencyTargetDirectory, ClassifierInformation.DEFAULT_JAR);
+            jar.ifPresent(jarFile -> artifact.addFact(new ArtifactJar(jarFile.toPath())));
+        }
+
+        if (!artifact.getSourceFile().isPresent() && !artifact.getFile().isPresent()) {
+            processingReporter.add(artifact, MessageType.MISSING_SOURCES, "Maven Artifact Coordinates present but non resolvable sources (maybe sources are available using P2).");
+        }
+    }
+
+
+    private boolean isIgnoredForSourceResolving(Artifact artifact) {
+        return sourceResolvingBlacklist.stream()
+                .anyMatch(artifactSelector -> artifactSelector.matches(artifact));
+    }
+
+    private Predicate<Artifact> getFilterPredicate() {
+        return artifact -> {
+            final Optional<MavenCoordinates> mavenCoordinates = artifact.askFor(MavenCoordinates.class);
+            return !artifact.getFlag(Artifact.IS_PROPRIETARY_FLAG_KEY) &&
+                    mavenCoordinates.isPresent() &&
+                    mavenCoordinates.get().getGroupId() != null &&
+                    mavenCoordinates.get().getArtifactId() != null;
+        };
+    }
+
+}

--- a/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/IArtifactRequesterTest.java
+++ b/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/IArtifactRequesterTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class IArtifactRequesterTest extends AntennaTestWithMockedContext {
 
-    private IArtifactRequester artifactRequester = new IArtifactRequester(antennaContextMock) {
+    private IArtifactRequester artifactRequester = new IArtifactRequester() {
         @Override
         public Optional<File> requestFile(MavenCoordinates coordinates, Path targetDirectory, ClassifierInformation classifierInformation) {
             return Optional.empty();

--- a/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/MavenInvokerRequesterTest.java
+++ b/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/MavenInvokerRequesterTest.java
@@ -14,11 +14,9 @@ import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.utils.cli.CommandLineException;
-import org.eclipse.sw360.antenna.api.IProject;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaException;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,9 +39,6 @@ public class MavenInvokerRequesterTest extends AntennaTestWithMockedContext {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Mock
-    private IProject projectMock = Mockito.mock(IProject.class);
-
-    @Mock
     private DefaultInvoker defaultInvokerMock = Mockito.mock(DefaultInvoker.class);
     @Captor
     private
@@ -59,17 +54,9 @@ public class MavenInvokerRequesterTest extends AntennaTestWithMockedContext {
 
         System.setProperty("maven.home", temporaryFolder.newFolder("m2").toString());
 
-        Mockito.when(projectMock.getBasedir())
-                .thenReturn(temporaryFolder.newFile("projectBasedir"));
-        Mockito.when(antennaContextMock.getProject())
-                .thenReturn(projectMock);
+        File basedir = temporaryFolder.newFile("projectBasedir");
 
-        mir = new MavenInvokerRequester(antennaContextMock, defaultInvokerMock, Optional.empty());
-    }
-
-    @After
-    public void assertThatOnlyExpectedMethodsAreCalled() {
-        Mockito.verify(antennaContextMock, Mockito.atLeastOnce()).getProject();
+        mir = new MavenInvokerRequester(basedir, defaultInvokerMock, Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
refactored maven artifact resolver to have an impl class that is not dependent on the AntennaContext. 
Consequently I refactored all classes used in the `process` function of the workflow step. 