### PR TITLE
bug fix #349 missing component type in create component request

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -36,6 +36,8 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     private static final String COPYRIGHTS_KEY = "copyrights";
     private static final String CLEARINGSTATE_KEY = "clearingState";
 
+    @JsonIgnore
+    private boolean isProprietary;
     private String name;
     private String version;
     private String cpeId;
@@ -263,6 +265,17 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
 
     public SW360Release setCopyrights(String copyrights) {
         additionalData.put(COPYRIGHTS_KEY, copyrights);
+        return this;
+    }
+
+    @JsonIgnore
+    public boolean isProprietary() {
+        return isProprietary;
+    }
+
+    @JsonIgnore
+    public SW360Release setProprietary(boolean proprietary) {
+        isProprietary = proprietary;
         return this;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
@@ -37,7 +37,11 @@ public class SW360ComponentAdapterUtils {
     }
 
     private static void setComponentType(SW360Component component, Artifact artifact) {
-        if (artifact.isProprietary()) {
+        setComponentType(component, artifact.isProprietary());
+    }
+
+    private static void setComponentType(SW360Component component, boolean isProprietary) {
+        if (isProprietary) {
             component.setComponentType(SW360ComponentType.INTERNAL);
         } else {
             component.setComponentType(SW360ComponentType.OSS);
@@ -47,7 +51,7 @@ public class SW360ComponentAdapterUtils {
     public static SW360Component createFromRelease(SW360Release release) {
         SW360Component sw360Component = new SW360Component();
         sw360Component.setName(release.getName());
-        // TODO: set component type
+        setComponentType(sw360Component, release.isProprietary());
         return sw360Component;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ReleaseAdapterUtils.java
@@ -39,6 +39,7 @@ public class SW360ReleaseAdapterUtils {
         SW360ReleaseAdapterUtils.setClearingStatus(release, artifact);
         SW360ReleaseAdapterUtils.setChangeStatus(release, artifact);
         SW360ReleaseAdapterUtils.setCopyrights(release, artifact);
+        release.setProprietary(artifact.isProprietary());
 
         return release;
     }


### PR DESCRIPTION
When creating a component for a new release that has no component in
SW360 yet the post request failed with a 400 null BadRequest error.
This was due to missing required value "componentType".
This was not set since the component is created from the release.
The release does not contain that information.

Hence, a variable was introduced to the release that has a
JsonIgnore property to set an isProprietary boolean value.
This allows to check for the value when creating a component from
release.

It is not ideal, since otherwise the new variable is not used or
necessary and creates unnecessary overhead.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@bs-ondem 
Note: I don't think this is a pretty fix, but I could not think of another way of bringing the information we need to this point in the code. Suggestions are more than welcome.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
- 'mvn clean install' on project
- 'mvn package' with example project

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
