### PR TITLE
Revert changes that make Tina extensions break

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/jsonreader/JsonReader.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/jsonreader/JsonReader.java
@@ -44,8 +44,8 @@ import java.util.stream.StreamSupport;
 public class JsonReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonReader.class);
     private static final String COMPONENTS = "components";
-    private final Charset encoding;
-    private final Path recordingFile;
+    protected final Charset encoding;
+    protected final Path recordingFile;
     private final Path dependencyDir;
 
     private static final Map<String, MissingLicenseReasons> SPECIAL_INFORMATION = Stream.of(new Object[][] {


### PR DESCRIPTION
During improvement of static code analysis, an improvement has been done, which is incompatible to tina-extensions. This reverts the changes, so that we can build Tina again.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>