### PR TITLE
integrate ORT Downloader as a processor step

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/ort-downloader.md
+++ b/antenna-documentation/src/site/markdown/processors/ort-downloader.md
@@ -1,0 +1,12 @@
+## ORT Downloader 
+The ORT Downloader processor downloads the sources of each artifact if no `ArtifactSourceFile` fact is present.
+
+### HowTo Use
+Add the following step into the `<processors>` section of your workflow.xml
+
+```xml
+<step>
+    <name>ORT Downloader</name>
+    <classHint>org.eclipse.sw360.antenna.workflow.processors.enricher.OrtDownloaderProcessor</classHint>
+</step>
+```

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
@@ -139,6 +139,8 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
 
         enricher.setDeactivated(true);
         processors.add(enricher);
+        enricher = mkWorkflowStep("ORT Downloader", "org.eclipse.sw360.antenna.ort.workflow.processors.enricher.OrtDownloaderProcessor");
+        processors.add(enricher);
         return processors;
     }
 

--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -217,6 +217,10 @@
             <groupId>com.github.ralfstuckert.pdfbox-layout</groupId>
             <artifactId>pdfbox2-layout</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <artifactId>downloader</artifactId>
+        </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
             <groupId>junit</groupId>

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactVcsInfo.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactVcsInfo.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.model.artifact.facts;
+
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ArtifactVcsInfo implements ArtifactFact<ArtifactVcsInfo> {
+    private final VcsInfo vcsInfo;
+
+    public static class VcsInfo {
+        private final String type;
+        private final String url;
+        private final String revision;
+
+        public VcsInfo(String type, String url, String revision) {
+            this.type = type;
+            this.url = url;
+            this.revision = revision;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public String getRevision() {
+            return revision;
+        }
+
+        public boolean isEmpty() {
+            return type == null && url == null && revision == null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            VcsInfo vcsInfo = (VcsInfo) o;
+            return Objects.equals(type, vcsInfo.type) &&
+                    Objects.equals(url, vcsInfo.url) &&
+                    Objects.equals(revision, vcsInfo.revision);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, url, revision);
+        }
+
+        @Override
+        public String toString() {
+            return "VcsInfo{" +
+                    "type='" + type + '\'' +
+                    ", url='" + url + '\'' +
+                    ", revision='" + revision + '\'' +
+                    '}';
+        }
+    }
+
+    public ArtifactVcsInfo(String type, String url, String revision) {
+        this(new VcsInfo(type, url, revision));
+    }
+
+    public ArtifactVcsInfo(VcsInfo vcsInfo) {
+        this.vcsInfo = vcsInfo;
+    }
+
+    public VcsInfo getVcsInfo() {
+        return vcsInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArtifactVcsInfo that = (ArtifactVcsInfo) o;
+        return Objects.equals(vcsInfo, that.vcsInfo);
+    }
+
+    @Override
+    public String toString() {
+        return Optional.ofNullable(vcsInfo)
+                .map(Objects::toString)
+                .orElse("EMPTY");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vcsInfo);
+    }
+
+    @Override
+    public String getFactContentName() {
+        return "VCS Information";
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return vcsInfo == null;
+    }
+
+    @Override
+    public String prettyPrint() {
+        return "Set ArtifactVcsInfo to " + toString();
+    }
+}

--- a/example-projects/example-project/src/workflow.xml
+++ b/example-projects/example-project/src/workflow.xml
@@ -61,6 +61,10 @@
             </configuration>
             <deactivated>true</deactivated>
         </step>
+        <step>
+            <name>ORT Downloader</name>
+            <classHint>org.eclipse.sw360.antenna.ort.workflow.processors.enricher.OrtDownloaderProcessor</classHint>
+        </step>
     </processors>
     <generators>
         <step>

--- a/example-projects/mvn-test-project/src/workflow.xml
+++ b/example-projects/mvn-test-project/src/workflow.xml
@@ -47,6 +47,10 @@
             </configuration>
             <deactivated>true</deactivated>
         </step>
+        <step>
+            <name>ORT Downloader</name>
+            <classHint>org.eclipse.sw360.antenna.ort.workflow.processors.enricher.OrtDownloaderProcessor</classHint>
+        </step>
     </processors>
     <generators>
         <step>

--- a/modules/ort/pom.xml
+++ b/modules/ort/pom.xml
@@ -58,6 +58,10 @@
             <groupId>com.github.heremaps.oss-review-toolkit</groupId>
             <artifactId>model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <artifactId>downloader</artifactId>
+        </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -47,6 +47,11 @@ private fun mapSourceUrl(pkg: Package): ArtifactSourceUrl? =
         ArtifactSourceUrl(it)
     }
 
