### PR TITLE
Move license knowledge base resolver back in the execution sequence

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolver.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolver.java
@@ -38,7 +38,7 @@ public class LicenseKnowledgeBaseResolver extends AbstractProcessor {
     private ILicenseManagementKnowledgeBase knowledgeBase;
 
     public LicenseKnowledgeBaseResolver() {
-        this.workflowStepOrder = 600;
+        this.workflowStepOrder = 9000;
     }
 
     public LicenseKnowledgeBaseResolver(ILicenseManagementKnowledgeBase knowledgeBase) {


### PR DESCRIPTION
Resolving license information should be a step that is executed late in metadata aquisition,
because it does not change the general structure of the existing elements but only adds
information lie the license text. If executed earlier, the results can be overwritten.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch-si.com>

Closes #356 

### Request Reviewer
@bs-ondem 
@neubs-bsi 

### Type of Change

*Type of change*:  bugfix

### How Has This Been Tested?
Ran an example project which created the expected result

### Checklist
Must:
- [x] All related issues are referenced in commit messages
