### PR TITLE
fix(sw360): cpeId is now written with sw360 updater

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
@@ -50,7 +50,7 @@ public class SW360Attributes {
     public static final String RELEASE_COMPONENT_ID = "componentId";
     public static final String RELEASE_NAME = "name";
     public static final String RELEASE_VERSION = "version";
-    public static final String RELEASE_CPE_ID = "cpeid";
+    public static final String RELEASE_CPE_ID = "cpeId";
     public static final String RELEASE_SOURCES = "downloadurl";
     public static final String RELEASE_MAIN_LICENSE_IDS = "mainLicenseIds";
     public static final String RELEASE_EXTERNAL_IDS = "externalIds";


### PR DESCRIPTION
CPE ID of the SW360 Release wasn't written to SW360 due to misconfigured SW360Attributes. Changed attribute, now it's working. 