### PR TITLE
modules: Use the processed variant of the declared licenses found by ORT

### DIFF
--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -48,7 +48,7 @@ private fun mapSourceUrl(pkg: Package): ArtifactSourceUrl? =
     }
 
 private fun mapDeclaredLicense(pkg: Package): DeclaredLicenseInformation? =
-    pkg.declaredLicenses.takeUnless { it.isEmpty() }?.let {
+    pkg.declaredLicensesProcessed.allLicenses.takeUnless { it.isEmpty() }?.let {
         DeclaredLicenseInformation(LicenseSupport.mapLicenses(it))
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>5.1.2.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ort.rev>f8d99920c9</ort.rev>
+        <ort.rev>2b8c4ef3af</ort.rev>
     </properties>
 
     <scm>


### PR DESCRIPTION
The processed variant has commonly used license names mapped to SPDX
ids, so e.g. "The Apache Software License, Version 2.0" is mapped to
"Apache-2.0".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>
#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvements
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?
- [ ] Specific Unit Test
- [ ] Executing the Example Projects
- [ ] `mvn test` of whole project
- [x] `mvn test` of submodule
- [ ] `gradle test` (for the gradle plugin)

#### Checklist
- [x] My code follows the style and guidelines of this project
- [x] I have self-reviewed my code 
- [ ] I have provided tests that prove my change is working 
- [x] Existing tests still pass with my changes 
- [ ] I have updated the documentation accordingly to my changes