### PR TITLE
Include Antenna Project Site link in projects information files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ their licenses,
 * a sources.zip containing all sources of the dependencies, and
 * a processing report.
 
-Learn more about Antenna in [What Antenna Does](antenna-documentation/src/site/markdown/index.md.vm).
+Learn more about Antenna in [What Antenna Does](antenna-documentation/src/site/markdown/index.md.vm).  
+Or visit us on our [Eclipse Project Site](https://www.eclipse.org/antenna/) for the latest news of the project.
 
 If you want to contribute to Antenna, please check out the [Contribution guidlines](CONTRIBUTING.md). 
 

--- a/antenna-documentation/src/site/markdown/index.md.vm
+++ b/antenna-documentation/src/site/markdown/index.md.vm
@@ -1,6 +1,6 @@
 # About
 
-${docNameCap} scans artifacts of a project, downloads sources for dependencies, 
+[${docNameCap}](https://www.eclipse.org/antenna/) scans artifacts of a project, downloads sources for dependencies,
 validates sources and licenses and creates:
 
 * a third-party disclosure document that lists all dependencies with 


### PR DESCRIPTION
Included the Antenna Project site link in README.md and
the index page of the Documentation.

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
*Type of change*:  Documentation Update

### How Has This Been Tested?
Tested with running antenna documentations `mvn site site:run`. Link works.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
