### PR TITLE
Add the BDD testing to the policy engine

### DIFF
--- a/modules/policy/engine-testing/pom.xml
+++ b/modules/policy/engine-testing/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.eclipse.sw360.antenna</groupId>
+        <artifactId>policy-module</artifactId>
+        <version>${revision}${qualifier}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>engine-testing</artifactId>
+    <name>policy-engine-testing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>policy-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>4.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>4.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-picocontainer</artifactId>
+            <version>4.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.11</version>
+        </dependency>
+        <!-- ################################ compliance dependency ########################### -->
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>antenna-license-provider</artifactId>
+            <version>1</version>
+            <classifier>licenseinfo</classifier>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/GivenSteps.java
+++ b/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/GivenSteps.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing;
+
+import cucumber.api.java.en.Given;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.*;
+import org.eclipse.sw360.antenna.model.util.ArtifactUtils;
+import org.eclipse.sw360.antenna.model.xml.generated.License;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseOperator;
+import org.eclipse.sw360.antenna.model.xml.generated.LicenseThreatGroup;
+import org.eclipse.sw360.antenna.util.LicenseSupport;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GivenSteps {
+    private static final String LICENSES_PROP = "licenses";
+    private static final String PROPRIETARY_PROP = "proprietary";
+    private static final String COORDINATES_PROP = "coordinates";
+
+    private ScenarioState state;
+
+    public GivenSteps(ScenarioState state) {
+        this.state = state;
+    }
+
+    @Given("^an artifact with$")
+    public void an_artifact_with(List<List<String>> artifact_facts) {
+        an_artifact_with("Default Name", artifact_facts);
+    }
+
+    @Given("^an artifact called \"([^\"]*)\" with$")
+    public void an_artifact_with(String name, List<List<String>> artifact_facts) {
+        Artifact artifact = new Artifact();
+        mapArtifactFacts(artifact_facts, artifact);
+        state.artifacts.put(name, artifact);
+    }
+
+    private void mapArtifactFacts(List<List<String>> artifact_facts, Artifact artifact) {
+        artifact_facts.forEach(row -> mapProperty(row, artifact));
+    }
+
+    private void mapProperty(List<String> row, Artifact artifact) {
+        switch (getRowPropertyType(row)) {
+            case LICENSES_PROP:
+                addLicenseInformation(row, artifact);
+                break;
+            case PROPRIETARY_PROP:
+                artifact.setProprietary("true".equals(row.get(1)));
+                break;
+            case COORDINATES_PROP:
+                addCoordinates(row, artifact);
+                break;
+            default:
+                throw new IllegalArgumentException("Configuration Error: "
+                        + getRowPropertyType(row) + " is an unknown property for an artifact");
+        }
+    }
+
+    private String getRowPropertyType(List<String> row) {
+        return row.get(0);
+    }
+
+    private void addLicenseInformation(List<String> row, Artifact artifact) {
+        Optional<String> threatGroup = Optional.empty();
+        if (row.size() >= 4) {
+            threatGroup = Optional.ofNullable(row.get(3));
+        }
+        artifact.addFact(parseLicenseExpression(row.get(1), row.get(2), threatGroup));
+    }
+
+    private ArtifactLicenseInformation parseLicenseExpression(String licenseExpression, String expressionType,
+            Optional<String> threatGroup) {
+        if (licenseExpression.contains(" OR ")) {
+            return createLicenseInformation(expressionType,
+                    createLicenseExpression(LicenseOperator.OR, licenseExpression.split(" OR ")));
+        } else if (licenseExpression.contains(" AND ")) {
+            return createLicenseInformation(expressionType,
+                    createLicenseExpression(LicenseOperator.AND, licenseExpression.split(" AND ")));
+        }
+        return createLicenseInformation(expressionType, createLicense(licenseExpression, threatGroup));
+    }
+
+    private LicenseInformation createLicenseExpression(LicenseOperator or, String... licenseExpressionParts) {
+        return LicenseSupport.mapLicenses(Arrays.asList(licenseExpressionParts), or);
+    }
+
+    private static final String UNKNOWN_THREAT_GROUP = "unknown";
+    private static final String LIBERAL_THREAT_GROUP = "liberal";
+    private static final String STRICT_COPYLEFT_THREAT_GROUP = "strict copyleft";
+    private static final String HIGH_RISK_THREAT_GROUP = "high risk";
+    private static final String FREEWARE_THREAT_GROUP = "freeware";
+    private static final String NON_STANDARD_THREAT_GROUP = "non standard";
+
+    private static final Map<String, LicenseThreatGroup> THREAT_GROUP_MAP = Stream.of(new Object[][] {
+            { UNKNOWN_THREAT_GROUP, LicenseThreatGroup.UNKNOWN },
+            { LIBERAL_THREAT_GROUP, LicenseThreatGroup.LIBERAL },
+            { STRICT_COPYLEFT_THREAT_GROUP, LicenseThreatGroup.STRICT_COPYLEFT },
+            { HIGH_RISK_THREAT_GROUP, LicenseThreatGroup.HIGH_RISK },
+            { FREEWARE_THREAT_GROUP, LicenseThreatGroup.FREEWARE },
+            { NON_STANDARD_THREAT_GROUP, LicenseThreatGroup.NON_STANDARD }})
+            .collect(Collectors.toMap(data -> (String) data[0], data -> (LicenseThreatGroup) data[1]));
+
+    private License createLicense(String licenseExpression, Optional<String> threatGroup) {
+        License license = new License();
+        license.setName(licenseExpression);
+        threatGroup.ifPresent(tg -> license.setThreatGroup(THREAT_GROUP_MAP.get(tg)));
+        return license;
+    }
+
+    private static final String DECLARED_LICENSE_EXPRESSION = "Declared";
+    private static final String OBSERVED_LICENSE_EXPRESSION = "Observed";
+    private static final String OVERWRITTEN_LICENSE_EXPRESSION = "Overridden";
+    private static final String CONFIGURED_LICENSE_EXPRESSION = "Configured";
+
+    private ArtifactLicenseInformation createLicenseInformation(String expressionType,
+            LicenseInformation licenseExpression) {
+        switch (expressionType) {
+            case DECLARED_LICENSE_EXPRESSION:
+                return new DeclaredLicenseInformation(licenseExpression);
+            case OBSERVED_LICENSE_EXPRESSION:
+                return new ObservedLicenseInformation(licenseExpression);
+            case OVERWRITTEN_LICENSE_EXPRESSION:
+                return new OverriddenLicenseInformation(licenseExpression);
+            case CONFIGURED_LICENSE_EXPRESSION:
+                return new ConfiguredLicenseInformation(licenseExpression);
+            default:
+                throw new IllegalArgumentException("Configuration Error: " + expressionType
+                        + " is not a defined license expression type");
+        }
+    }
+
+    private void addCoordinates(List<String> row, Artifact artifact) {
+        artifact.addFact(ArtifactUtils.createArtifactCoordinatesFromPurl(row.get(1)));
+    }
+}