+private fun mapVcsInfo(pkg: Package) : ArtifactVcsInfo? =
+        pkg.vcs.takeUnless { it == VcsInfo.EMPTY }?.let {
+            ArtifactVcsInfo(it.type.toString(), it.url, it.revision)
+        }
+
 private fun mapDeclaredLicense(pkg: Package): DeclaredLicenseInformation? =
     pkg.declaredLicensesProcessed.allLicenses.takeUnless { it.isEmpty() }?.let {
         DeclaredLicenseInformation(LicenseSupport.mapLicenses(it))
@@ -86,6 +91,7 @@ class OrtResultArtifactResolver(result: OrtResult) : Function<Package, Artifact>
             a.addCoordinate(mapCoordinates(pkg))
 
             mapSourceUrl(pkg)?.let { a.addFact(it) }
+            mapVcsInfo(pkg)?.let { a.addFact(it) }
             mapDeclaredLicense(pkg)?.let { a.addFact(it) }
             mapFilename(pkg)?.let { a.addFact(it) }
             mapHomepage(pkg)?.let { a.addFact(it) }

--- a/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
+++ b/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.ort.utils
+
+import com.here.ort.model.*
+import org.eclipse.sw360.antenna.model.artifact.Artifact
+import org.eclipse.sw360.antenna.model.artifact.ArtifactCoordinates
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactVcsInfo
+import java.util.function.Function
+
+const val MAVEN_TYPE_KEY = "Maven"
+const val NPM_TYPE_KEY = "NPM"
+const val NUGET_TYPE_KEY = "nuget"
+const val UNMANAGED_TYPE_KEY = "Unmanaged"
+
+class ArtifactToPackageMapper : Function<Artifact, Package> {
+    override fun apply(artifact: Artifact): Package {
+        return Package(
+                id = mapIdentifier(artifact) ?: Identifier.EMPTY,
+                declaredLicenses = sortedSetOf(),
+                description = "",
+                homepageUrl = "",
+                binaryArtifact = RemoteArtifact.EMPTY,
+                sourceArtifact = mapSourceRemoteArtifact(artifact) ?: RemoteArtifact.EMPTY,
+                vcs = mapVcsInfo(artifact) ?: VcsInfo.EMPTY
+        )
+    }
+
+    private fun mapIdentifier(artifact: Artifact): Identifier? =
+            artifact.askFor(ArtifactCoordinates::class.java).takeIf { it.isPresent }?.let {
+                val coordinates = it.get()
+                val type = coordinates.mainCoordinate.type.toLowerCase()
+                val namespace = coordinates.mainCoordinate.namespace ?: ""
+                val name = coordinates.mainCoordinate.name ?: ""
+                val version = coordinates.mainCoordinate.version ?: ""
+                val ortType = when (type) {
+                    "maven" -> MAVEN_TYPE_KEY
+                    "npm" -> NPM_TYPE_KEY
+                    "nuget" -> NUGET_TYPE_KEY
+                    else -> UNMANAGED_TYPE_KEY
+                }
+                Identifier(type = ortType, namespace = namespace, name = name, version = version)
+            }
+
+    private fun mapVcsInfo(artifact: Artifact) : VcsInfo? =
+        artifact.askFor(ArtifactVcsInfo::class.java).takeIf { it.isPresent }?.let {
+            val vcsInfo = it.get().vcsInfo
+            VcsInfo(type = VcsType(vcsInfo.type), url = vcsInfo.url, revision = vcsInfo.revision)
+        }
+
+    private fun mapSourceRemoteArtifact(artifact: Artifact) : RemoteArtifact? =
+        artifact.askForGet(ArtifactSourceUrl::class.java).takeIf { it.isPresent }?.let {
+            RemoteArtifact.EMPTY.copy(url = it.get())
+        }
+
+
+}

--- a/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
+++ b/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.ort.workflow.processors.enricher
+
+import com.here.ort.downloader.DownloadException
+import com.here.ort.downloader.Downloader
+import com.here.ort.utils.encodeOrUnknown
+import com.here.ort.utils.packZip
+import org.eclipse.sw360.antenna.api.exceptions.ConfigurationException
+import org.eclipse.sw360.antenna.model.artifact.Artifact
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile
+import org.slf4j.LoggerFactory
+import org.eclipse.sw360.antenna.ort.utils.ArtifactToPackageMapper
+import java.io.File
+import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor
+import org.eclipse.sw360.antenna.model.artifact.ArtifactCoordinates
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename
+
+class OrtDownloaderProcessor : AbstractProcessor() {
+    companion object {
+        const val ORT_DOWNLOADER_DIR = "ort-downloader-result"
+        private val LOGGER = LoggerFactory.getLogger(OrtDownloaderProcessor::class.java)
+    }
+
+    init {
+        workflowStepOrder = 350
+    }
+
+    private lateinit var sourcesZipDirectory: File
+
+    override fun configure(configMap: MutableMap<String, String>) {
+        sourcesZipDirectory = context.toolConfiguration.antennaTargetDirectory.resolve(ORT_DOWNLOADER_DIR).toFile()
+        if (!sourcesZipDirectory.isDirectory && !sourcesZipDirectory.mkdirs()) {
+            throw ConfigurationException("Failed to create directory '${sourcesZipDirectory.absolutePath}' " +
+                    "for ORT Downloader result. ")
+        }
+    }
+
+    override fun process(intermediates: MutableCollection<Artifact>): MutableCollection<Artifact> {
+        intermediates.filterNot {
+            it.sourceFile.isPresent
+        }.forEach { artifact ->
+            val pkg = ArtifactToPackageMapper().apply(artifact)
+            val name = artifact.askFor(ArtifactCoordinates::class.java).takeIf {
+                fact -> fact.isPresent
+            }?.get()?.mainCoordinate?.canonicalize() ?: artifact.askFor(ArtifactFilename::class.java).takeIf {
+                fact -> fact.isPresent
+            }?.let { filename ->
+                filename.get().bestFilenameEntryGuess.takeIf { filenameEntry ->
+                    filenameEntry.isPresent
+                }?.get()?.filename
+            } ?: "unknown"
+            try {
+                LOGGER.debug("Download sources via ORT Downloader for '${name}'")
+                val ortDownloadDirectory = createTempDir("ortDownloaderDirectory").also { it.deleteOnExit() }
+                val downloadResult = Downloader().download(pkg, ortDownloadDirectory)
+                if (downloadResult.downloadDirectory.isDirectory) {
+                    val zipFile = File(
+                            sourcesZipDirectory,
+                            "${pkg.id.name.encodeOrUnknown()}-${pkg.id.version.encodeOrUnknown()}.zip"
+                    )
+                    LOGGER.debug("Pack source directory '${downloadResult.downloadDirectory.absolutePath}' to " +
+                            "'${zipFile.absolutePath}.")
+                    downloadResult.downloadDirectory.packZip(zipFile)
+
+                    if (zipFile.isFile) {
+                        artifact.addFact(ArtifactSourceFile(zipFile.toPath()))
+                    }
+                }
+            } catch (e: DownloadException) {
+                LOGGER.warn("Failed to download sources for '${name}'")
+            }
+        }
+        return intermediates
+    }
+}

--- a/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
+++ b/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
@@ -92,6 +92,14 @@ public class OrtResultAnalyzerTest {
                 .flatMap(s -> Stream.of(s.split("\n"))).toArray())
                 .hasSize(4);
 
+        assertThat(artifacts.stream()
+                .map(artifact -> artifact.askFor(ArtifactVcsInfo.class))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .anyMatch(o -> "https://github.com/babel/babel/tree/master/packages/babel-generator"
+                        .equals(o.getVcsInfo().getUrl())))
+                .isTrue();
+
         assertThat(sourceUrls).hasSize(1);
 
         assertThat(sourceUrls).contains("https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz");

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,11 @@
             </dependency>
             <dependency>
                 <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+                <artifactId>downloader</artifactId>
+                <version>${ort.rev}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.heremaps.oss-review-toolkit</groupId>
                 <artifactId>spdx-utils</artifactId>
                 <version>${ort.rev}</version>
             </dependency>


### PR DESCRIPTION
Resolves https://github.com/eclipse/antenna/issues/326

This PR implements a new processor step, in which the ORT Downloader is programmatically called. The ORT Downloader downloads the sources of the artifacts in a temporary directory if it has no local sources. Afterwards it will be archived to a ZIP file in the hardcoded directory `<AntennaTargetDirectory>/ort-downloader-result` and saved in the artifact model. 

New Dependencies: 
- com.github.heremaps.oss-review-toolkit:downloader:f91202964b

### Request Reviewer
@sschuberth @blaumeiser-at-bosch @neubs-bsi 

### Type of Change
new feature | documentation update

### How Has This Been Tested?
Run `example-projects/example-project` with `mvn clean package` and check the `ort-downloader-result` directory and the `sources.zip` file, which now contains also the sources of the JS components. 

### Checklist
- [x] All related issues are referenced in commit messages
- [x] I have updated the documentation accordingly to my changes 
