### PR TITLE
change condition for checking for git diff in writeIndexRootFile

### DIFF
--- a/antenna-documentation/scripts/writeIndexRootFile.sh
+++ b/antenna-documentation/scripts/writeIndexRootFile.sh
@@ -51,7 +51,7 @@ git clean -fd
 
 generateIndexFile | tee index.html
 # if there is a difference after writing the index html, commit
-if ! git diff-index HEAD; then
+if ! git diff-index --quiet HEAD --; then
   git add index.html
   git commit -m "update index file to be according to new version ${CURRENT_COMMIT}" -s
 fi


### PR DESCRIPTION
Since the Jenkins job failed when trying to checkout to current branch
because changes in branch might be lost, condition must not have worked.

Hence this changes the if condition to decide if a commit should happen.
`--quiet` was added to stop the search as soon as a difference has been
found. The command implies the git parameter `exit-code` and will exit
with 1 when the tree is modified
`--` was added for the command to work as intended, since it separates
the path from the rest of the argument and helps Git know that `HEAD`
is not the name of a file.
The condition is specifically designed to exit with an error if the
script is using `set -e`, as described here:
https://stackoverflow.com/a/28296286

#### Request Reviewer
@sschuberth 

#### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvements
- [x] Documentation update
- [ ] Other

#### How Has This Been Tested?
- [x] Testing with a shell script on a mock git project

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [ ] I have provided tests that prove my change is working 
- [ ] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes