### PR TITLE
feat(doc): prepare documentation for hosting on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Antenna can be used with Java versions 9 or newer.
 However, it requires some additional configuration described in [Tool Configuration](antenna-documentation/src/site/markdown/tool-configuration.md.vm/#additional-configuration-for-java-9-or-newer).
 
  *To find answers in the most frequent questions/problems go to [Troubleshooting](antenna-documentation/src/site/markdown/troubleshooting.md.vm).*
+
+### Documentation
+
+For more information please refer to our [documentation](https://eclipse.github.io/antenna/).

--- a/antenna-documentation/Jenkinsfile.eclipse.documentation
+++ b/antenna-documentation/Jenkinsfile.eclipse.documentation
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/*
+ * This is an additional Jenkinsfile, for building the documentation
+ * with the GitHub site-maven-plugin within the Eclipse Foundation infrastructure
+ */
+
+pipeline {
+    agent any
+
+    tools {
+        maven 'apache-maven-latest'
+        jdk 'adoptopenjdk-hotspot-jdk8-latest'
+    }
+
+    environment {
+        GITHUB_CREDENTIALS = credentials('7d588c11-a40f-4529-bcaa-57b6d9691af6')
+    }
+    stages {
+        stage('Configure Git') {
+            steps {
+                sh 'git config --global user.name "${GITHUB_CREDENTIALS_USR}"'
+                sh 'git config --global user.email "${GITHUB_CREDENTIALS_USR}@eclipse.org"'
+            }
+        }
+        stage('Site Deploy') {
+            steps {
+                sh 'antenna-documentation/scripts/main.sh'
+            }
+        }
+    }
+}

--- a/antenna-documentation/pom.xml
+++ b/antenna-documentation/pom.xml
@@ -71,6 +71,39 @@
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
+        <profile>
+            <id>site-deploy</id>
+            <activation>
+                <property>
+                    <name>site-deploy</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.github</groupId>
+                        <artifactId>site-maven-plugin</artifactId>
+                        <configuration>
+                            <message>Creating documentation on Github Pages for ${project.name} ${project.version}</message>
+                            <merge>true</merge>
+                            <path>${ANTENNA_DOCUMENTATION_VERSION}</path>
+                            <noJekyll>true</noJekyll>
+                            <userName>${GITHUB_USERNAME}</userName>
+                            <password>${GITHUB_PASSWORD}</password>
+                            <outputDirectory>${basedir}/target/documentation</outputDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>site</goal>
+                                </goals>
+                                <phase>site-deploy</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -216,6 +249,4 @@
             </resource>
         </resources>
     </build>
-
-
 </project>

--- a/antenna-documentation/scripts/documentation_release.sh
+++ b/antenna-documentation/scripts/documentation_release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+set -e
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+CURRENT_TAG="$(git describe --tag)"
+
+createDocumentation() {
+  "${BASEDIR}"/execute_github_site_maven_plugin.sh "$CURRENT_TAG"
+}
+
+createNewIndexRootFile() {
+  fetchGhPages
+  "${BASEDIR}"/writeIndexRootFile.sh
+  pushGhPages
+}
+
+fetchGhPages() {
+  git fetch "https://github.com/eclipse/antenna.git" gh-pages:gh-pages
+}
+
+pushGhPages() {
+  if ! grep -E '^[[:alnum:]]*$' <<< "$GITHUB_CRENDETIALS_PSW"; then
+    echo "WARN: password might contain special characters, which generate problems in the following URL."
+  fi
+  if ! grep -E '^[[:alnum:]]*$' <<< "$GITHUB_CRENDETIALS_USR"; then
+    echo 'WARN: username might contain special characters, which generate problems in the following URL.'
+  fi
+  git push "https://${GITHUB_CREDENTIALS_USR}:${GITHUB_CREDENTIALS_PSW}@github.com/eclipse/antenna.git" gh-pages
+
+}
+
+createDocumentation
+createNewIndexRootFile

--- a/antenna-documentation/scripts/execute_github_site_maven_plugin.sh
+++ b/antenna-documentation/scripts/execute_github_site_maven_plugin.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+set -e
+
+mvn -q -B clean install -DskipTests -P ci
+
+GITHUB_USERNAME="${GITHUB_CREDENTIALS_USR}" \
+    GITHUB_PASSWORD="${GITHUB_CREDENTIALS_PSW}" \
+    ANTENNA_DOCUMENTATION_VERSION=$1 \
+    mvn -f ./antenna-documentation/pom.xml \
+        site-deploy -Psite-deploy

--- a/antenna-documentation/scripts/main.sh
+++ b/antenna-documentation/scripts/main.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+set -e
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+PROJECT_VERSION="$(mvn -q\
+    -Dexec.executable=echo \
+    -Dexec.args='${project.version}' \
+    --non-recursive \
+    exec:exec)"
+
+if [[ "$PROJECT_VERSION" == *"SNAPSHOT" ]]; then
+  "${BASEDIR}"/execute_github_site_maven_plugin.sh SNAPSHOT
+else
+  "${BASEDIR}"/documentation_release.sh
+fi

--- a/antenna-documentation/scripts/writeIndexRootFile.sh
+++ b/antenna-documentation/scripts/writeIndexRootFile.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+set -e
+
+generateIndexFile() {
+  cat <<EOF
+  <!DOCTYPE html>
+  <html lang="en">
+      <head>
+          <meta charset="utf-8">
+          <title>SW360 Antenna Documentation</title>
+      </head>
+      <body>
+          <h1>SW360 Antenna Documentation</h1>
+          <p>The following versions of our documentation are available:</p>
+          <ol>
+EOF
+
+  for DIRECTORY in */
+  do
+    dir=$(basename "$DIRECTORY")
+    echo "          <li><a href='https://eclipse.github.io/antenna/${dir}'>${dir}</a></li>"
+  done
+
+  cat <<EOF
+          </ol>
+          <p>This project is hosted on GitHub as
+              <a href="https://github.com/eclipse/antenna">eclipse/antenna</a>.
+          </p>
+          <p>For more information about this project, check out our
+              <a href="https://eclipse.org/antenna">project website</a>.
+          </p>
+      </body>
+  </html>
+EOF
+}
+
+CURRENT_COMMIT=$(git describe --tag)
+
+# checkout gh-pages branch and delete untracked files and directories
+git checkout gh-pages
+git clean -fd
+
+generateIndexFile | tee index.html
+# if there is a difference after writing the index html, commit
+if ! git diff-index HEAD; then
+  git add index.html
+  git commit -m "update index file to be according to new version ${CURRENT_COMMIT}" -s
+fi
+
+git checkout "${CURRENT_COMMIT}"

--- a/assembly/gradle-plugin/pom.xml
+++ b/assembly/gradle-plugin/pom.xml
@@ -123,7 +123,7 @@
                     <execution>
                         <id>gradle-build</id>
                         <phase>prepare-package</phase>
-                        <configuration>
+                        <configuration combine.self="override">
                             <executable>${gradle.executable}</executable>
                             <arguments>
                                 <argument>clean</argument>
@@ -175,6 +175,34 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <!-- this profile is for cases when a ci fails due to vm failures in gradle -->
+            <id>ci</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration combine.self="override">
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>clean</argument>
+                                        <argument>${gradle.task}</argument>
+                                        <argument>-Pversion=${project.version}</argument>
+                                        <argument>-Pdescription=${project.description}</argument>
+                                        <argument>-S</argument>
+                                        <argument>--no-daemon</argument>
+                                    </arguments>
+                                    <skip>${skip.gradle.build}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>windows</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,8 @@
     </properties>
 
     <scm>
-        <connection>
-            scm:git:https://github.com/eclipse/antenna
-        </connection>
+        <url>https://github.com/eclipse/antenna</url>
+        <connection>scm:git:https://github.com/eclipse/antenna</connection>
         <tag>HEAD</tag>
     </scm>
 
@@ -381,6 +380,11 @@
         </resources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.12</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven</groupId>
                     <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Added GitHubs `site-maven-plugin` to the antenna-documentation `pom.xml` in new profile `site-deploy`. 

This allows to generate and push the static documentation content to the `gh-pages` branch when activating the `-Psite-deploy` profile when running `mvn clean site-deploy` in the `antenna-documentation` directory