### PR TITLE
docs: Remove an outdated comment about limiting ORT result files to YAML format

### DIFF
--- a/antenna-documentation/src/site/markdown/analyzers/ort-result-analyzer-step.md
+++ b/antenna-documentation/src/site/markdown/analyzers/ort-result-analyzer-step.md
@@ -1,11 +1,9 @@
 ## ORT Result Analyzer
-This analyzer investigates a given *yaml* file that was created by the [*OSS Review Toolkit* (ORT)](https://github.com/heremaps/oss-review-toolkit/) from *heremaps*.
+This analyzer uses the information provided in a given result file of a project that was analyzed and / or scanned with
+the [*OSS Review Toolkit* (ORT)](https://github.com/heremaps/oss-review-toolkit/).  
 
-This analyzer collects the dependencies of a given result of a project that was scanned or analyzed with ORT and has the corresponding yaml output format.  
-ORT has several possible steps that can be performed. 
-This analyzer only supports results created from the *Scan* and *Analyze* steps of the tool.
-
-For more information on how to use and execute the *OSS Review Toolkit* we refer you to their [repository](https://github.com/heremaps/oss-review-toolkit/).
+For more information on how to use and execute ORT we refer you to its
+[Getting Started](https://github.com/heremaps/oss-review-toolkit/blob/master/docs/GettingStarted.md) guide.
 
 ### How to use
 Add the following step into the `<analyzers>` section of your workflow.xml
@@ -15,8 +13,8 @@ Add the following step into the `<analyzers>` section of your workflow.xml
                     <name>Ort Result Analyzer</name>
                     <classHint>org.eclipse.sw360.antenna.ort.workflow.analyzers.OrtResultAnalyzer</classHint>
                     <configuration>
-                        <entry key="base.dir"  value="${project.basedir}"/>
-                        <entry key="file.path" value="ort/scan-result.yml"/>
+                        <entry key="base.dir" value="${project.basedir}" />
+                        <entry key="file.path" value="ort/scan-result.yml" />
                     </configuration>
         </step>
 ```
@@ -24,4 +22,3 @@ Add the following step into the `<analyzers>` section of your workflow.xml
 #### Explanation of parameters
 * `base.dir`: the base dir
 * `file.path`: Relative path to the ort result file. 
-Note: The file needs to be in a yaml format, since at the time of writing this analyzer that is standard output format of the ORT result files from the Analyzer or Scanner. 


### PR DESCRIPTION
This limitation had been removed already in a734c5b. While at it, also
reword some sentences to reduce duplication and be more precise.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

### Type of Change
documentation update

*Type of change*:  

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have updated the documentation accordingly to my changes 
