### PR TITLE
Clean up log output of policy engine and enhance report information

### DIFF
--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/stubs/AbstractComplianceCheckerTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/stubs/AbstractComplianceCheckerTest.java
@@ -97,6 +97,7 @@ public class AbstractComplianceCheckerTest extends AntennaTestWithMockedContext 
             IEvaluationResult result = Mockito.mock(IEvaluationResult.class);
             when(result.getFailedArtifacts()).thenReturn(failedArtifacts);
             when(result.getSeverity()).thenReturn(f);
+            when(result.getId()).thenReturn("TestId");
             results.add(result);
         });
 

--- a/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyEngine.java
+++ b/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyEngine.java
@@ -31,18 +31,24 @@ public class PolicyEngine {
     }
 
     public Collection<PolicyViolation> evaluate(final Collection<ThirdPartyArtifact> thirdPartyArtifacts) {
-        LOGGER.info("Start policy engine run");
         LOGGER.debug("Artifacts are " + thirdPartyArtifacts.stream()
                 .map(ThirdPartyArtifact::getPurls)
                 .flatMap(Collection::stream)
                 .map(PackageURL::canonicalize)
                 .collect(Collectors.joining(",", "[", "]")));
 
-        return executors
-                .parallelStream()
+        Collection<PolicyViolation> violations =  executors.parallelStream()
                 .map(executor -> executor.executeRules(thirdPartyArtifacts))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
+
+        if (violations.size() > 0) {
+            LOGGER.warn("Number of violations found: " + violations.size());
+        } else {
+            LOGGER.info("No violations found");
+        }
+        
+        return violations;
     }
 
     public Collection<Ruleset> getRulesets() {

--- a/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyEngineConfigurator.java
+++ b/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/engine/PolicyEngineConfigurator.java
@@ -10,9 +10,6 @@
  */
 package org.eclipse.sw360.antenna.policy.engine;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Map;
@@ -24,8 +21,6 @@ import java.util.stream.Collectors;
  * and instantiates the {@link PolicyEngine} infrastructure with the {@link Rule} objects defined in them.
  */
 public class PolicyEngineConfigurator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PolicyEngineConfigurator.class);
-
     private static final String SINGLE_ARTIFACT_EXECUTOR = SingleArtifactExecutor.class.getName();
     private static final String COMPARE_ARTIFACT_EXECUTOR = CompareArtifactExecutor.class.getName();
 
@@ -43,8 +38,6 @@ public class PolicyEngineConfigurator {
             throw new IllegalArgumentException("Configuration Error: No rule set reference given");
         }
 
-        LOGGER.debug("Configuring the policy engine with rulesetRefs " + rulesetRefs.toString());
-
         final Map<String, Set<Rule>> executorToRuleMapping = rulesetRefs.stream()
                 .map(PolicyEngineConfigurator::createRuleset)
                 .map(Ruleset::getRules)
@@ -54,8 +47,6 @@ public class PolicyEngineConfigurator {
                         Collectors.mapping(RuleToExecutor::getRule, Collectors.toSet())));
 
         PolicyEngine resultEngine = new PolicyEngine(createExecutors(executorToRuleMapping));
-
-        LOGGER.debug("Policy engine created");
 
         return resultEngine;
     }


### PR DESCRIPTION
- Get rid of redundant logger calls in policy engine
- Enrich output of abstract compliance checker for report to contain information on artifacts failing compliance checks

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvements
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?
- [ ] Specific Unit Test
- [ ] Executing the Example Projects
- [x] `mvn test` of whole project
- [ ] `mvn test` of submodule
- [ ] `gradle test` (for the gradle plugin)

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [ ] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes