### PR TITLE
fix(template): update according to new discussed standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -16,10 +16,9 @@ labels: bug
 - [ ] ...
 
 ### Definition of Done
-- [ ] Acceptance criteria fulfilled
-- [ ] A test case is created to reproduce the bug
-- [ ] A PR is created, the CI infrastructure reports green, the bug test case proves that bug is fixed
-- [ ] The PR is reviewed and approved
-- [ ] No TODOs left in the code unless explained in the ticket, if something else is still open, this is summarized in a comment in the issue
-- [ ] Documentation is updated
-
+- Acceptance criteria fulfilled
+- A test case is created to reproduce the bug
+- A PR is created, the CI infrastructure reports green, the bug test case proves that bug is fixed
+- The PR is reviewed and approved
+- No TODOs left in the code unless explained in the ticket, if something else is still open, this is summarized in a comment in the issue
+- Documentation is updated

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -10,9 +10,9 @@ about: A new feature of the software
 - [ ] ...
 
 ### Definition of Done
-- [ ] Acceptance criteria fulfilled
-- [ ] A PR is created, the CI infrastructure reports green
-- [ ] The PR is reviewed and approved
-- [ ] No TODOs left in the code unless explained in the ticket, if something else is still open, this is summarized in a comment in the issue
-- [ ] Test cases are created to prove the functionality of the feature
-- [ ] Documentation is updated
+- Acceptance criteria fulfilled
+- A PR is created, the CI infrastructure reports green
+- The PR is reviewed and approved
+- No TODOs left in the code unless explained in the ticket, if something else is still open, this is summarized in a comment in the issue
+- Test cases are created to prove the functionality of the feature
+- Documentation is updated

--- a/.github/ISSUE_TEMPLATE/infrastructure_template.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure_template.md
@@ -11,8 +11,8 @@ labels: infrastructure
 - [ ] ...
 
 ### Definition of Done
-- [ ] Acceptance criteria fulfilled
-- [ ] The ticket describes what has been done and describes how the results can be verified (e.g. new Jenkins step is inserted, the report can be viewed at X)
-- [ ] All known limitations are listed and it is described how they will be addressed (e.g., a ticket for the remaining stuff)
-- [ ] Documentation is updated
-- [ ] The result has been reviewed: Everything works as described and can be verified reading only the documentation
+- Acceptance criteria fulfilled
+- The ticket describes what has been done and describes how the results can be verified (e.g. new Jenkins step is inserted, the report can be viewed at X)
+- All known limitations are listed and it is described how they will be addressed (e.g., a ticket for the remaining stuff)
+- Documentation is updated
+- The result has been reviewed: Everything works as described and can be verified reading only the documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,25 @@
-### Pull Request
-
-#### Description
-> Please provide a summary of your changes here. 
+> Please provide a summary of your changes here.
 > * Which issue is this pull request belonging to? (*Refer to issue here*)
 > * How is it solving the issue?
-> * Did you add any new dependencies that are required for your change?
+> * Did you add or update any new dependencies that are required for your change?
 
-#### Commit Messages  
->    The commit messages should follow the syntax for [auto-closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords). 
->    It is preferred if you reference the issue in your commit message.
+### Request Reviewer
+> You can add desired reviewers here with an @mention.
 
