### PR TITLE
fix(#286): exclude broken jsonld-java dependency

### DIFF
--- a/assembly/spdx-license-knowledge-base/pom.xml
+++ b/assembly/spdx-license-knowledge-base/pom.xml
@@ -61,6 +61,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.jsonld-java.jsonld-java</groupId>
+                    <artifactId>jsonld-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- ################################ compliance dependency ########################### -->


### PR DESCRIPTION
this closes https://github.com/eclipse/antenna/issues/286