### PR TITLE
fix path function sw360 release

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
+++ b/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
@@ -40,7 +40,7 @@ Add the following step into the `<generators>` section of your workflow.xml
 * `client.id`: The REST API uses a two step authentication, this is general client id used.
 * `client.password`: The password of the client id.
 * `proxy.use`: Enable proxy for communication to SW360.
-* `update_releases`: Update already existsing releases (This feature is currently **not** supported)
+* `update_releases`: Update already existing releases 
 * `update_sources`: Upload sources corresponding to releases to SW360
 
 #### Data Model

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
@@ -110,7 +110,7 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
     public SW360Release patchRelease(SW360Release sw360Release, HttpHeaders header) {
         HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360Release, header);
 
-        ResponseEntity<Resource<SW360Release>> response = doRestPATCH(getEndpoint(), httpEntity,
+        ResponseEntity<Resource<SW360Release>> response = doRestPATCH(getEndpoint() + "/" + sw360Release.getReleaseId(), httpEntity,
                 new ParameterizedTypeReference<Resource<SW360Release>>() {});
 
         if (! response.getStatusCode().is2xxSuccessful()) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
@@ -12,7 +12,6 @@
 package org.eclipse.sw360.antenna.sw360.workflow.generators;
 
 import org.eclipse.sw360.antenna.api.IAttachable;
-import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractGenerator;
 import org.eclipse.sw360.antenna.model.SW360ProjectCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
@@ -52,9 +51,6 @@ public class SW360Updater extends AbstractGenerator {
 
         // General configuration
         final boolean updateReleases = getBooleanConfigValue(UPDATE_RELEASES, configMap);
-        if (updateReleases) {
-            throw new ExecutionException("The functionality to update releases, activated with the " + UPDATE_RELEASES + " is not yet supported.");
-        }
         Boolean uploadSources = getBooleanConfigValue(UPLOAD_SOURCES, configMap);
 
         sw360MetaDataUpdater = new SW360MetaDataUpdater(sw360ConnectionConfiguration, updateReleases, uploadSources);


### PR DESCRIPTION
This changes the url that was given to the RestTemplate that
executes the Patch function.
Opposed to the create function that is done with a POST request, the
PATCH function needs the releaseId in the url, otherwise a 405
Method Not Allowed Error is thrown.

The if-statement that checks if the Update_releases flag is set
and then throws and Exception was removed, since it is no longer
necessary.

### Request Reviewer
@bs-ondem @blaumeiser-at-bosch 

### Type of Change
*Type of change*:  bug fix & improvements 


### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

- run local test with the example project
    -  activated the SW360Updater
    -  inserted a new dependency in the csv Analyzer file
    -  first run of the example project  
    -  add a new information (source URL) to the dependecy
    -  run again -> see there is additional info in SW360

### Checklist
Must:
- [ ] ~All related issues are referenced in commit messages~
    -  There is no issue for this is in the eclipse/antenna repository

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
