### PR TITLE
fix javadoc comments

### DIFF
--- a/modules/attribution-document/attribution-document-core/pom.xml
+++ b/modules/attribution-document/attribution-document-core/pom.xml
@@ -21,7 +21,6 @@
         <relativePath>../</relativePath>
     </parent>
     <artifactId>attribution-document-core</artifactId>
-    <name>Attribution Document::Core</name>
     <description>Core library for the generation of the attribution document</description>
 
     <dependencies>

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/TemplateBundle.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/TemplateBundle.java
@@ -19,11 +19,11 @@ import java.util.Optional;
  * Describes the templates to be used in document generation.
  *
  * This is used as service provider interface, so this is used to load implementations from classpath (via
- * {@link java.util.ServiceLoader}.
- * <p />
+ * {@link java.util.ServiceLoader}).
+ * <p>
  * As there potentially might be multiple template bundles available, this must return a key, that is used by
  * {@link TemplateLoaderUtil} to select the correct implementation.
- * <p />
+ * <p>
  * As an optional feature, you can provide your own fonts here. Typically this would mean to load a ttf-file from
  * classpath using PDType0Font.
  *
@@ -32,7 +32,7 @@ import java.util.Optional;
 public interface TemplateBundle {
    /**
     * The key identifies this bundle.
-    * <p />
+    * <p>
     * It is intended to be used in the configuration in order to load the correct template. Thus, this should have a
     * meaningful name and to some degree unique.
     *

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/model/ArtifactAndLicense.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/model/ArtifactAndLicense.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) Robert Bosch Manufacturing Solutions GmbH 2019.
- * <p>
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.sw360.antenna.attribution.document.core.model;
@@ -26,7 +26,7 @@ public interface ArtifactAndLicense {
     /**
      * @return (non - null) the package-url as String representation. This should be present if the artifact is a component
      * (e.g. a Maven artifact, a NPM module, ..)
-     * @see https://github.com/package-url/purl-spec
+     * @see <a href="https://github.com/package-url/purl-spec">PURL specification</a>
      */
     Optional<String> getPurl();
 

--- a/modules/attribution-document/attribution-document-demo-bundle/pom.xml
+++ b/modules/attribution-document/attribution-document-demo-bundle/pom.xml
@@ -22,7 +22,6 @@
     </parent>
 
     <artifactId>attribution-document-demo-bundle</artifactId>
-    <name>Attribution Document::Demo Bundle</name>
     <description>A demo bundle showing how the templating works.</description>
 
     <dependencies>

--- a/modules/attribution-document/attribution-document-generator/pom.xml
+++ b/modules/attribution-document/attribution-document-generator/pom.xml
@@ -22,7 +22,6 @@
     </parent>
 
     <artifactId>attribution-document-generator</artifactId>
-    <name>Attribution Document::Generator</name>
     <description>Antenna integration for the generation of the attribution document.</description>
 
     <dependencies>

--- a/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/ArtifactAdapter.java
+++ b/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/ArtifactAdapter.java
@@ -29,8 +29,9 @@ import org.eclipse.sw360.antenna.model.xml.generated.LicenseInformation;
 
 /**
  * This adapter helps to encapsulate Antenna API.
- * <p />
- * In the current state it may still be changed and this should help to limit the places that need to change to < 2.
+ * <p>
+ * In the current state it may still be changed and this should help to limit the places that need to change to
+ * {@literal <} 2.
  */
 public class ArtifactAdapter implements ArtifactAndLicense {
 

--- a/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
+++ b/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Attribution Document Generator for Antenna.
- * <p />
+ * <p>
  * This can be added as a step in the workflow configuration of Antenna. Please consult the Antenna documentation on how
  * to do this.
  */

--- a/modules/attribution-document/pom.xml
+++ b/modules/attribution-document/pom.xml
@@ -21,7 +21,6 @@
     </parent>
 
     <artifactId>attribution-document</artifactId>
-    <name>attribution-document-module</name>
     <packaging>pom</packaging>
 
 


### PR DESCRIPTION
Fixes the javadoc comments in the `attribution-document` module.

### Request Reviewer
@neubs-bsi @blaumeiser-at-bosch 

### Type of Change
fix  

### How Has This Been Tested?
Run `mvn javadoc:javadoc` 
