### PR TITLE
break antenna run properly when fail causing exception

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/processors.md
+++ b/antenna-documentation/src/site/markdown/processors/processors.md
@@ -19,3 +19,14 @@ specific attributes of the artifacts. Aside from a processor enriching artifact 
 * [Match State Validator](./match-state-validator.html)
 * [Security Issue Validator](./security-issue-validator.html)
 * [Rule Engine](./rule-engine.html)
+
+> **Note**:  
+> Processors that check for compliance (e.g. the rule engine or any validator) might fail due to data errors (e.g. a rule violation).
+> To prevent the Antenna build from failing when there is no configuration error and still produce all output products
+> the Antenna run will fail after the [generator steps](./../generators/generators.html) have run if any evaluation results
+> have a severity that is equal or higher to the `failOn` value that by default is set to`FAIL`.
+> There will be a list of fails causing exceptions in the workflow steps along with an `ExecutionException`.
+
+  
+> *Note*: If you want to have a validator fail at any severity lower than `FAIL`, you need to add the 
+>         `failOn` entry to the configuration of the desired workflow step. 

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ProcessingState.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ProcessingState.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.api.workflow;
 
 import org.eclipse.sw360.antenna.api.IAttachable;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,7 @@ public class ProcessingState {
     private List<Artifact> artifacts = new ArrayList<>();
     private final Map<String,IAttachable> attachableMap = new HashMap<>();
     private final List<String> additionalReportComments = new ArrayList<>();
+    private final Map<String, Set<IEvaluationResult>> failCausingResults = new HashMap<>();
 
     private final Logger LOGGER =  LoggerFactory.getLogger(ProcessingState.class);
 
@@ -45,6 +47,10 @@ public class ProcessingState {
         return additionalReportComments;
     }
 
+    public Map<String, Set<IEvaluationResult>> getFailCausingResults() {
+        return failCausingResults;
+    }
+
     public void applyWorkflowStepResult(WorkflowStepResult workflowStepResult) {
         applyWorkflowStepResult(workflowStepResult, false);
     }
@@ -57,6 +63,9 @@ public class ProcessingState {
         }
         attachableMap.putAll(workflowStepResult.getAttachables());
         additionalReportComments.addAll(workflowStepResult.getAdditionalReportComments());
+        Optional.ofNullable(workflowStepResult.getFailCausingResults())
+                .map(failCausingResult ->
+                        failCausingResults.put(failCausingResult.getKey(), failCausingResult.getValue()));
     }
 
     private void checkingDuplicateArtifactsInWorkflowStepResults(Collection<WorkflowStepResult> initialResults) {

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/WorkflowStepResult.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/WorkflowStepResult.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.api.workflow;
 
 import org.eclipse.sw360.antenna.api.IAttachable;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 
 import java.util.*;
@@ -28,6 +29,7 @@ public class WorkflowStepResult {
     private final Map<String,IAttachable> attachableMap = new HashMap<>();
 
     private final List<String> additionalReportComments = new ArrayList<>();
+    private Map.Entry<String, Set<IEvaluationResult>> failCausingResults;
 
     public WorkflowStepResult(Collection<Artifact> artifacts, boolean artifactsShouldBeAppended) {
         this.artifacts.addAll(artifacts);
@@ -61,6 +63,14 @@ public class WorkflowStepResult {
 
     public boolean addAdditionalReportComment(String comment) {
         return additionalReportComments.add(comment);
+    }
+
+    public Map.Entry<String, Set<IEvaluationResult>> getFailCausingResults() {
+        return this.failCausingResults;
+    }
+
+    public void addFailCausingResults(String workflowItemName, Set<IEvaluationResult> failCausingResults) {
+        this.failCausingResults = new AbstractMap.SimpleEntry(workflowItemName, failCausingResults);
     }
 
     public boolean isArtifactsShouldBeAppended() {

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/stubs/AbstractComplianceCheckerTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/stubs/AbstractComplianceCheckerTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.workflow.stubs;
 import org.eclipse.sw360.antenna.api.IEvaluationResult;
 import org.eclipse.sw360.antenna.api.IPolicyEvaluation;
 import org.eclipse.sw360.antenna.api.exceptions.FailCausingException;
+import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.java.MavenCoordinates;
 import org.eclipse.sw360.antenna.model.reporting.MessageType;
@@ -79,7 +80,7 @@ public class AbstractComplianceCheckerTest extends AntennaTestWithMockedContext 
         complianceChecker = new AbstractComplianceChecker() {
             @Override
             public IPolicyEvaluation evaluate(Collection<Artifact> artifacts) {
-                return null;
+                return evaluation;
             }
 
             @Override
@@ -111,17 +112,14 @@ public class AbstractComplianceCheckerTest extends AntennaTestWithMockedContext 
     }
 
     @Test
-    public void testSimpleExecutionWithoutFail() throws FailCausingException {
+    public void testSimpleExecutionWithoutFail() {
+        WorkflowStepResult workflowStepResult = new WorkflowStepResult(complianceChecker.process(Collections.EMPTY_SET));
 
+        complianceChecker.postProcessResult(workflowStepResult);
         if(failureExpected) {
-            try {
-                complianceChecker.execute(evaluation);
-            } catch (FailCausingException e) {
-                return; // success
-            }
-            fail("this should not be reached");
+            assertFalse(workflowStepResult.getFailCausingResults().getValue().isEmpty());
         } else {
-            complianceChecker.execute(evaluation);
+            assertNull(workflowStepResult.getFailCausingResults());
             verify(reporterMock, atMost(0))
                     .add(eq(MessageType.PROCESSING_FAILURE), anyString());
         }


### PR DESCRIPTION
#### Request Reviewer
@sschuberth , @blaumeiser-at-bosch 

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvements
- [x] Documentation update
- [ ] Other

#### How Has This Been Tested?
- [x] Specific Unit Test
- [x] Executing the Example Projects
- [x] `mvn test` of whole project
- [x] `mvn test` of submodule
- [ ] `gradle test` (for the gradle plugin)

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [x] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [x] I have updated the documentation accordingly to my changes

##### Note
I have written a test in the `AbstractComplianceChecker`. However I could not find a place to test the `AntennaWorkflow` ExecutionException that should occur upon fails causing results. Ideas are welcome. 