### PR TITLE
feat(doc): follow up to #303 pull request template for antenna

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,34 @@
-# PULL REQUEST TEMPLATE
+### Pull Request
 
-## Description
+#### Description
 > Please provide a summary of your changes here. 
 > * Which issue is this pull request belonging to? (*Refer to issue here*)
 > * How is it solving the issue?
 > * Did you add any new dependencies that are required for your change?
 
-## Commit Messages  
+#### Commit Messages  
 >    The commit messages should follow the syntax for [auto-closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords). 
 >    It is preferred if you reference the issue in your commit message.
-> 
-## Request Reviewer
+
+#### Request Reviewer
 > You can add desired reviewers here with an @mention.  
 > For a full list of reviewers check out the *Committers* slot on [the project site](https://projects.eclipse.org/projects/technology.sw360.antenna/who).
 
-## Type of Change
+#### Type of Change
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Improvements
 - [ ] Documentation update
 - [ ] Other
 
-## How Has This Been Tested?
+#### How Has This Been Tested?
 - [ ] Specific Unit Test
 - [ ] Executing the Example Projects
 - [ ] `mvn test` of whole project
 - [ ] `mvn test` of submodule
 - [ ] `gradle test` (for the gradle plugin)
 
-## Checklist
+#### Checklist
 - [ ] My code follows the style and guidelines of this project
 - [ ] I have self-reviewed my code 
 - [ ] I have provided tests that prove my change is working 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ The process described here has several goals:
 - Maintain Antenna's quality
 - Enable a sustainable system for maintainers to review contributions
 
-Please follow these steps, detailed in the [pull request template](.github/PULL_REQUEST_TEMPLATE/pull_request_template.md), to have your contribution considered by the maintainers:
+Please follow these steps, detailed in the [pull request template](.github/pull_request_template.md), to have your contribution considered by the maintainers:
 
 1. Describe in your PR what you have done, what this is fixing or introducing and why this isn't regressive. 
 If there is an issue to your PR, please link it. 


### PR DESCRIPTION
I moved the pull-request-template one folder up.
According to this https://github.community/t5/How-to-use-Git-and-GitHub/Multiple-Pull-Request-Templates/m-p/20909
it is not possible to have multiple pull request templates at once by automation.
Since so far we only have one pull request template I propose
to use this as a temporary solution until GitHub actually supports
multiple pull request templates.

Signed-off-by: Stephanie Neubauer <Stephanie.Neubauer@bosch-si.com>