### PR TITLE
Rework exception handling in Sw360 module

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -55,6 +55,8 @@ public class SW360MetaDataUpdater {
         return licenses.stream()
                 .filter(license -> isLicenseInSW360(license, header))
                 .map(license -> licenseClientAdapter.getSW360LicenseByAntennaLicense(license, header))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -32,12 +32,12 @@ public class SW360ComponentClientAdapter {
         this.componentClient = new SW360ComponentClient(restUrl, proxySettings);
     }
 
-    public SW360Component getOrCreateComponent(SW360Component componentFromRelease, HttpHeaders header) {
+    public Optional<SW360Component> getOrCreateComponent(SW360Component componentFromRelease, HttpHeaders header) {
         if(componentFromRelease.getComponentId() != null) {
             return getComponentById(componentFromRelease.getComponentId(), header);
         }
-        return getComponentByName(componentFromRelease.getName(), header)
-                .orElseGet(() -> createComponent(componentFromRelease, header));
+        return Optional.of(getComponentByName(componentFromRelease.getName(), header)
+                .orElseGet(() -> createComponent(componentFromRelease, header)));
     }
 
     public SW360Component createComponent(SW360Component component, HttpHeaders header) {
@@ -47,7 +47,7 @@ public class SW360ComponentClientAdapter {
         return componentClient.createComponent(component, header);
     }
 
-    public SW360Component getComponentById(String componentId, HttpHeaders header) {
+    public Optional<SW360Component> getComponentById(String componentId, HttpHeaders header) {
         return componentClient.getComponent(componentId, header);
     }
 
@@ -67,7 +67,8 @@ public class SW360ComponentClientAdapter {
                 .collect(Collectors.toList());
 
         for (String componentId : componentIds) {
-            completeComponents.add(getComponentById(componentId, header));
+            getComponentById(componentId, header)
+                    .map(completeComponents::add);
         }
 
         return completeComponents.stream()

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
@@ -40,11 +40,11 @@ public class SW360LicenseClientAdapter {
         return licenseClient.createLicense(sw360License, header);
     }
 
-    public SW360License getSW360LicenseByAntennaLicense(License license, HttpHeaders header) {
+    public Optional<SW360License> getSW360LicenseByAntennaLicense(License license, HttpHeaders header) {
         return licenseClient.getLicenseByName(license.getName(), header);
     }
 
     public Optional<SW360License> getLicenseDetails(SW360SparseLicense sparseLicense, HttpHeaders headers) {
-        return Optional.of(licenseClient.getLicenseByName(sparseLicense.getShortName(), headers));
+        return licenseClient.getLicenseByName(sparseLicense.getShortName(), headers);
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -17,19 +17,25 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360LicenseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.checkRestStatus;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSaveOrThrow;
+
 public class SW360LicenseClient extends SW360Client {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SW360LicenseClient.class);
     private static final String LICENSES_ENDPOINT = "/licenses";
     private final String restUrl;
 
@@ -44,56 +50,55 @@ public class SW360LicenseClient extends SW360Client {
     }
 
     public List<SW360SparseLicense> getLicenses(HttpHeaders header) {
-        ResponseEntity<Resource<SW360LicenseList>> response = doRestGET(getEndpoint(), header,
-                new ParameterizedTypeReference<Resource<SW360LicenseList>>() {});
+        try {
+            ResponseEntity<Resource<SW360LicenseList>> response = doRestGET(getEndpoint(), header,
+                    new ParameterizedTypeReference<Resource<SW360LicenseList>>() {});
 
-        if (response.getStatusCode().is2xxSuccessful()) {
-            SW360LicenseList resource = Optional.ofNullable(response.getBody())
-                    .orElseThrow(() -> new ExecutionException("Body was null"))
-                    .getContent();
+            checkRestStatus(response);
+            SW360LicenseList resource = getSaveOrThrow(response.getBody(), Resource::getContent);
             if (resource.get_Embedded() != null &&
                     resource.get_Embedded().getLicenses() != null) {
                 return new ArrayList<>(resource.get_Embedded().getLicenses());
             } else {
                 return new ArrayList<>();
             }
-        } else {
-            throw new ExecutionException("Request to get all licenses failed with " + response.getStatusCode());
+        } catch (ExecutionException e) {
+            LOGGER.debug("Request to get all licenses failed with {}", e.getMessage());
+            return new ArrayList<>();
         }
     }
 
-    public SW360License getLicenseByName(String name, HttpHeaders header) {
-        ResponseEntity<Resource<SW360License>> response = doRestGET(getEndpoint() + "/" + name, header,
-                new ParameterizedTypeReference<Resource<SW360License>>() {});
+    public Optional<SW360License> getLicenseByName(String name, HttpHeaders header) {
+        try {
+            ResponseEntity<Resource<SW360License>> response = doRestGET(getEndpoint() + "/" + name, header,
+                    new ParameterizedTypeReference<Resource<SW360License>>() {});
 
-        if (response.getStatusCode().is2xxSuccessful()) {
-            return Optional.ofNullable(response.getBody())
-                    .orElseThrow(() -> new ExecutionException("Body was null"))
-                    .getContent();
-        } else {
-            throw new ExecutionException("Request to get license " + name + " failed with "
-                    + response.getStatusCode());
+            checkRestStatus(response);
+            return Optional.of(getSaveOrThrow(response.getBody(), Resource::getContent));
+        } catch (ExecutionException e) {
+            LOGGER.debug("Request to get license {} failed with {}",
+                    name, e.getMessage());
+            return Optional.empty();
         }
     }
 
     public SW360License createLicense(SW360License sw360License, HttpHeaders header) {
-        HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360License, header);
-        ResponseEntity<Resource<SW360License>> response;
         try {
-            response = doRestPOST(getEndpoint(), httpEntity,
+            HttpEntity<String> httpEntity = RestUtils.convertSW360ResourceToHttpEntity(sw360License, header);
+            ResponseEntity<Resource<SW360License>> response = doRestPOST(getEndpoint(), httpEntity,
                 new ParameterizedTypeReference<Resource<SW360License>>() {});
-        } catch (HttpClientErrorException e) {
-            throw new ExecutionException("Request to create license " + sw360License.getFullName() + " failed with "
-                    + e.getStatusCode());
-        }
 
-        if (response.getStatusCode() == HttpStatus.CREATED) {
-            return Optional.ofNullable(response.getBody())
-                    .orElseThrow(() -> new ExecutionException("Body was null"))
-                    .getContent();
-        } else {
-            throw new ExecutionException("Request to create license " + sw360License.getFullName() + " failed with "
-                    + response.getStatusCode());
+            checkRestStatus(response);
+            return getSaveOrThrow(response.getBody(), Resource::getContent);
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            LOGGER.error("Request to create license {} failed with {}",
+                    sw360License.getFullName(), e.getStatusCode());
+            LOGGER.debug("Error: ", e);
+            return sw360License;
+        } catch (ExecutionException e) {
+            LOGGER.error("Request to create license {} failed with {}",
+                    sw360License.getFullName(), e.getMessage());
+            return sw360License;
         }
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
@@ -33,7 +33,6 @@ public class SW360Attributes {
     public static final String PROJECT_BUSINESS_UNIT = "businessUnit";
     public static final String PROJECT_CLEARING_TEAM= "clearingTeam";
     public static final String PROJECT_VISIBILITY = "visbility";
-    public static final String PROJECT_LINKED_RELEASES = "linkedReleases";
     public static final String PROJECT_RELEASE_ID_TO_USAGE = "releaseIdToUsage";
 
     // Attributes of Sw360Component

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
@@ -24,7 +24,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.test.web.client.match.MockRestRequestMatchers;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -227,43 +226,14 @@ public class SW360ProjectClientTest {
         assertEquals(PROJECT_EMAIL_VALUE_1, project.get_Embedded().getCreatedBy().getEmail());
     }
 
-    @Test( expected = HttpClientErrorException.class )
+    @Test
     public void testCreateProjectWithBadStatusCode() {
         mockedServer.expect(requestTo(PROJECTS_ENDPOINT))
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withBadRequest());
-        client.createProject(new SW360Project(), new HttpHeaders());
-    }
-
-    @Test
-    public void testGetProjectWithSuccess() {
-        String projectId = "anyId";
-        String requestUrl = PROJECTS_ENDPOINT + "/" + projectId;
-        String expectedResponseBody = new JsonObject(new HashMap<String, String>() {{
-            put(PROJECT_NAME_KEY, PROJECT_NAME_VALUE_1);
-            put(PROJECT_VERSION_KEY, PROJECT_VERSION_VALUE_1);
-            put(PROJECT_PROJECT_TYPE_KEY, PROJECT_PROJECT_TYPE_VALUE_1);
-        }}).toJson();
-
-        mockedServer.expect(requestTo(requestUrl))
-                .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-                .andRespond(withSuccess(expectedResponseBody, MediaType.APPLICATION_JSON));
-
-        SW360Project project = client.getProject(projectId, new HttpHeaders());
-
-        assertNotNull(project);
-        assertEquals(PROJECT_NAME_VALUE_1, project.getName());
-        assertEquals(PROJECT_PROJECT_TYPE_VALUE_1, project.getProjectType().toString());
-        assertEquals(PROJECT_VERSION_VALUE_1, project.getVersion());
-    }
-
-    @Test( expected = HttpClientErrorException.class )
-    public void testGetProjectWithBadStatusCode() {
-        String projectId = "anyId";
-        String requestUrl = PROJECTS_ENDPOINT + "/" + projectId;
-        mockedServer.expect(requestTo(requestUrl))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withBadRequest());
-        client.getProject(projectId, new HttpHeaders());
+        SW360Project sw360Project = new SW360Project();
+        SW360Project projectAfter = client.createProject(sw360Project, new HttpHeaders());
+        assertEquals(sw360Project.hashCode(), projectAfter.hashCode());
+        assertEquals(sw360Project, projectAfter);
     }
 }


### PR DESCRIPTION
Fixes #358
Exception handling was reworked to catch places where due to a
runtime excpetion thrown within SW360 the Antenna build failed
without throwing an ExecutionException and without a log/excpetion
explaining the error and source properly.

Furthermore most thrown ExecutionExceptions where removed and
replaced with LOGGER inputs to avoid the Antenna build to fail.
Now an error or debug message will be logged.
Errors in the communication with SW360 should not make the Antenna
run fail, since they are not crucial for an attribution document.

The function getProject in the SW360ProjectClient and the test
testing that function are removed because they are never used.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  improvements | bug fixes

### How Has This Been Tested?
Example project was run with SW360 Enricher and Updater activated. 
Some errors where provoked and resulted in the wished behaviour. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages