### PR TITLE
Add utils for parsing SPDX license statemens

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -181,6 +181,10 @@
             <artifactId>model</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <artifactId>spdx-utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>

--- a/core/model/src/main/resources/bindings.xjb
+++ b/core/model/src/main/resources/bindings.xjb
@@ -196,12 +196,24 @@
                     if (isEmpty()) {
                         return "";
                     }
+                    if (getLeftStatement() == null) {
+                        return getRightStatement().evaluate();
+                    }
+                    if (getRightStatement() == null) {
+                        return getLeftStatement().evaluate();
+                    }
                     return String.format("( %s %s %s )", getLeftStatement().evaluate(), op.value(), getRightStatement().evaluate());
                 }
 
                 public String evaluateLong() {
                     if (isEmpty()) {
-                        return evaluate();
+                        return "";
+                    }
+                    if (getLeftStatement() == null) {
+                        return getRightStatement().evaluateLong();
+                    }
+                    if (getRightStatement() == null) {
+                        return getLeftStatement().evaluateLong();
                     }
                     return String.format("( %s %s %s )", getLeftStatement().evaluateLong(), op.value(), getRightStatement().evaluateLong());
                 }
@@ -211,6 +223,7 @@
                         return new java.util.ArrayList<>();
                     }
                     return java.util.stream.Stream.of(getLeftStatement().getLicenses(), getRightStatement().getLicenses())
+                            .filter(java.util.Objects::nonNull)
                             .flatMap(java.util.Collection::stream)
                             .distinct()
                             .collect(java.util.stream.Collectors.toList());

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <artifactId>spdx-utils</artifactId>
+        </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherImpl.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseEmbedded;
+import org.eclipse.sw360.antenna.util.LicenseSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,8 +102,8 @@ public class SW360EnricherImpl {
     }
 
     private void addLicenseFact(Optional<String> licenseList, Artifact artifact, Function<LicenseInformation, ArtifactLicenseInformation> licenseCreator) {
-        licenseList.map(this::makeLicenseStatementFromString)
-                .map(licenseCreator::apply)
+        licenseList.map(LicenseSupport::fromSPDXExpression)
+                .map(licenseCreator)
                 .ifPresent(artifact::addFact);
     }
 
@@ -110,13 +111,6 @@ public class SW360EnricherImpl {
         final Map<String, String> purls = sw360Release.getPurls();
         return purls.values().stream()
                 .map(ArtifactUtils::createArtifactCoordinatesFromPurl);
-    }
-
-    private License makeLicenseStatementFromString(String license) {
-        License license1 = new License();
-        license1.setName(license);
-
-        return license1;
     }
 
     private void addSourceUrlIfAvailable(Artifact artifact, SW360Release release) {

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
@@ -116,7 +116,7 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
 
         assertThat(artifact0.askFor(ObservedLicenseInformation.class).isPresent()).isTrue();
         License tempOLicense = new License();
-        tempOLicense.setName("A Test License");
+        tempOLicense.setName("A-Test-License");
         assertThat(artifact0.askForGet(ObservedLicenseInformation.class).get().getLicenses()).contains(tempOLicense);
 
         LicenseStatement licenseStatement = new LicenseStatement();
@@ -242,7 +242,7 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
 
 
         sw360Release.setDeclaredLicense("Apache-2.0");
-        sw360Release.setObservedLicense("A Test License");
+        sw360Release.setObservedLicense("A-Test-License");
         sw360Release.setPurls(Collections.singletonMap(PackageURL.StandardTypes.MAVEN,
                 PackageURLBuilder.aPackageURL()
                 .withName("test")

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>5.1.2.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ort.rev>547e0bb2d3</ort.rev>
     </properties>
 
     <scm>
@@ -263,7 +264,12 @@
             <dependency>
                 <groupId>com.github.heremaps.oss-review-toolkit</groupId>
                 <artifactId>model</artifactId>
-                <version>547e0bb2d3</version>
+                <version>${ort.rev}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+                <artifactId>spdx-utils</artifactId>
+                <version>${ort.rev}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.hateoas</groupId>


### PR DESCRIPTION
### Description
We want to store and recover SPDX expressions in SW360, and therefore we need
parsing capabilities.

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
- [x] Bug fix
- [x] New feature
- [x] Improvements

### How Has This Been Tested?
- [x] Specific Unit Test
- [ ] Executing the Example Projects
- [x] `mvn test` of whole project
- [x] `mvn test` of submodule
- [x] `gradle test` (for the gradle plugin)

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [x] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes