### PR TITLE
Improve JavaScriptCoordinates and fix SW360ComponentAdapterUtils::createComponentName 

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/jsonreader/JsonReader.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/jsonreader/JsonReader.java
@@ -268,9 +268,9 @@ public class JsonReader {
     private Optional<ArtifactCoordinates> mapJavaScriptCoordinates(JsonObject objCoordinates) {
         if (objCoordinates != null) {
             JavaScriptCoordinates.JavaScriptCoordinatesBuilder c = new JavaScriptCoordinates.JavaScriptCoordinatesBuilder();
-            c.setName((String) objCoordinates.get("name"));
+            setJavaScriptCoordinatesPackageName(c, (String) objCoordinates.get("name"));
+            setJavaScriptCoordinatesNamespace(c, (String) objCoordinates.get("name"));
             c.setVersion((String) objCoordinates.get("version"));
-            c.setArtifactId(objCoordinates.get("name") + "-" + objCoordinates.get("version"));
             return Optional.of(c.build());
         }
         return Optional.empty();
@@ -300,6 +300,30 @@ public class JsonReader {
             }
         }
         return Optional.empty();
+    }
+
+    private void setJavaScriptCoordinatesNamespace(JavaScriptCoordinates.JavaScriptCoordinatesBuilder jsCoordsBuilder, String name) {
+        String[] nameParts = name.split("/");
+
+        if (nameParts.length > 1 && nameParts[0].startsWith("@")) {
+            jsCoordsBuilder.setNamespace(nameParts[0]);
+        }
+    }
+
+    private void setJavaScriptCoordinatesPackageName(JavaScriptCoordinates.JavaScriptCoordinatesBuilder jsCoordsBuilder, String name) {
+        String[] nameParts = name.split("/");
+
+        if (nameParts.length == 1) {
+            jsCoordsBuilder.setPackageName(name);
+        } else if (nameParts.length > 1) {
+            if (nameParts[0].startsWith("@")) {
+                jsCoordsBuilder.setPackageName(Arrays.asList(nameParts).stream()
+                        .skip(1)
+                        .collect(Collectors.joining("/")));
+            } else {
+                jsCoordsBuilder.setPackageName(name);
+            }
+        }
     }
 
     private String mapArtifactDownloadurl(JsonObject obj) {

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerImpl.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerImpl.java
@@ -143,7 +143,7 @@ public class CsvAnalyzerImpl {
             case "dotnet":
                 return new DotNetCoordinates(record.get(NAME), record.get(VERSION));
             case "javascript":
-                return new JavaScriptCoordinates(record.get(NAME), record.get(GROUP), record.get(VERSION));
+                return new JavaScriptCoordinates(record.get(GROUP), record.get(NAME), record.get(VERSION));
             case "bundle":
                 return new BundleCoordinates(record.get(NAME), record.get(VERSION));
             default:

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/jsonreader/JsonReaderTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/jsonreader/JsonReaderTest.java
@@ -118,7 +118,7 @@ public class JsonReaderTest {
                 .ifPresent(jsC -> {
                     assertThat(jsC.getName()).isEqualTo("process");
                     assertThat(jsC.getVersion()).isEqualTo("0.5.1");
-                    assertThat(jsC.getArtifactId()).isEqualTo("process-0.5.1");
+                    assertThat(jsC.getNamespace()).isNull();
                 });
 
         artifacts.stream()

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/javaScript/JavaScriptCoordinates.java
@@ -20,17 +20,19 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.eclipse.sw360.antenna.model.artifact.ArtifactSelectorHelper.compareStringsAsWildcard;
 
 public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordinates> {
-    private final String artifactId;
-    private final String name;
+    private final String namespace;
+    private final String packageName;
     private final String version;
 
-    public JavaScriptCoordinates(String artifactId, String name, String version) {
-        this.artifactId = artifactId;
-        this.name = name;
+    public JavaScriptCoordinates(String namespace, String packageName, String version) {
+        this.namespace = namespace;
+        this.packageName = packageName;
         this.version = version;
     }
 
@@ -42,10 +44,10 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
     @Override
     public JavaScriptCoordinates mergeWith(JavaScriptCoordinates resultWithPrecedence) {
         return new JavaScriptCoordinates(
-                Optional.ofNullable(resultWithPrecedence.getArtifactId())
-                        .orElse(Optional.ofNullable(getArtifactId())
+                Optional.ofNullable(resultWithPrecedence.getNamespace())
+                        .orElse(Optional.ofNullable(getNamespace())
                                 .orElse(null)),
-                Optional.ofNullable(resultWithPrecedence.getName())
+                Optional.ofNullable(resultWithPrecedence.getPackageName())
                         .orElse(Optional.ofNullable(getName())
                                 .orElse(null)),
                 Optional.ofNullable(resultWithPrecedence.getVersion())
@@ -55,7 +57,10 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
 
     @Override
     public String getName() {
-        return name;
+        return Stream.of(namespace, packageName)
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining("/"));
     }
 
     @Override
@@ -70,34 +75,41 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
 
     @Override
     protected PackageURLBuilder addPurlFacts(PackageURLBuilder builder) {
-        return builder.withNamespace(getName()).withName(getArtifactId());
+        return builder.withNamespace(namespace).withName(packageName);
     }
 
     @Override
     public String toString() {
-        return name + ":" + version + " (" + artifactId + ")";
+        return Stream.of(namespace, packageName, version)
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(":"));
     }
 
     @Override
     public boolean isEmpty() {
-        return (name == null || "".equals(name)) &&
+        return (packageName == null || "".equals(packageName)) &&
                 (version == null || "".equals(version)) &&
-                (artifactId == null || "".equals(artifactId));
+                (namespace == null || "".equals(namespace));
     }
 
     @Override
     public boolean matches(ArtifactIdentifier artifactIdentifier) {
         if(artifactIdentifier instanceof JavaScriptCoordinates) {
             final JavaScriptCoordinates javaScriptCoordinates = (JavaScriptCoordinates) artifactIdentifier;
-            return compareStringsAsWildcard(artifactId, javaScriptCoordinates.getArtifactId()) ||
-                    compareStringsAsWildcard(name, javaScriptCoordinates.getName()) ||
+            return compareStringsAsWildcard(namespace, javaScriptCoordinates.getNamespace()) ||
+                    compareStringsAsWildcard(packageName, javaScriptCoordinates.getName()) ||
                     compareStringsAsWildcard(version, javaScriptCoordinates.getVersion());
         }
         return false;
     }
 
-    public String getArtifactId() {
-        return artifactId;
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getPackageName() {
+        return packageName;
     }
 
     @Override
@@ -105,30 +117,30 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JavaScriptCoordinates that = (JavaScriptCoordinates) o;
-        return Objects.equals(artifactId, that.artifactId) &&
-                Objects.equals(name, that.name) &&
+        return Objects.equals(namespace, that.namespace) &&
+                Objects.equals(packageName, that.packageName) &&
                 Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(artifactId, name, version);
+        return Objects.hash(namespace, packageName, version);
     }
 
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class JavaScriptCoordinatesBuilder
             implements ArtifactFactBuilder {
-        protected String artifactId;
-        protected String name;
+        protected String namespace;
+        protected String packageName;
         protected String version;
 
-        public JavaScriptCoordinatesBuilder setArtifactId(String value) {
-            this.artifactId = value;
+        public JavaScriptCoordinatesBuilder setNamespace(String value) {
+            this.namespace = value;
             return this;
         }
 
-        public JavaScriptCoordinatesBuilder setName(String value) {
-            this.name = value;
+        public JavaScriptCoordinatesBuilder setPackageName(String value) {
+            this.packageName = value;
             return this;
         }
 
@@ -139,16 +151,16 @@ public class JavaScriptCoordinates extends ArtifactCoordinates<JavaScriptCoordin
 
         @Override
         public JavaScriptCoordinates build() {
-            if(artifactId != null) {
-                artifactId = artifactId.trim();
+            if(namespace != null) {
+                namespace = namespace.trim();
             }
-            if(name != null) {
-                name = name.trim();
+            if(packageName != null) {
+                packageName = packageName.trim();
             }
             if(version != null) {
                 version = version.trim();
             }
-            return new JavaScriptCoordinates(artifactId, name, version);
+            return new JavaScriptCoordinates(namespace, packageName, version);
         }
     }
 }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/util/ArtifactUtils.java
@@ -81,18 +81,21 @@ public class ArtifactUtils {
 
     public static ArtifactCoordinates createArtifactCoordinates(PackageURL packageURL) {
         String type = packageURL.getType();
+        String namespace = Optional.ofNullable(packageURL.getNamespace()).orElse("");
+        String name = Optional.ofNullable(packageURL.getName()).orElse("");
+        String version = Optional.ofNullable(packageURL.getVersion()).orElse("");
 
         switch (type) {
             case "maven":
-                return new MavenCoordinates(packageURL.getName(), packageURL.getNamespace(), packageURL.getVersion());
+                return new MavenCoordinates(name, namespace, version);
             case "npm":
-                return new JavaScriptCoordinates(packageURL.getName(), packageURL.getNamespace(), packageURL.getVersion());
+                return new JavaScriptCoordinates(namespace, name, version);
             case "nuget":
-                return new DotNetCoordinates(packageURL.getName(), packageURL.getVersion());
+                return new DotNetCoordinates(name, version);
             case "p2":
-                return new BundleCoordinates(packageURL.getName(), packageURL.getVersion());
+                return new BundleCoordinates(name, version);
             default:
-                return new GenericArtifactCoordinates(packageURL.getName(), packageURL.getVersion());
+                return new GenericArtifactCoordinates(name, version);
         }
     }
 

--- a/core/model/src/main/resources/config.xsd
+++ b/core/model/src/main/resources/config.xsd
@@ -302,8 +302,8 @@
 
     <xsd:complexType name="javaScriptCoordinates">
         <xsd:all>
-            <xsd:element name="artifactId" minOccurs="0"  type="xsd:string"/>
-            <xsd:element name="name" minOccurs="0"  type="xsd:string"/>
+            <xsd:element name="namespace" minOccurs="0"  type="xsd:string"/>
+            <xsd:element name="packageName" minOccurs="0"  type="xsd:string"/>
             <xsd:element name="version" minOccurs="0"  type="xsd:string"/>
         </xsd:all>
     </xsd:complexType>

--- a/modules/drools/rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/Mappings.java
+++ b/modules/drools/rule-engine-testing/src/main/java/org/eclipse/sw360/antenna/droolstesting/Mappings.java
@@ -88,7 +88,7 @@ public final class Mappings {
                 });
                 put("javascript", row -> {
                     if (row.size() < 5) {
-                        throw new ConfigurationException("JavaScript coordinates need to specify artifactId, name and version in that order");
+                        throw new ConfigurationException("JavaScript coordinates need to specify namespace, packageName and version in that order");
                     }
                     return new JavaScriptCoordinates(row.get(2), row.get(3), row.get(4));
                 });

--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -32,7 +32,7 @@ private fun mapCoordinates(pkg: Package): ArtifactCoordinates<*> {
     return when (pkg.id.type.toLowerCase()) {
         "nuget", "dotnet" -> mapDotNetCoordinates(name, version)
         "maven" -> mapMavenCoordinates(namespace, name, version)
-        "npm" -> mapJavaScriptCoordinates(name, version)
+        "npm" -> mapJavaScriptCoordinates(namespace, name, version)
         else -> mapSimpleCoordinates(name, version)
     }
 }
@@ -50,11 +50,11 @@ private fun mapMavenCoordinates(namespace: String, name: String, version: String
             .setArtifactId(name)
             .build()
 
-private fun mapJavaScriptCoordinates(name: String, version: String): ArtifactCoordinates<*> =
+private fun mapJavaScriptCoordinates(namespace: String, name: String, version: String): ArtifactCoordinates<*> =
     JavaScriptCoordinates.JavaScriptCoordinatesBuilder()
-            .setName(name)
+            .setNamespace(namespace)
+            .setPackageName(name)
             .setVersion(version)
-            .setArtifactId("$name-$version")
             .build()
 
 private fun mapSimpleCoordinates(name: String, version: String): ArtifactCoordinates<*> =

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtilsTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.antenna.sw360.utils;
+
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.dotnet.DotNetCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.BundleCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.javaScript.JavaScriptCoordinates;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class SW360ComponentAdapterUtilsTest {
+    private static final ArtifactCoordinates MVN = new MavenCoordinates("artifact.id", "any.group.id", "1.0.0");
+    private static final ArtifactCoordinates P2 = new BundleCoordinates("anySymbolicName", "1.0.0");
+    private static final ArtifactCoordinates JS_WITHOUT_NS = new JavaScriptCoordinates("", "anyPackage", "1.4");
+    private static final ArtifactCoordinates JS_WITH_NS = new JavaScriptCoordinates("@anyNamespace", "anyPackage", "1.4");
+    private static final ArtifactCoordinates NUGET = new DotNetCoordinates("anyDll", "2.0.0");
+
+    @Parameters
+    public static Collection<Object[]> coordinateToName() {
+        return Arrays.asList(new Object[][]{
+                { MVN, "any.group.id:artifact.id" },
+                { P2, "anySymbolicName" },
+                { JS_WITHOUT_NS, "anyPackage" },
+                { JS_WITH_NS, "@anyNamespace/anyPackage" },
+                { NUGET, "anyDll" }
+        });
+    }
+
+    private ArtifactCoordinates inputCoordinates;
+    private String expectedComponentName;
+
+    public SW360ComponentAdapterUtilsTest(ArtifactCoordinates inputCoordinates, String expectedComponentName) {
+        this.inputCoordinates = inputCoordinates;
+        this.expectedComponentName = expectedComponentName;
+    }
+
+    @Test
+    public void testCreateComponentName() {
+        Artifact artifact = new Artifact()
+                .addFact(inputCoordinates);
+
+        String componentName = SW360ComponentAdapterUtils.createComponentName(artifact);
+
+        assertThat(componentName).isEqualTo(expectedComponentName);
+    }
+}


### PR DESCRIPTION
### Pull Request
#### Description
This PR improves the `JavaScriptCoordinates` class with a new instance variable `namespace`. This change is made to fix the `SW360ComponentAdapterUtils::createComponentName` and to be able to represent the JS coordinates of components like `@angular/core`.

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvements
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?
- [x] Specific Unit Test
- [x] Executing the Example Projects
- [x] `mvn test` of whole project
- [ ] `mvn test` of submodule
- [ ] `gradle test` (for the gradle plugin)

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [x] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes