### PR TITLE
Add purl getter to ArtifactCoordinates

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -187,6 +187,10 @@
             <artifactId>spring-hateoas</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+        </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
             <groupId>junit</groupId>

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactCoordinates.java
@@ -11,9 +11,35 @@
 
 package org.eclipse.sw360.antenna.model.artifact.facts;
 
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
+
 public abstract class ArtifactCoordinates<T extends ArtifactCoordinates> implements ArtifactIdentifier<T> {
     public abstract String getName();
+
     public abstract String getVersion();
+
+    public abstract String getType();
+
+    protected PackageURLBuilder addPurlFacts(PackageURLBuilder builder) {
+        return builder;
+    }
+
+    public PackageURL getPurl() {
+        PackageURLBuilder builder =  PackageURLBuilder.aPackageURL()
+                .withType(getType())
+                .withName(getName())
+                .withVersion(getVersion());
+
+        builder = addPurlFacts(builder);
+        
+        try {
+            return builder.build();
+        } catch (MalformedPackageURLException e) {
+            throw new IllegalArgumentException("Could not build Purl", e);
+        }
+    }
 
     @Override
     public String prettyPrint() {

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/GenericArtifactCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/GenericArtifactCoordinates.java
@@ -38,6 +38,11 @@ public class GenericArtifactCoordinates extends ArtifactCoordinates {
     }
 
     @Override
+    public String getType() {
+        return "generic";
+    }
+
+    @Override
     public boolean isEmpty() {
         return (name == null || "".equals(name)) &&
                 (version == null || "".equals(version));

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/dotnet/DotNetCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/dotnet/DotNetCoordinates.java
@@ -37,6 +37,11 @@ public class DotNetCoordinates extends ArtifactCoordinates<DotNetCoordinates> {
     @Override
     public String getVersion() { return version; }
 
+    @Override
+    public String getType() {
+        return "nuget";
+    }
+
     public String getPackageId() { return packageId; }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/BundleCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/BundleCoordinates.java
@@ -63,6 +63,11 @@ public class BundleCoordinates extends JavaCoordinates<BundleCoordinates> {
     }
 
     @Override
+    public String getType() {
+        return "p2";
+    }
+
+    @Override
     public boolean matches(ArtifactIdentifier artifactIdentifier) {
         if(artifactIdentifier instanceof BundleCoordinates) {
             final BundleCoordinates bundleCoordinates = (BundleCoordinates) artifactIdentifier;

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/MavenCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/MavenCoordinates.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.sw360.antenna.model.artifact.facts.java;
 
+import com.github.packageurl.PackageURLBuilder;
 import org.eclipse.sw360.antenna.model.artifact.ArtifactFactBuilder;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactIdentifier;
 
@@ -59,6 +60,16 @@ public class MavenCoordinates extends JavaCoordinates<MavenCoordinates> {
     @Override
     public String getVersion() {
         return version;
+    }
+
+    @Override
+    public String getType() {
+        return "maven";
+    }
+
+    @Override
+    protected PackageURLBuilder addPurlFacts(PackageURLBuilder builder) {
+        return builder.withNamespace(getGroupId());
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
@@ -63,6 +63,11 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
     }
 
     @Override
+    public String getType() {
+        return "npm";
+    }
+
+    @Override
     public String toString() {
         return name + ":" + version + " (" + artifactId + ")";
     }

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,11 @@
                 <version>0.25.0.RELEASE</version>
             </dependency>
             <dependency>
+                <groupId>com.github.package-url</groupId>
+                <artifactId>packageurl-java</artifactId>
+                <version>1.1.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>3.1.12</version>


### PR DESCRIPTION
Add the support for purls : https://github.com/package-url/purl-spec to artifacts. This is done as getter in the ArtifactCoordinates fact.

Will be tested within the policy engine, as soon as this PR is through