-#### Request Reviewer
-> You can add desired reviewers here with an @mention.  
-> For a full list of reviewers check out the *Committers* slot on [the project site](https://projects.eclipse.org/projects/technology.sw360.antenna/who).
+### Type of Change
+> Mention one of the following:   
+> bug fix | new feature | improvements | documentation update | CI | Other
 
-#### Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Improvements
-- [ ] Documentation update
-- [ ] Other
+*Type of change*:  
 
-#### How Has This Been Tested?
-- [ ] Specific Unit Test
-- [ ] Executing the Example Projects
-- [ ] `mvn test` of whole project
-- [ ] `mvn test` of submodule
-- [ ] `gradle test` (for the gradle plugin)
+### How Has This Been Tested?
+> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
+> All test that passed before your contribution should pass after it as well. 
 
-#### Checklist
-- [ ] My code follows the style and guidelines of this project
-- [ ] I have self-reviewed my code 
-- [ ] I have provided tests that prove my change is working 
-- [ ] Existing tests still pass with my changes 
-- [ ] I have updated the documentation accordingly to my changes
+### Checklist
+Must:
+- [ ] All related issues are referenced in commit messages
+
+Optional: *(delete if not applicable)*
+- [ ] I have provided tests for the changes (if there are changes that need additional tests)
+- [ ] I have updated the documentation accordingly to my changes 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This is a set of guidelines for contributing to [Antenna](https://github.com/ecl
 
 ## Code of Conduct
 
-This project is hosted by the [Eclipse Foundation](https://github.com/eclipse) on GitHub and hence adheres to the 
+This project is hosted by the [Eclipse Foundation](https://github.com/eclipse) on GitHub and hence adheres to the
 [Eclipse Code of Conduct](https://wiki.eclipse.org/Eclipse_Code_of_Conduct) that is based on the
 [Contributor Covenant](https://www.contributor-covenant.org/).
 
@@ -39,15 +39,15 @@ electronically sign the [Eclipse Contributor Agreement (ECA)](http://www.eclipse
 Commits that are provided by non-committers must have a Signed-off-by field in
 the footer indicating that the author is aware of the terms by which the
 contribution has been provided to the project.
-To achieve this, sign your commits by adding `-s` to your `git commit` command. 
-The non-committer must additionally have an Eclipse Foundation account and 
+To achieve this, sign your commits by adding `-s` to your `git commit` command.
+The non-committer must additionally have an Eclipse Foundation account and
 must have a signed Eclipse Contributor Agreement (ECA) on file.
 Your Git signature must match your Eclipse Foundation account information to be accepted.
-If your signature was accepted is visible by checking the status check on your pull request. 
+If your signature was accepted is visible by checking the status check on your pull request.
 
 For more information, please see the [Eclipse Committer Handbook](https://www.eclipse.org/projects/handbook/#resources-commit).
 
-> **Note**: You can submit issues without signing the ECA. 
+> **Note**: You can submit issues without signing the ECA.
 
 ### Contact
 
@@ -57,12 +57,13 @@ Contact the project developers via the [project's "dev" list](https://dev.eclips
 
 ### Before Submitting An Issue
 
-* **Check the [troubleshooting documentation](https://github.com/eclipse/antenna/blob/master/antenna-documentation/src/site/markdown/troubleshooting.md.vm).** 
-You might be able to find the cause of the problem and fix things yourself. Most importantly, check if you can reproduce the problem [in the current version of Antenna](https://github.com/eclipse/antenna/blob/master). 
-It is possible that the bug has already been fixed. 
+* **Check the [troubleshooting documentation](https://github.com/eclipse/antenna/blob/master/antenna-documentation/src/site/markdown/troubleshooting.md.vm).**
+You might be able to find the cause of the problem and fix things yourself. 
+Most importantly, check if you can reproduce the problem [in the current version of Antenna](https://github.com/eclipse/antenna/blob/master).
+It is possible that the bug has already been fixed.
 * **Check the [documentation](https://github.com/eclipse/antenna/tree/master/antenna-documentation/src/site/markdown)**.
-Your issue might already be mentioned there. 
-* **Perform a [cursory search](https://github.com/eclipse/antenna/issues?utf8=%E2%9C%93&q=is%3Aissue)** to see if the problem has already been reported. 
+Your issue might already be mentioned there.
+* **Perform a [cursory search](https://github.com/eclipse/antenna/issues?utf8=%E2%9C%93&q=is%3Aissue)** to see if the problem has already been reported.
 If it has *and the issue is still open*, add a comment to the existing issue instead of opening a new one.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you want to report, open a new issue and include a link to the original issue in the body of your new one.
@@ -70,26 +71,26 @@ If it has *and the issue is still open*, add a comment to the existing issue ins
 ### Reporting Bugs
 
 This section guides you through submitting a bug report.
-Before creating bug reports, please check [the "before-submitting-an-issue" list](#before-submitting-an-issue) as you might find out that you don't need to create one. 
+Before creating bug reports, please check [the "before-submitting-an-issue" list](#before-submitting-an-issue) as you might find out that you don't need to create one.
 Fill out [the required template](https://github.com/bsinno/osm-antenna/issues/new?labels=bug&template=bug_template.md).
 
 #### How Do I Submit A (Good) Bug Report?
 
-We have a template for a [bug report](https://github.com/eclipse/antenna/issues/new?labels=bug&template=bug_template.md). 
+We have a template for a [bug report](https://github.com/eclipse/antenna/issues/new?labels=bug&template=bug_template.md).
 Please use that by clicking on **new issue** and then choose the option **bug report**.
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
 * Give a **clear and descriptive title** that identifies the problem.
 * Give a **summary of the bug**.
-* Describe the **steps to reproduce** the bug. 
+* Describe the **steps to reproduce** the bug.
     * Don't hesitate to go into detail.
-    * Everything that helps to reproduce the bug on a local machine is helpful. 
+    * Everything that helps to reproduce the bug on a local machine is helpful.
         * Logs with stack traces
         * Antenna configuration files
         * System properties
         * Code snippets
         * Links to projects that experienced the problem.
-    * Describe the behavior you experienced in detail and point out what exactly is the problem with that behavior. 
+    * Describe the behavior you experienced in detail and point out what exactly is the problem with that behavior.
     * Explain what you expected to experience instead.
 * Give your **acceptance criteria**
     * What behavior do you want to see?
@@ -99,12 +100,12 @@ Explain the problem and include additional details to help maintainers reproduce
 Provide more context by answering these questions:
 
 * **Did the problem start happening recently** (e.g. after updating to a new version of Antenna) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of Antenna?** 
-What's the most recent version in which the problem doesn't occur? 
-* **Can you reliably reproduce the issue?** 
+* If the problem started happening recently, **can you reproduce the problem in an older version of Antenna?**
+What's the most recent version in which the problem doesn't occur?
+* **Can you reliably reproduce the issue?**
 If not, provide details about how often the problem happens and under which conditions it normally happens.
 If not, check if a server you are trying to contact might be at fault (e.g. your SW360 instance).
-* If the problem is related to working with files, **does the problem happen for all files and projects or only some?** 
+* If the problem is related to working with files, **does the problem happen for all files and projects or only some?**
 
 Include details about your configuration and environment:
 
@@ -112,7 +113,7 @@ Include details about your configuration and environment:
 * What's the name and version of the OS you're using?
 * Do you have Apache Maven installed? If so, which version?
 * What kind of dependencies does your project have?
-* How does your tool configuration file, workflow file and antenna configuration file look? 
+* How does your tool configuration file, workflow file and antenna configuration file look?
 
 ### Suggesting Enhancements
 
@@ -128,14 +129,14 @@ Fill in [the template](https://github.com/bsinno/osm-antenna/issues/new?template
 * Give your **acceptance criteria**
     * What behavior do you want to see
     * What are your minimum requirements
-* The **Definition of Done** is already predefined by us, but you can add points when you feel like something is missing. 
+* The **Definition of Done** is already predefined by us, but you can add points when you feel like something is missing.
 
 ### Your First Code Contribution
 
-When you first contribute to Antenna, it can be that it takes a while for us to start reviewing your code. 
-Please be patient, and if necessary, write one of the contributors and ask what the state is on your PR. 
+When you first contribute to Antenna, it can be that it takes a while for us to start reviewing your code.
+Please be patient, and if necessary, write one of the contributors and ask what the state is on your PR.
 
-Be sure you fulfill all legal requirements (e.g. [Eclipse Contributor Agreement](#eclipse-contributor-agreement)), otherwise we can't accept your pull request. 
+Be sure you fulfill all legal requirements (e.g. [Eclipse Contributor Agreement](#eclipse-contributor-agreement)), otherwise we can't accept your pull request.
 
 ### Pull Requests
 
@@ -146,20 +147,96 @@ The process described here has several goals:
 
 Please follow these steps, detailed in the [pull request template](.github/pull_request_template.md), to have your contribution considered by the maintainers:
 
-1. Describe in your PR what you have done, what this is fixing or introducing and why this isn't regressive. 
-If there is an issue to your PR, please link it. 
+1. Fill out the [pull request template](.github/pull_request_template.md).
+Be sure to tick all boxes that apply to your pull request.  
 2. Follow the [style guides](#style-guides).
-3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing.
-Should a status check fail and you believe it is unrelated to your contribution, please write so in a comment in the PR. 
+3. Describe in your PR what you have done, what this is fixing or introducing and why this isn't regressive.
+If there is an issue to your PR, please link it.
+If you have adhered to the style guide of the [commit messages](#git-commit-messages), you will have that content already.
+4. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing.
+Should a status check fail and you believe it is unrelated to your contribution, please write so in a comment in the PR.
 
-While the prerequisites above may be satisfied, the reviewer(s) may still ask you to do additional work or ask for changes before your PR is finally accepted. 
-Since the reviewer knows the code very well, they might have ideas how to include features more elegantly or see inconsistencies compared to the code base. 
+While the prerequisites above may be satisfied, the reviewer(s) may still ask you to do additional work or ask for changes before your PR is finally accepted.
+Since the reviewer knows the code very well, they might have ideas how to include features more elegantly or see inconsistencies compared to the code base.
+
+#### Reviews
+Once your pull request is being reviewed, there are some guidelines.
+1. Threads started during a review should only be marked as resolved by the starter of the thread.
+2. Comments and discussions should be ended cleanly. This can be done by using emoticons on the comments,
+e. g. a "thumbs-up" to mark a comment as done.
+3. Once you have integrated changes that were requested, you can dismiss the review of the reviewer and re-request a review.
+
+When integrating a reviewers comments into a pull request, please fix the issue in the respective commit where it appears,
+instead of in a new commit. 
+
+An approval of the PR means that the PR can be merged as is, without any changes still necessary.
+If the owner of a PR is an Eclipse committer of the project, the owner can merge their own PR once approved.
+Otherwise, the PR needs to be merged by an Eclipse committer of the project.
+
+##### Request Reviewer
+ You can add desired reviewers here with an @mention.
+> For a full list of reviewers check out the *Committers* slot on [the project site](https://projects.eclipse.org/projects/technology.sw360.antenna/who).  
+> A list of their GitHub names can be found in the [Eclipse Antenna Wiki](https://github.com/eclipse/antenna/wiki/Current-Committers).
+
+#### Squashing
+Depending the size or content of a pull request it might be sensible to separate your pull request into
+[logically separate commits](https://github.com/git/git/blob/master/Documentation/SubmittingPatches#L43).
+However, several commits are not always necessary. Only separate commits if their contents belong separately.
+If a commit alone does not build, then it probably belongs with additional other changes.
+When changes are required fixup your commits or squash new commits based on requested changes.
+[Here you can find a guide on fixups and autosquashing](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html).
+Do not forget to amend your commit messages along with the changes.
+
+> Note: Formatting changes should be in independent commits, as they are not necessary for functional changes.
+
+#### Testing Changes:
+Changes that include changes to the code need to be tested. 
+* If you have added changes that require a new test, you should write it. 
+* If you make changes that impact an existing test, it should still pass.
+ 
+Here is a list of possible tests you can perform to see if your changes are working:
+- Specific Unit Test
+- Executing the Example Projects
+- `mvn test` of whole project
+- `mvn test` of submodule
+- `gradle test` (for the gradle plugin)
+- Integration tests with a running SW360
 
 ## Style Guides
 
 ### Git Commit Messages
 
-We use the commit style of the [SW360 project](https://github.com/eclipse/sw360/wiki/Dev-Semantic-Commits).
+When writing the commit message headline, keep in mind that the prefixes in the commit messages are meant to help when searching for changes.
+
+Additionally, you should add descriptions to your commit messages of
+- changes you have made to the code
+    - why those changes are necessary 
+    - why those changes are implemented in that way specifically
+    
+Don't just describe what is "obvious" in your code. 
+A rational explanation why the changes are necessary help the reviewer understand the reasoning *behind* your code.
+
+If there is an issue to your commit, link it using keywords as described [here](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
+
+When there are changes in a commit that are the result of discussions which arose during the review of a pull request,
+those discussions and their result should be mentioned in the commit message. 
+This helps that the understanding of changes made is not lost in time.
+
+> Note: please be sure not to exceed the standard length of 72 characters per line.
+
+##### Sign your commits
+It is very important that you sign your commits, so the
+[Eclipse Contributor Agreement Validation](https://github.com/apps/eclipse-eca-validation)
+will not be rejected. You can either use the `-s` flag the Git provides to sign a commit:
+```
+$ git commit -s -m 'doc: add variable x and y to the description of the sw360 data model'
+```
+or you can insert it when righting your commit message. Be sure to follow this example:
+```
+    my commit message
+
+    Signed-off-by: John Doe <john.doe@antenna.org>
+```
 
 ### Java Styleguide
 
@@ -167,13 +244,12 @@ All Java should adhere to the [Java Language Specification](https://docs.oracle.
 
 ### Documentation Styleguide
 
-Our documentation mainly focuses on the usage of Antenna. 
-So should you introduce any new properties, configurations, workflow steps or anything else the user will have to configure, please add a documentation about this. 
+Our documentation mainly focuses on the usage of Antenna.
+So should you introduce any new properties, configurations, workflow steps or anything else the user will have to configure, please add a documentation about this.
 Also, when you introduce path sensitive features or changes (like reading in a document), make sure it works with most standard OSs Antenna supports.
  Any drawbacks, additional information and small notes should also be documented.
- 
- For our documentation we use [Markdown](https://daringfireball.net/projects/markdown) and the [Doxia Markup Languages References](https://maven.apache.org/doxia/references/index.html). 
- With the Doxia Markup Language References we reference the name of the product and some other values that can be found in the site modules POM file. 
 
-Our documentation is written in American English. 
+ For our documentation we use [Markdown](https://daringfireball.net/projects/markdown) and the [Doxia Markup Languages References](https://maven.apache.org/doxia/references/index.html).
+ With the Doxia Markup Language References we reference the name of the product and some other values that can be found in the site modules POM file.
 
+Our documentation is written in American English.


### PR DESCRIPTION
Issue Template changes:
- removed checkboxes from definition of done, since they added overhead

Pull Request Template changes:
- removed superfluous headers
- removed commit message part since they are part of the
  contributing.md not the pull request template
- added SW360 Integration Tests to possible tests list

CONTRIBUTING.md:
Add content to PR part about reviewing and squashing that
reflect the new standars.
Update style guide for commit messages to reflect the new standards

#### NOTE - Discuss
- I have considered removing the checklist from the pull request template, but found in my last two pull requests that it was actually helping me having a cleaner pull request. 
- I have however noticed, that the **Type Of Change** list to me seems superfluous. 

#### Request Reviewer
@sschuberth @bs-ondem @maxhbr @blaumeiser-at-bosch 

#### Type of Change
- [x] Other

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [x] I have updated the documentation accordingly to my changes