### PR TITLE
fix(gradle): refactored pomPath to toolConfigurationPath and fixed up…

### DIFF
--- a/antenna-documentation/src/site/markdown/tool-configuration.md.vm
+++ b/antenna-documentation/src/site/markdown/tool-configuration.md.vm
@@ -5,7 +5,7 @@ Currently, the configuration is almost the same for all three types (maven, grad
 It is based on the structure of a Maven pom configuration.
 In what follows, the configuration is described and some hints are given if special means have to be taken into account for certain build systems.
 
-For maven, a possible configuration is:
+Below you can find an example for a possible configuration with maven. For other build systems you would create a file with the same xml content but you can omit the maven coordinates.
 
 ```xml
 <plugin>
@@ -40,7 +40,6 @@ For maven, a possible configuration is:
     </configuration>
 </plugin>
 ```
-For other build systems you would create a file with the same xml content but you can omit the maven coordinates.
 
 #[[###]]# Explanation of parameters
 

--- a/assembly/cli/src/site/markdown/index.md.vm
+++ b/assembly/cli/src/site/markdown/index.md.vm
@@ -7,7 +7,7 @@ using the CLI frontend.
 
 #[[##]]# Configuring
 
-${docNameCap} CLI reads the same pom.xml configuration file that the Maven plugin version does.
+${docNameCap} CLI reads a [Tool Configuration](../tool-configuration.html) file (toolConfiguration.xml) that has the same structure as the Maven plugin.
 However, the CLI understands this file only as plain XML and not as a Maven pom.
 This means that some functionality provided by Maven cannot be relied upon.
 
@@ -19,11 +19,11 @@ must describe the original locations of your source artifacts.
 
 * All paths must be absolute.
 
-* For technical reasons variables / properties containing dots will in general not be rendered correctly
+* For technical reasons variables / properties containing dots or hyphens will in general not be rendered correctly in the toolConfiguration.xml
 
-    * No Maven variables can be used except for those properties noted in [WorkflowConfiguration](../workflow-configuration.html)
+    * No Maven variables can be used (except for `project.build.directory`, `project.build.outputDirectory` and `project.basedir`, since they have been added to the context).
 
-    * Properties with a dot in them, like `${system.password}` should be changed to `${systemPassword}` in order to be rendered.
+    * Properties with a dot in them, like `${system.password}` or hyphen, like `${system-password}` should be changed to `${systemPassword}` in order to be rendered.
 
 #[[##]]# Running
 
@@ -44,8 +44,8 @@ ${docNameAllCap}_JAR=/path/to/${docName}.jar
 # Location of custom disclosure document jar file
 DISCLOSURE_DOCUMENT_JAR=
 
-# Pom.xml file for your project
-POM_FILE=osmi-configuration/pom.xml
+# toolConfiguration.xml file for your project
+TOOL_CONF_FILE=osmi-configuration/toolConfiguration.xml
 
 #
 # Run ${docNameCap}
@@ -53,7 +53,7 @@ POM_FILE=osmi-configuration/pom.xml
 
 # Put these together on the classpath and run ${docNameCap}
 CLASSPATH=$${docNameAllCap}_JAR:$DISCLOSURE_DOCUMENT_JAR
-java -cp $CLASSPATH $${antennaCliJavaFilename} $POM_FILE
+java -cp $CLASSPATH $${antennaCliJavaFilename} $TOOL_CONF_FILE
 ```
 
 And the equivalent batch script:
@@ -66,18 +66,18 @@ REM Add your configuration here
 REM Location of main ${docNameCap} jar file
 SET ${docNameAllCap}_JAR=c:\path\to\ ${docName}.jar
 
-REM Pom.xml file for your project
-SET POM_FILE=osmi-configuration\pom.xml
+REM toolConfiguration.xml file for your project
+SET TOOL_CONF_FILE=osmi-configuration\toolConfiguration.xml
 
 REM Run ${docNameCap}
 SET CLASSPATH=%${docNameAllCap}_JAR%
-java -cp %CLASSPATH% %${antennaCliJavaFilename}% %POM_FILE%
+java -cp %CLASSPATH% %${antennaCliJavaFilename}% %TOOL_CONF_FILE%
 ```
 
 Alternatively ${docNameCap} can be run over the command line with this simple line:
 
 ```
-java -jar path\to\ ${docName}.jar path\to\pom.xml
+java -jar path\to\ ${docName}.jar path\to\toolConfiguration.xml
 ```
 
 #[[##]]# Adding workflow steps and plugins
@@ -87,7 +87,7 @@ To do this, the jars need to be added to the classpath.
 If you have a custom plugin `my-custom-plugin` where the jar can be found at `$MY_CUSTOM_PLUGIN_JAR`, then simply add
 ```sh
 CLASSPATH=$ANTENNA_JAR:$MY_CUSTOM_PLUGIN_JAR
-java -cp %CLASSPATH% $${antennaCliJavaFilename} %POM_FILE%
+java -cp %CLASSPATH% $${antennaCliJavaFilename} %TOOL_CONF_FILE%
 ```
 in the script above.
 
@@ -100,10 +100,10 @@ Sometimes a workflow step contains entries with variables that are credentials o
 You can use system environment variables that you have either set in the environment or when executing the analyze command:
 
 ```
-SECRET=password12345 java -jar path\to\ ${docName}.jar path\to\pom.xml
+SECRET=password12345 java -jar path\to\ ${docName}.jar path\to\toolConfiguration.xml
 ```
 
 Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
 ${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
 
-Within both, your `pom.xml` or the `workflow.xml`, you can then reference the variables.
+Within both, your `toolConfiguration.xml` and the `workflow.xml`, you can then reference the variables.

--- a/assembly/gradle-plugin/src/site/markdown/index.md.vm
+++ b/assembly/gradle-plugin/src/site/markdown/index.md.vm
@@ -1,15 +1,14 @@
 # How to use ${docNameCap} as a Gradle plugin
 
-For Gradle, ${docNameCap} is configured in an external configuration file, which is expected to have the same format as the plugin configuration of the `${antennaMavenPluginName}`.
-Please refer to the documentation of [the ${antennaMavenPluginName}](../${docName}-maven-plugin/index.html).
+For Gradle, ${docNameCap}'s tool configuration is contained in an external configuration file, which is expected to have the same format as the plugin configuration of the `${antennaMavenPluginName}`.
+Please refer to the documentation of the [Tool Configuration](../tool-configuration.html).
 
 The plugin itself is configured in your `build.gradle` file by adding the following configuration.
 
 ```groovy
 buildscript{
     repositories {
-        mavenLocal()
-        mavenCentral()
+        jcenter()
         ${antennaGradleRepoAddition}
     }
 
@@ -29,14 +28,13 @@ tasks.withType(Jar) {
 }
 
 repositories {
-    mavenLocal()
-    mavenCentral()
+    jcenter()
 }
 
 version '1.0-SNAPSHOT'
 
-${docNameCap}Configuration{
-    pomPath 'pom.xml'
+AntennaConfiguration{
+    toolConfigurationPath 'toolConfiguration.xml'
     debugEnabled = false
 }
 ```
@@ -50,16 +48,15 @@ If you choose to run ${docNameCap} with Maven, you need to set the maven environ
 ```xml
 <isMavenInstalled>true</isMavenInstalled>
 ```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to the ${docNameCap} configuration in the pom.xml.
-
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to the ${docNameCap} configuration in the toolConfiguration.xml.
 
 * All paths must be absolute.
 
-* For technical reasons variables / properties containing dots will in general not be rendered correctly
+* For technical reasons variables / properties containing dots or hyphens will in general not be rendered correctly in the toolConfiguration.xml
 
     * No Maven variables can be used (except for `project.build.directory`, `project.build.outputDirectory` and `project.basedir`, since they have been added to the context).
 
-    * Properties with a dot in them, like `${system.password}` should be changed to `${systemPassword}` in order to be rendered.
+    * Properties with a dot in them, like `${system.password}` or hyphen, like `${system-password}` should be changed to `${systemPassword}` in order to be rendered.
 
 #[[##]]# Adding workflow steps and plugins
 
@@ -92,7 +89,7 @@ To use this functionality one can give the properties file in the `${docNameCap}
 
 ```groovy
 ${docNameCap}Configuration{
-    pomPath 'pom.xml'
+    toolConfigurationPath 'toolConfiguration.xml'
     propertiesFilePath '/path/to/antenna.properties'
 }
 ```
@@ -105,7 +102,7 @@ ExampleUsername=maxMustermann
 ExamplePassword=12345password
 ```
 
-Within your `pom.xml` or the `workflow.xml` you can then reference variables by the usual xml standard `${ExampleUsername}`.
+Within your `toolConfiguration.xml` and also the `workflow.xml` you can then reference variables by the usual xml standard `${ExampleUsername}`.
 This will get rendered by the `TemplateRenderer` according to the value you assigned to the key in the secrets file.
 
 Note: You should still refrain from using key names containing dots, as the `TemplateRenderer` will not render them correctly.

--- a/assembly/gradle-plugin/src/test/java/org/eclipse/sw360/antenna/frontend/gradle/AntennaGradlePluginTest.java
+++ b/assembly/gradle-plugin/src/test/java/org/eclipse/sw360/antenna/frontend/gradle/AntennaGradlePluginTest.java
@@ -57,7 +57,7 @@ public class AntennaGradlePluginTest {
         System.setProperty("user.dir", projectRoot.toAbsolutePath().toString());
 
         String buildGradle = "plugins {\nid 'org.eclipse.sw360.antenna'\n}\n" +
-                "AntennaConfiguration{\npomPath '" + exampleTestProject.getProjectPom() + "'\n}";
+        "AntennaConfiguration{\ntoolConfigurationPath '" + exampleTestProject.getProjectPom() + "'\n}";
         FileUtils.writeStringToFile(projectRoot.resolve("build.gradle").toFile(), buildGradle, StandardCharsets.UTF_8);
 
         when(project.getBuildDir())

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AnalyzeTask.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AnalyzeTask.java
@@ -28,15 +28,15 @@ public abstract class AnalyzeTask extends DefaultTask {
             extension = new AntennaExtension();
         }
 
-        Path pomPath = Paths.get(System.getProperty("user.dir")).resolve(extension.getPomPath()).toAbsolutePath();
+        Path toolConfigurationPath = Paths.get(System.getProperty("user.dir")).resolve(extension.getToolConfigurationPath()).toAbsolutePath();
 
         AntennaImpl osmRunner;
 
         if(extension.getPropertiesFilePath() != null) {
             Path propertiesFilePath = Paths.get(System.getProperty("user.dir")).resolve(extension.getPropertiesFilePath()).toAbsolutePath();
-            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), pomPath, getProject(), propertiesFilePath);
+            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), toolConfigurationPath, getProject(), propertiesFilePath);
         } else {
-            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), pomPath, getProject());
+            osmRunner = new AntennaImpl(getPluginDescendantArtifactIdName(), toolConfigurationPath, getProject());
         }
 
         osmRunner.execute();

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaExtension.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/AntennaExtension.java
@@ -11,16 +11,16 @@
 package org.eclipse.sw360.antenna.frontend.stub.gradle;
 
 public class AntennaExtension {
-    private String pomPath;
+    private String toolConfigurationPath;
 
     private String propertiesFilePath;
 
-    public String getPomPath() {
-        return pomPath;
+    public String getToolConfigurationPath() {
+        return toolConfigurationPath;
     }
 
-    public void setPomPath(String pomPath) {
-        this.pomPath = pomPath;
+    public void setToolConfigurationPath(String toolConfigurationPath) {
+        this.toolConfigurationPath = toolConfigurationPath;
     }
 
     public String getPropertiesFilePath() {

--- a/example-projects/example-project/build.gradle
+++ b/example-projects/example-project/build.gradle
@@ -36,5 +36,5 @@ repositories {
 version '1.0-SNAPSHOT'
 
 AntennaConfiguration{
-    pomPath 'pom.xml'
+    toolConfigurationPath 'pom.xml'
 }

--- a/example-projects/mvn-test-project/build.gradle
+++ b/example-projects/mvn-test-project/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 AntennaConfiguration{
-    pomPath 'pom.xml'
+    toolConfigurationPath 'pom.xml'
     debugEnabled = false
 }

--- a/example-projects/p2-example-project/build.gradle
+++ b/example-projects/p2-example-project/build.gradle
@@ -27,5 +27,5 @@ repositories {
 }
 
 AntennaConfiguration{
-    pomPath 'pom.xml'
+    toolConfigurationPath 'pom.xml'
 }


### PR DESCRIPTION
… documentation for gradle and cli

-fix
-- refactored pomPath in plugin configuration for gradle to toolConfigurationPath 

- doc improvement
-- removed mavenLocal() and replaced with jcenter() in dependencies (gradle)
-- renamed TinaConfiguration to AntennaConfiguration (gradle)
-- mentioned hyphens can't be used in properties (gradle & cli)
-- renamed pom.xml to toolConfiguration.xml (gradle & cli)
-- renamed POM_FILE to TOOL_CONF_FILE in example for script (cli)

Signed-off-by: Hanna Modica <Hanna.Modica@bosch-si.com>