### PR TITLE
add profil with id "ci" to mvn install calls in Jenkinsfile.eclipse

### DIFF
--- a/Jenkinsfile.eclipse
+++ b/Jenkinsfile.eclipse
@@ -125,12 +125,14 @@ spec:
                     sh """
                       mvn -Dmaven.repo.local=\$(readlink -f localRepository) \
                           --batch-mode \
-                          install -DskipTests ${params.SIGNING_COMMAND}
+                          clean install -DskipTests ${params.SIGNING_COMMAND} \
+                          -P ci
                       mvn -Dmaven.repo.local=\$(readlink -f localRepository) \
                           --batch-mode \
-                          install -DskipTests ${params.SIGNING_COMMAND} deploy \
+                          clean install -DskipTests ${params.SIGNING_COMMAND} deploy \
                           -pl '!core/model-testing,!core/frontend-stubs-testing,!modules/drools/rule-engine-testing' \
-                          -DaltDeploymentRepository=localRepositoryFolder::default::file:\$(readlink -f ./repository)
+                          -DaltDeploymentRepository=localRepositoryFolder::default::file:\$(readlink -f ./repository) \
+                          -P ci
                     """
                 }
                 sh 'ls repository/org/eclipse/sw360/antenna/'

--- a/modules/sw360/pom.xml
+++ b/modules/sw360/pom.xml
@@ -106,7 +106,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <id>integration-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,11 @@
                   <artifactId>eclipse-jarsigner-plugin</artifactId>
                   <version>1.1.5</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
    Since the antenna-build job is currently failing with error code 137
    it has been suggested that this could be due to the gradle daemon
    costing to much resources. Hence, the "ci" profile created for the
    documentation job that runs on the same Jenkins instance has been
    added to the mvn install calls that build antenna.

#### Request Reviewer
@bs-ondem 

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Improvements
- [ ] Documentation update
- [x] Other: -> CI

#### How Has This Been Tested?
- Test pipeline: https://ci.eclipse.org/antenna/job/build-pipeline-test/ 

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [x] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes