### PR TITLE
fix(sw360): license header added to SW360RelesaeTest

### DIFF
--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.antenna.sw360.rest;
 
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;


### PR DESCRIPTION
Added license header to `SW360ReleaseTest` was forgotten in PR and will make license header test in master green.