### PR TITLE
Ensure correct roundtrip of purl functionality

### DIFF
--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/MavenCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/java/MavenCoordinates.java
@@ -69,7 +69,7 @@ public class MavenCoordinates extends JavaCoordinates<MavenCoordinates> {
 
     @Override
     protected PackageURLBuilder addPurlFacts(PackageURLBuilder builder) {
-        return builder.withNamespace(getGroupId());
+        return builder.withNamespace(getGroupId()).withName(getArtifactId());
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.sw360.antenna.model.artifact.facts.javaScript;
 
+import com.github.packageurl.PackageURLBuilder;
 import org.eclipse.sw360.antenna.model.artifact.ArtifactFactBuilder;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactIdentifier;
@@ -65,6 +66,11 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
     @Override
     public String getType() {
         return "npm";
+    }
+
+    @Override
+    protected PackageURLBuilder addPurlFacts(PackageURLBuilder builder) {
+        return builder.withNamespace(getName()).withName(getArtifactId());
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch Software Innovations GmbH 2018-2019.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactUtilPurlTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactUtilPurlTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.model.test;
+
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.dotnet.DotNetCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.BundleCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.javaScript.JavaScriptCoordinates;
+import org.eclipse.sw360.antenna.model.util.ArtifactUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ArtifactUtilPurlTest {
+    private static final String MAVENPURL = "pkg:maven/com.something/foo@1.2.3";
+    private static final String P2PURL = "pkg:p2/com.something.foo@1.2.3";
+    private static final String NUGETPURL = "pkg:nuget/foo-dll@1.2.3";
+    private static final String JSNAMESPACEPURL = "pkg:npm/%40angular/animation@1.2.3";
+    private static final String JSSIMPLEPURL = "pkg:npm/foobar@12.3.1";
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { MAVENPURL, MavenCoordinates.class },
+                { P2PURL, BundleCoordinates.class },
+                { NUGETPURL, DotNetCoordinates.class },
+                { JSNAMESPACEPURL, JavaScriptCoordinates.class },
+                { JSSIMPLEPURL, JavaScriptCoordinates.class }
+        });
+    }
+
+    private String inputPurl;
+    private Class<ArtifactCoordinates> expectedCoordinateClass;
+
+    public ArtifactUtilPurlTest(String inputPurl, Class<ArtifactCoordinates> expectedCoordinateClass) {
+        this.inputPurl = inputPurl;
+        this.expectedCoordinateClass = expectedCoordinateClass;
+    }
+
+    @Test
+    public void testPurlRoundtrip() {
+        ArtifactCoordinates coordinates = ArtifactUtils.createArtifactCoordinatesFromPurl(inputPurl);
+
+        assertThat(coordinates).isInstanceOf(expectedCoordinateClass);
+        assertThat(coordinates.getPurl().canonicalize()).isEqualTo(inputPurl);
+    }
+}


### PR DESCRIPTION
* Add a roundtrip test starting from a purl and comparing the result of the AntennaCoordinates purl creator with the original purl for all coordinates types except generic
* Fix bugs in the purl generation of AntennaCoordinates

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>