### PR TITLE
modules(ort): Upgrade the ORT model version

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -21,12 +21,6 @@
     <name>maven-frontend-stub</name>
 
     <repositories>
-        <!-- For ch.frankel.log4k used by ORT -->
-        <repository>
-            <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
-        </repository>
-
         <!-- For ORT -->
         <repository>
             <id>jitpack.io</id>

--- a/modules/ort/pom.xml
+++ b/modules/ort/pom.xml
@@ -24,12 +24,6 @@
     <packaging>jar</packaging>
 
     <repositories>
-        <!-- For ch.frankel.log4k used by ORT -->
-        <repository>
-            <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
-        </repository>
-
         <!-- For ORT -->
         <repository>
             <id>jitpack.io</id>

--- a/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/resolver/OrtResultArtifactResolver.java
+++ b/modules/ort/src/main/java/org/eclipse/sw360/antenna/ort/resolver/OrtResultArtifactResolver.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class OrtResultArtifactResolver implements Function<Package, Artifact> {
-    private SortedMap<Identifier, Map<LicenseFinding, List<PathExclude>>> licenseFindings;
+    private SortedMap<Identifier, Map<LicenseFindings, List<PathExclude>>> licenseFindings;
 
     public OrtResultArtifactResolver(OrtResult result) {
         licenseFindings = result.collectLicenseFindings(false);
@@ -133,7 +133,7 @@ public class OrtResultArtifactResolver implements Function<Package, Artifact> {
         Collection<String> licenses = Optional.ofNullable(licenseFindings.get(pkg.getId()))
                 .map(Map::keySet)
                 .orElse(Collections.emptySet()).stream()
-                .map(LicenseFinding::getLicense)
+                .map(LicenseFindings::getLicense)
                 .collect(Collectors.toList());
 
         return Optional.of(LicenseSupport.mapLicenses(licenses))
@@ -144,9 +144,9 @@ public class OrtResultArtifactResolver implements Function<Package, Artifact> {
         return Optional.ofNullable(licenseFindings.get(pkg.getId()))
                 .map(Map::keySet)
                 .orElse(Collections.emptySet()).stream()
-                .map(LicenseFinding::getCopyrights)
+                .map(LicenseFindings::getCopyrights)
                 .flatMap(Collection::stream)
-                .map(CopyrightFinding::getStatement)
+                .map(CopyrightFindings::getStatement)
                 .map(CopyrightStatement::new)
                 .reduce(CopyrightStatement::mergeWith);
     }

--- a/modules/ort/src/test/resources/scan-result.yml
+++ b/modules/ort/src/test/resources/scan-result.yml
@@ -129,17 +129,43 @@ scanner:
             start_time: "2019-01-07T07:51:42.194Z"
             end_time: "2019-01-07T07:52:10.961Z"
             file_count: 430
-            license_findings:
+            licenses:
             - license: "Apache-2.0"
-              copyrights: []
+              location:
+                path: "path/to/a/file"
+                start_line: 1
+                end_line: 2
             - license: "BSD-2-Clause"
-              copyrights:
-              - "Copyright (c) 2012 Test Person1 <test.person@1.com>"
+              location:
+                path: "path/to/another/file"
+                start_line: 3
+                end_line: 4
             - license: "MIT"
-              copyrights:
-              - "Copyright (c) 2014-2017 Teist Peirson2 <teist.peirson@2.com>"
-              - "Copyright (c) 2015 Teost Peorson3"
-              - "Copyright (c) 2015 Teast Pearson4 <teast.pearson@15.com>"
+              location:
+                path: "path/to/yet/another/file"
+                start_line: 42
+                end_line: 42
+            copyrights:
+            - statement: "Copyright (c) 2012 Test Person1 <test.person@1.com>"
+              location:
+                path: "path/to/another/file"
+                start_line: 2
+                end_line: 2
+            - statement: "Copyright (c) 2014-2017 Teist Peirson2 <teist.peirson@2.com>"
+              location:
+                path: "path/to/yet/another/file"
+                start_line: 39
+                end_line: 39
+            - statement: "Copyright (c) 2015 Teost Peorson3"
+              location:
+                path: "path/to/yet/another/file"
+                start_line: 40
+                end_line: 40
+            - statement: "Copyright (c) 2015 Teast Pearson4 <teast.pearson@15.com>"
+              location:
+                path: "path/to/yet/another/file"
+                start_line: 41
+                end_line: 41
     cache_stats:
       num_reads: 407
       num_hits: 0

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
             <dependency>
                 <groupId>com.github.heremaps.oss-review-toolkit</groupId>
                 <artifactId>model</artifactId>
-                <version>dd6412b9e4</version>
+                <version>547e0bb2d3</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.hateoas</groupId>


### PR DESCRIPTION
This allows to get rid of jcenter for log4k as ORT is using Log4j2 now
[1]. On the "downside" some adaptions due to refactorings in ORT were
necessary.

[1] https://github.com/heremaps/oss-review-toolkit/pull/1729

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>