--- a/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/ScenarioState.java
+++ b/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/ScenarioState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing;
+
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ScenarioState {
+    Map<String, Artifact> artifacts = new HashMap<>();
+    List<IEvaluationResult> evaluations = new ArrayList<>();
+    List<String> rulesets = new ArrayList<>();
+}

--- a/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/ThenSteps.java
+++ b/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/ThenSteps.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing;
+
+import cucumber.api.java.en.Then;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
+import org.eclipse.sw360.antenna.policy.workflow.processors.PolicyEngineProcessor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThenSteps {
+    private static final String RULESETCONFIGKEY = "ruleset.classes";
+
+    private ScenarioState state;
+
+    public ThenSteps(ScenarioState state) {
+        this.state = state;
+    }
+
+    @Then("^the artifact called \"([^\"]*)\" should fail with policy id \"([^\"]*)\"$")
+    public void the_artifact_should_fail(String name, String policy) {
+        runRules();
+
+        IEvaluationResult evaluationResult = findEvaluation(policy);
+
+        assertThat(evaluationResult.getFailedArtifacts()).hasSize(1);
+        assertThat(evaluationResult.getFailedArtifacts()).containsExactly(state.artifacts.get(name));
+    }
+
+    @Then("^the artifact should fail with policy id \"([^\"]*)\"$")
+    public void the_artifact_should_fail(String policy) {
+        runRules();
+
+        IEvaluationResult evaluationResult = findEvaluation(policy);
+
+        assertThat(state.artifacts).hasSize(1);
+        assertThat(evaluationResult.getFailedArtifacts()).hasSize(1);
+    }
+
+    @Then("^all artifacts fail with policy id \"([^\"]*)\"$")
+    public void all_artifacts_fail(String policy) {
+        runRules();
+
+        IEvaluationResult evaluationResult = findEvaluation(policy);
+
+        assertThat(evaluationResult.getFailedArtifacts()).hasSize(state.artifacts.size());
+    }
+
+    @Then("^no artifact fails$")
+    public void the_artifact_should_pass() {
+        runRules();
+
+        state.evaluations.forEach(evaluation -> assertThat(evaluation.getFailedArtifacts()).hasSize(0));
+    }
+
+    private IEvaluationResult findEvaluation(String policy) {
+        return state.evaluations.stream()
+                .filter(evaluation -> evaluation.getId().equals(policy))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Could not find evaluation policy with id " + policy));
+    }
+
+    private void runRules() {
+        PolicyEngineProcessor testee = new PolicyEngineProcessor();
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(RULESETCONFIGKEY, state.rulesets.stream().collect(Collectors.joining(",")));
+        try {
+            testee.configure(configMap);
+        } catch (AntennaConfigurationException e) {
+            throw new IllegalArgumentException(e);
+        }
+        state.evaluations.addAll(testee.evaluate(state.artifacts.values()).getEvaluationResults());
+    }
+
+}

