### PR TITLE
fix(sw360): Fix license handling in SW360Updater

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -121,11 +121,13 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
 
     @JsonIgnore
     public SW360Release setMainLicenseIds(Set<String> mainLicenseIds) {
-        List<SW360SparseLicense> licenses = mainLicenseIds.stream()
-                .map(licenseId -> new SW360SparseLicense()
-                        .setShortName(licenseId))
-                .collect(Collectors.toList());
-        get_Embedded().setLicenses(licenses);
+        if (mainLicenseIds.size() > 0) {
+            List<SW360SparseLicense> licenses = mainLicenseIds.stream()
+                    .map(licenseId -> new SW360SparseLicense()
+                            .setShortName(licenseId))
+                    .collect(Collectors.toList());
+            get_Embedded().setLicenses(licenses);
+        }
         return this;
     }
 
@@ -259,12 +261,12 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
         return this;
     }
 
-    public SW360Release setExternalIds(Map<String,String> externalIds) {
+    public SW360Release setExternalIds(Map<String, String> externalIds) {
         this.externalIds.putAll(externalIds);
         return this;
     }
 
-    public SW360Release setAdditionalData(Map<String,String> additionalData) {
+    public SW360Release setAdditionalData(Map<String, String> additionalData) {
         this.additionalData.putAll(additionalData);
         return this;
     }
@@ -283,11 +285,11 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
             setMainLicenseIds(releaseWithPrecedence.getMainLicenseIds());
         }
         Self releaseIdWithPrecedence = releaseWithPrecedence.get_Links().getSelf();
-        if(releaseIdWithPrecedence != null && ! releaseIdWithPrecedence.getHref().isEmpty()) {
+        if (releaseIdWithPrecedence != null && !releaseIdWithPrecedence.getHref().isEmpty()) {
             get_Links().setSelf(releaseIdWithPrecedence);
         }
         Self componentIdWithPrecedence = releaseWithPrecedence.get_Links().getSelfComponent();
-        if(componentIdWithPrecedence != null && ! componentIdWithPrecedence.getHref().isEmpty()) {
+        if (componentIdWithPrecedence != null && !componentIdWithPrecedence.getHref().isEmpty()) {
             get_Links().setSelfComponent(componentIdWithPrecedence);
         }
         externalIds.putAll(releaseWithPrecedence.externalIds);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
@@ -13,12 +13,16 @@ package org.eclipse.sw360.antenna.sw360.workflow.generators;
 import org.eclipse.sw360.antenna.api.IAttachable;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
+import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.sw360.SW360MetaDataUpdater;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
+import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class SW360UpdaterImpl {
     private final String projectName;
@@ -37,9 +41,16 @@ public class SW360UpdaterImpl {
         try {
             List<SW360Release> releases = new ArrayList<>();
             for (Artifact artifact : intermediates) {
-                Set<String> licenses = sw360MetaDataUpdater.getOrCreateLicenses(artifact);
+                List<License> availableLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
+
+                Set<SW360License> detectedLicenses = sw360MetaDataUpdater.getLicenses(availableLicenses);
+                Set<String> licenseIds = Collections.emptySet();
+                if (detectedLicenses.size() == availableLicenses.size()) {
+                    licenseIds = detectedLicenses.stream().map(SW360License::getShortName).collect(Collectors.toSet());
+                }
+
                 SW360Component component = sw360MetaDataUpdater.getOrCreateComponent(artifact);
-                releases.add(sw360MetaDataUpdater.getOrCreateRelease(artifact, licenses, component));
+                releases.add(sw360MetaDataUpdater.getOrCreateRelease(artifact, licenseIds, component));
             }
             sw360MetaDataUpdater.createProject(projectName, projectVersion, releases);
         } catch (IOException e) {
@@ -47,5 +58,4 @@ public class SW360UpdaterImpl {
         }
         return Collections.emptyMap();
     }
-
 }


### PR DESCRIPTION
Wrong behavior: Updater creates a license for every piece of license string found and always fill in Main Licenses
Right behavior: Updater only checks for availability of license and sets only those licenses in Main Licenses, that are already known.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>