### PR TITLE
fix(gradle): correct resolving of basedir in config files

### DIFF
--- a/assembly/gradle-plugin/build.gradle
+++ b/assembly/gradle-plugin/build.gradle
@@ -14,6 +14,8 @@ repositories {
 dependencies {
     compile gradleApi()
     testCompile gradleTestKit()
+    testCompile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
+    testCompile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
     // other dependencies are prepared by maven
     compile fileTree(dir: 'target/dependencies/compile', include: '*.jar')
     runtime fileTree(dir: 'target/dependencies/runtime', include: '*.jar')

--- a/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AntennaCLISettingsReader.java
+++ b/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AntennaCLISettingsReader.java
@@ -16,7 +16,6 @@ import org.eclipse.sw360.antenna.api.FrontendCommons;
 import org.eclipse.sw360.antenna.api.configuration.ToolConfiguration;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaConfigurationException;
 import org.eclipse.sw360.antenna.api.exceptions.AntennaExecutionException;
-import org.eclipse.sw360.antenna.model.util.Utils;
 import org.eclipse.sw360.antenna.model.xml.generated.Workflow;
 import org.eclipse.sw360.antenna.util.TemplateRenderer;
 import org.eclipse.sw360.antenna.util.XmlSettingsReader;
@@ -124,13 +123,11 @@ public class AntennaCLISettingsReader {
 
     private XmlSettingsReader getSettingsReader(MetaDataStoringProject project) {
         File pomFile = project.getConfigFile();
-        Path parent = Utils.getParent(pomFile.toPath())
-                .orElseThrow(() -> new IllegalArgumentException("Could not get parent dir from pomFile=[" + pomFile + "]"));
 
         // Since we are not Maven we must render the pom.xml first
         HashMap<String, Object> contextMap = new HashMap<>();
         contextMap.put("project", project);
-        contextMap.put("basedir", parent.toString());
+        contextMap.put("basedir", project.getBasedir());
 
         Optional.ofNullable(project.getPropertiesFile())
                 .map(this::mapProperties)

--- a/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/WrappedGradleProject.java
+++ b/core/frontend-stubs/gradle-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/gradle/WrappedGradleProject.java
@@ -48,6 +48,11 @@ public class WrappedGradleProject extends MetaDataStoringProject {
     }
 
     @Override
+    public File getBasedir() {
+        return innerProject.getRootDir();
+    }
+
+    @Override
     public Object getRawProject() {
         return innerProject;
     }


### PR DESCRIPTION
This PR is the sequel to https://github.com/eclipse/antenna/commit/9e17b2aa2badd963fa65a63ed9137ac9f83c79a6. The property `${project.basedir}` or `${basedir}` was not correctly resolved if the tool configuration file (pom.xml) was not placed in the root directory of the project but in the sub directories.

Signed-off-by: Onur Demirci <Onur.Demirci@Bosch-si.com>