--- a/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/WhenSteps.java
+++ b/modules/policy/engine-testing/src/main/java/org/eclipse/sw360/antenna/policy/testing/WhenSteps.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing;
+
+import cucumber.api.java.en.When;
+import org.eclipse.sw360.antenna.policy.engine.Ruleset;
+import org.reflections.Reflections;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Set;
+
+public class WhenSteps {
+    private ScenarioState state;
+
+    public WhenSteps(ScenarioState state) {
+        this.state = state;
+    }
+
+    @When("^I use the rule \"([^\"]*)\"$")
+    public void i_use_the_rule(String rule) {
+        Reflections searchEngine = new Reflections("");
+        Set<Class<? extends Ruleset>> rulesets = searchEngine.getSubTypesOf(Ruleset.class);
+        Ruleset relevantRuleset = rulesets.stream()
+                .map(this::createRuleset)
+                .filter(rs -> containsRule(rs, rule))
+                .findFirst().orElseThrow(IllegalStateException::new);
+        state.rulesets = Arrays.asList(relevantRuleset.getClass().getName());
+
+    }
+
+    private boolean containsRule(Ruleset ruleset, String ruleId) {
+        return ruleset.getRules().stream().anyMatch(rule -> ruleId.equalsIgnoreCase(rule.getId()));
+    }
+
+    private Ruleset createRuleset(Class<? extends Ruleset> rulesetclass) {
+        try {
+            return (Ruleset) rulesetclass.getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/RunCucumberTest.java
+++ b/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/RunCucumberTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "src/test/resources/features/",
+        glue = "org.eclipse.sw360.antenna.policy.testing"
+)
+public class RunCucumberTest {
+        // nothing to do, this is just a wrapper to execute the tests
+}

--- a/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/CheckDifferentCoordinates.java
+++ b/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/CheckDifferentCoordinates.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing.rules;
+
+import com.github.packageurl.PackageURL;
+import org.eclipse.sw360.antenna.policy.engine.*;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.eclipse.sw360.antenna.policy.engine.RuleUtils.artifactAppliesToRule;
+import static org.eclipse.sw360.antenna.policy.engine.RuleUtils.artifactRaisesPolicyViolation;
+
+public class CheckDifferentCoordinates implements CompareArtifactRule {
+    private final Ruleset ruleset;
+
+    public CheckDifferentCoordinates(final Ruleset ruleset) {
+        this.ruleset = ruleset;
+    }
+
+    @Override
+    public Optional<PolicyViolation> evaluate(ThirdPartyArtifact leftArtifact, ThirdPartyArtifact rightArtifact) {
+        System.out.println("Execute with " + leftArtifact.toString() + " and " + rightArtifact.toString());
+        if (countComponentTypes(leftArtifact, rightArtifact) > 1) {
+            System.out.println("Policy Violation");
+            return artifactRaisesPolicyViolation(this, leftArtifact, rightArtifact);
+        }
+        return artifactAppliesToRule(this, leftArtifact, rightArtifact);
+    }
+
+    private long countComponentTypes(ThirdPartyArtifact leftArtifact, ThirdPartyArtifact rightArtifact) {
+        return Stream.of(leftArtifact, rightArtifact)
+                .map(ThirdPartyArtifact::getPurl)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(PackageURL::getType)
+                .distinct()
+                .count();
+    }
+
+    @Override
+    public String getId() {
+        return "T2";
+    }
+
+    @Override
+    public String getName() {
+        return "Check components of same type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Two components from different technologies have been found";
+    }
+
+    @Override
+    public RuleSeverity getSeverity() {
+        return RuleSeverity.INFO;
+    }
+
+    @Override
+    public Ruleset getRuleset() {
+        return ruleset;
+    }
+}

--- a/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/CheckForGPL.java
+++ b/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/CheckForGPL.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing.rules;
+
+import org.eclipse.sw360.antenna.policy.engine.*;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.eclipse.sw360.antenna.policy.engine.RuleUtils.artifactAppliesToRule;
+import static org.eclipse.sw360.antenna.policy.engine.RuleUtils.artifactRaisesPolicyViolation;
+
+public class CheckForGPL implements SingleArtifactRule {
+    private final Ruleset ruleset;
+
+    public CheckForGPL(final Ruleset ruleset) {
+        this.ruleset = ruleset;
+    }
+
+    @Override
+    public Optional<PolicyViolation> evaluate(ThirdPartyArtifact thirdPartyArtifact) {
+        if (thirdPartyArtifact.hasLicenses(Arrays.asList("GPL-2.0-only", "AGPL-3.0-or-later")).size() > 0) {
+            return artifactRaisesPolicyViolation(this, thirdPartyArtifact);
+        }
+        return artifactAppliesToRule(this, thirdPartyArtifact);
+    }
+
+    @Override
+    public String getId() {
+        return "T1";
+    }
+
+    @Override
+    public String getName() {
+        return "Check for GPL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A GPL license has been found";
+    }
+
+    @Override
+    public RuleSeverity getSeverity() {
+        return RuleSeverity.ERROR;
+    }
+
+    @Override
+    public Ruleset getRuleset() {
+        return ruleset;
+    }
+}

--- a/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/TestRuleset.java
+++ b/modules/policy/engine-testing/src/test/java/org/eclipse/sw360/antenna/policy/testing/rules/TestRuleset.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.policy.testing.rules;
+
+import org.eclipse.sw360.antenna.policy.engine.Rule;
+import org.eclipse.sw360.antenna.policy.engine.Ruleset;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class TestRuleset implements Ruleset {
+    @Override
+    public String getName() {
+        return "Test Ruleset";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public Collection<Rule> getRules() {
+        return Arrays.asList(new CheckForGPL(this), new CheckDifferentCoordinates(this));
+    }
+}

--- a/modules/policy/engine-testing/src/test/resources/features/T1_CheckForGPL.feature
+++ b/modules/policy/engine-testing/src/test/resources/features/T1_CheckForGPL.feature
@@ -1,0 +1,35 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+Feature: Identify usage of GPL license
+  GPL is a copyleft license which can not be used in this context
+
+  Scenario: Artifact with GPL or one of three other licenses passes the test
+    Given an artifact called "EPL" with
+      | licenses | EPL-1.0 | Declared |
+    And an artifact called "Apache 2.0" with
+      | licenses | Apache-2.0 | Declared |
+    And an artifact called "GPL" with
+      | licenses | GPL-2.0-only | Declared |
+    When I use the rule "T1"
+    Then the artifact called "GPL" should fail with policy id "T1"
+
+  Scenario: Artifact with GPL should fail
+    Given an artifact with
+      | licenses | AGPL-3.0-or-later | Declared |
+    When I use the rule "T1"
+    Then all artifacts fail with policy id "T1"
+
+  Scenario: Artifact without GPL should fail
+    Given an artifact with
+      | licenses | EPL-1.0 | Declared |
+    When I use the rule "T1"
+    Then no artifact fails

--- a/modules/policy/engine-testing/src/test/resources/features/T2_CheckDifferentCoordinates.feature
+++ b/modules/policy/engine-testing/src/test/resources/features/T2_CheckDifferentCoordinates.feature
@@ -1,0 +1,31 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+Feature: Check Multiple Coordinate Types
+  In this test we do not allow components from different technologies in the same project
+
+    Scenario: Artifacts from different technologies fail
+      Given an artifact called "Maven" with
+        | coordinates | pkg:maven/com.something/foo@1.0.0 |
+      And an artifact called "Nuget" with
+        | coordinates | pkg:nuget/bar@2.3.1 |
+      When I use the rule "T2"
+      Then all artifacts fail with policy id "T2"
+
+    Scenario: Artifacts from same technology succeed
+      Given an artifact called "Maven" with
+        | coordinates | pkg:maven/com.something/foo@1.0.0 |
+      And an artifact called "Maven2" with
+        | coordinates | pkg:maven/com.something/bar@2.3.1 |
+      When I use the rule "T2"
+      Then no artifact fails
+
+

--- a/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/CompareArtifactExecutor.java
+++ b/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/CompareArtifactExecutor.java
@@ -38,6 +38,7 @@ class CompareArtifactExecutor implements RuleExecutor {
         return thirdPartyArtifacts.stream()
                 .map(artifact -> findViolationsForLeftHandSide(rule, artifact, thirdPartyArtifacts))
                 .flatMap(Collection::stream)
+                .distinct()
                 .collect(Collectors.toList());
     }
 
@@ -45,6 +46,7 @@ class CompareArtifactExecutor implements RuleExecutor {
             final ThirdPartyArtifact leftHandSide, final Collection<ThirdPartyArtifact> rightHandSides) {
 
         return rightHandSides.stream()
+                .filter(rightHandSide -> !rightHandSide.equals(leftHandSide))
                 .map(rightHandSide -> rule.evaluate(leftHandSide, rightHandSide))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyViolation.java
+++ b/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyViolation.java
@@ -94,4 +94,22 @@ public class PolicyViolation {
     public Collection<ThirdPartyArtifact> getFailingArtifacts() {
         return Collections.unmodifiableCollection(failingArtifacts);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PolicyViolation) {
+            PolicyViolation other = (PolicyViolation) obj;
+            if (rule.getId().equalsIgnoreCase(other.rule.getId())
+                    && failingArtifacts.size() == other.failingArtifacts.size()
+                    && failingArtifacts.containsAll(other.failingArtifacts)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rule, failingArtifacts);
+    }
 }

--- a/modules/policy/pom.xml
+++ b/modules/policy/pom.xml
@@ -28,5 +28,6 @@
 
     <modules>
         <module>engine</module>
+        <module>engine-testing</module>
     </modules>
 </project>


### PR DESCRIPTION
* Add general step definition files for policy testing
* Add test rules and bdd based testing of the rules to validate functionality
* Testing can also be used as templete for real world rule development
* fix issues in policy engine execution found by tests

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>