### PR TITLE
infra(update): Update jaxb2 to avoid a bogus warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,12 +422,12 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>2.5.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.11.0</version>
+                            <version>1.11.1</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
This should make the warning

> The POM for org.glassfish.jaxb:jaxb-runtime:jar:2.2.11 is invalid

from Maven go away.