### PR TITLE
Restructure serialization of SW360HalResources

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/SW360Attributes.java
@@ -20,50 +20,14 @@ public class SW360Attributes {
     public static final String PROJECT_RELEASES_TRANSITIVE ="transitive";
     public static final String COMPONENT_SEARCH_BY_NAME = "name";
 
-
-    // Attributes of Sw360Project
-    public static final String PROJECT_ID = "id";
-    public static final String PROJECT_TYPE = "type";
-    public static final String PROJECT_NAME = "name";
-    public static final String PROJECT_VERSION = "version";
-    public static final String PROJECT_PROJECT_TYPE = "projectType";
-    public static final String PROJECT_DESCRIPTION = "description";
-    public static final String PROJECT_EXTERNAL_IDS = "externalIds";
-    public static final String PROJECT_CREATED_ON= "createdOn";
-    public static final String PROJECT_BUSINESS_UNIT = "businessUnit";
-    public static final String PROJECT_CLEARING_TEAM= "clearingTeam";
-    public static final String PROJECT_VISIBILITY = "visbility";
-    public static final String PROJECT_RELEASE_ID_TO_USAGE = "releaseIdToUsage";
-
-    // Attributes of Sw360Component
-    public static final String COMPONENT_ID = "id";
-    public static final String COMPONENT_COMPONENT_NAME = "name";
-    public static final String COMPONENT_COMPONENT_TYPE = "componentType";
-    public static final String COMPONENT_TYPE = "type";
-    public static final String COMPONENT_CREATED_ON = "createdOn";
-    public static final String COMPONENT_CATEGORIES = "categories";
-    public static final String COMPONENT_HOMEPAGE = "homepage";
-
-    // Attributes of Sw360Release
-    public static final String RELEASE_ID = "id";
-    public static final String RELEASE_COMPONENT_ID = "componentId";
-    public static final String RELEASE_NAME = "name";
-    public static final String RELEASE_VERSION = "version";
-    public static final String RELEASE_CPE_ID = "cpeId";
-    public static final String RELEASE_SOURCES = "downloadurl";
-    public static final String RELEASE_MAIN_LICENSE_IDS = "mainLicenseIds";
-    public static final String RELEASE_EXTERNAL_IDS = "externalIds";
-
     // Attributes of Sw360Attachment
     public static final String ATTACHMENT_ATTACHMENT_TYPE = "attachmentType";
     public static final String ATTACHMENT_CHECK_STATUS = "checkStatus";
 
     // Attributes of Sw360License
-    public static final String LICENSE_TYPE = "type";
     public static final String LICENSE_TEXT = "text";
     public static final String LICENSE_SHORT_NAME = "shortName";
     public static final String LICENSE_FULL_NAME = "fullName";
-    public static final String LICENSE_EXTERNAL_IDS = "externalIds";
 
     // Attributes of Sw360Authenticator
     public static final String AUTHENTICATOR_GRANT_TYPE = "grant_type";

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/components/SW360Component.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/components/SW360Component.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.rest.resource.components;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
@@ -21,7 +22,6 @@ import java.util.Optional;
 public class SW360Component extends SW360HalResource<LinkObjects, SW360ComponentEmbedded> {
     private String name;
     private SW360ComponentType componentType;
-    private String type;
     private String createdOn;
     private String homepage;
 
@@ -33,6 +33,7 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
                 .orElse(null);
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getName() {
         return this.name;
     }
@@ -42,15 +43,7 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
         return this;
     }
 
-    public String getType() {
-        return this.type;
-    }
-
-    public SW360Component setType(String type) {
-        this.type = type;
-        return this;
-    }
-
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getCreatedOn() {
         return this.createdOn;
     }
@@ -60,6 +53,7 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public SW360ComponentType getComponentType() {
         return this.componentType;
     }
@@ -69,6 +63,7 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHomepage() {
         return this.homepage;
     }
@@ -96,13 +91,12 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
         SW360Component that = (SW360Component) o;
         return Objects.equals(name, that.name) &&
                 componentType == that.componentType &&
-                Objects.equals(type, that.type) &&
                 Objects.equals(createdOn, that.createdOn) &&
                 Objects.equals(homepage, that.homepage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), name, componentType, type, createdOn, homepage);
+        return Objects.hash(super.hashCode(), name, componentType, createdOn, homepage);
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/licenses/SW360License.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/licenses/SW360License.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resource.licenses;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.Embedded;
 import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
@@ -30,6 +31,7 @@ public class SW360License extends SW360HalResource<LinkObjects, Embedded> {
         this.text = license.getText();
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getText() {
         return this.text;
     }
@@ -39,6 +41,7 @@ public class SW360License extends SW360HalResource<LinkObjects, Embedded> {
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getShortName() {
         return this.shortName;
     }
@@ -48,6 +51,7 @@ public class SW360License extends SW360HalResource<LinkObjects, Embedded> {
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFullName() {
         return this.fullName;
     }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/projects/SW360Project.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/projects/SW360Project.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.sw360.antenna.sw360.rest.resource.projects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.sw360.antenna.api.IProject;
 import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
@@ -22,7 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 
 public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbedded> {
-    private String type;
     private String name;
     private String version;
     private SW360ProjectType projectType;
@@ -45,15 +45,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         visibility = SW360Visibility.BUISNESSUNIT_AND_MODERATORS;
     }
 
-    public String getType() {
-        return this.type;
-    }
-
-    public SW360Project setType(String type) {
-        this.type = type;
-        return this;
-    }
-
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getName() {
         return this.name;
     }
@@ -63,6 +55,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getVersion() {
         return this.version;
     }
@@ -72,6 +65,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDescription() {
         return this.description;
     }
@@ -81,6 +75,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Map<String, String> getExternalIds() {
         return this.externalIds;
     }
@@ -90,6 +85,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getCreatedOn() {
         return this.createdOn;
     }
@@ -99,6 +95,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getBusinessUnit() {
         return this.businessUnit;
     }
@@ -108,6 +105,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public SW360ProjectType getProjectType() {
         return this.projectType;
     }
@@ -117,6 +115,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getClearingTeam() {
         return this.clearingTeam;
     }
@@ -126,6 +125,7 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         return this;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public SW360Visibility getVisibility() {
         return this.visibility;
     }
@@ -170,21 +170,19 @@ public class SW360Project extends SW360HalResource<LinkObjects, SW360ProjectEmbe
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         SW360Project that = (SW360Project) o;
-        return Objects.equals(type, that.type) &&
-                Objects.equals(name, that.name) &&
+        return Objects.equals(name, that.name) &&
                 Objects.equals(version, that.version) &&
                 projectType == that.projectType &&
                 Objects.equals(description, that.description) &&
                 Objects.equals(externalIds, that.externalIds) &&
                 Objects.equals(createdOn, that.createdOn) &&
                 Objects.equals(businessUnit, that.businessUnit) &&
-                Objects.equals(clearingTeam, that.clearingTeam) &&
                 visibility == that.visibility &&
                 Objects.equals(releaseIdToUsage, that.releaseIdToUsage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type, name, version, projectType, description, externalIds, createdOn, businessUnit, clearingTeam, visibility, releaseIdToUsage);
+        return Objects.hash(super.hashCode(), name, version, projectType, description, externalIds, createdOn, businessUnit, visibility, releaseIdToUsage);
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/projects/SW360ProjectReleaseRelationship.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/projects/SW360ProjectReleaseRelationship.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.sw360.antenna.sw360.rest.resource.projects;
 
+import java.util.Objects;
+
 public class SW360ProjectReleaseRelationship {
     public SW360ReleaseRelationship releaseRelation;
     public SW360MainlineState mainlineState;
@@ -39,5 +41,19 @@ public class SW360ProjectReleaseRelationship {
     public SW360ProjectReleaseRelationship setMainlineState(SW360MainlineState mainlineState) {
         this.mainlineState = mainlineState;
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SW360ProjectReleaseRelationship that = (SW360ProjectReleaseRelationship) o;
+        return releaseRelation == that.releaseRelation &&
+                mainlineState == that.mainlineState;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(releaseRelation, mainlineState);
     }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
@@ -16,17 +16,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Attributes;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360Attachment;
-import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
-import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360Project;
-import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 public class RestUtils {
     private static ObjectMapper objectMapper = new ObjectMapper();
@@ -39,32 +34,9 @@ public class RestUtils {
             throw new ExecutionException("Error when attempting to serialise the request body.", e);
         }
     }
-
-    public static HttpEntity<String> convertSW360ResourceToHttpEntity(SW360Project sw360Project, HttpHeaders header) {
-        Map<String, Object> project = new HashMap<>();
-        project.put(SW360Attributes.PROJECT_NAME, sw360Project.getName());
-        project.put(SW360Attributes.PROJECT_VERSION, sw360Project.getVersion());
-        project.put(SW360Attributes.PROJECT_DESCRIPTION, sw360Project.getDescription());
-        project.put(SW360Attributes.PROJECT_PROJECT_TYPE, sw360Project.getProjectType());
-        project.put(SW360Attributes.PROJECT_BUSINESS_UNIT, sw360Project.getBusinessUnit());
-        project.put(SW360Attributes.PROJECT_CLEARING_TEAM, sw360Project.getClearingTeam());
-        project.put(SW360Attributes.PROJECT_VISIBILITY, sw360Project.getVisibility());
-        return getHttpEntity(project, header);
-    }
-
-    public static HttpEntity<String> convertSW360ResourceToHttpEntity(SW360Component sw360Component, HttpHeaders header) {
-        Map<String, Object> component = new HashMap<>();
-        component.put(SW360Attributes.COMPONENT_COMPONENT_NAME, sw360Component.getName());
-        Optional.ofNullable(sw360Component.getComponentType())
-                .map(Objects::toString)
-                .ifPresent(componentType -> component.put(SW360Attributes.COMPONENT_COMPONENT_TYPE, componentType));
-        component.put(SW360Attributes.COMPONENT_HOMEPAGE, sw360Component.getHomepage());
-        return getHttpEntity(component, header);
-    }
-
-    public static HttpEntity<String> convertSW360ResourceToHttpEntity(SW360Release sw360Release, HttpHeaders header) {
+    public static <T> HttpEntity<String> convertSW360ResourceToHttpEntity(T itemToConvert, HttpHeaders header) {
         try {
-            String jsonBody = objectMapper.writeValueAsString(sw360Release);
+            String jsonBody = objectMapper.writeValueAsString(itemToConvert);
             return new HttpEntity<>(jsonBody, header);
         } catch (JsonProcessingException e) {
             throw new ExecutionException("Error when attempting to serialise the request body.", e);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ProjectAdapterUtils.java
@@ -36,13 +36,6 @@ public class SW360ProjectAdapterUtils {
         }
     }
 
-    public static void setClearingTeam(SW360Project project, String clearingTeam) {
-        if (clearingTeam != null &&
-                !clearingTeam.isEmpty()) {
-            project.setClearingTeam(clearingTeam);
-        }
-    }
-
     public static void prepareProject(SW360Project sw360Project, String projectName, String projectVersion) {
         SW360ProjectAdapterUtils.setName(sw360Project, projectName);
         SW360ProjectAdapterUtils.setVersion(sw360Project, projectVersion);

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/SW360ResourcesTestUtils.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/SW360ResourcesTestUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class SW360ResourcesTestUtils<T extends SW360HalResource<?,?>> {
+
+    public abstract T prepareItem();
+
+    public abstract Class<T> getHandledClassType();
+
+    @Test
+    public void serializationTest() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        final T release = prepareItem();
+
+        final String jsonBody = objectMapper.writeValueAsString(release);
+        final T deserialized = objectMapper.readValue(jsonBody, getHandledClassType());
+
+        assertThat(deserialized.get_Embedded())
+                .isEqualTo(release.get_Embedded());
+        assertThat(deserialized)
+                .isEqualTo(release);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/components/SW360ComponentsTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/components/SW360ComponentsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resources.components;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
+import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentType;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SW360ComponentsTest {
+    public SW360Component prepareComponent() {
+        SW360Component sw360Component = new SW360Component();
+        sw360Component.setName("Component Name");
+        sw360Component.setComponentType(SW360ComponentType.COTS);
+        sw360Component.setHomepage("componentName.org");
+        sw360Component.setCreatedOn("2019-12-09");
+        return sw360Component;
+    }
+
+    @Test
+    public void serializationTest() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        final SW360Component release = prepareComponent();
+
+        final String jsonBody = objectMapper.writeValueAsString(release);
+        final SW360Component deserialized = objectMapper.readValue(jsonBody, SW360Component.class);
+
+        assertThat(deserialized.get_Embedded())
+                .isEqualTo(release.get_Embedded());
+        assertThat(deserialized)
+                .isEqualTo(release);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/components/SW360ComponentsTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/components/SW360ComponentsTest.java
@@ -10,16 +10,13 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resources.components;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentType;
-import org.junit.Test;
+import org.eclipse.sw360.antenna.sw360.rest.resources.SW360ResourcesTestUtils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class SW360ComponentsTest {
-    public SW360Component prepareComponent() {
+public class SW360ComponentsTest extends SW360ResourcesTestUtils<SW360Component> {
+    @Override
+    public SW360Component prepareItem() {
         SW360Component sw360Component = new SW360Component();
         sw360Component.setName("Component Name");
         sw360Component.setComponentType(SW360ComponentType.COTS);
@@ -28,19 +25,8 @@ public class SW360ComponentsTest {
         return sw360Component;
     }
 
-    @Test
-    public void serializationTest() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
-        final SW360Component release = prepareComponent();
-
-        final String jsonBody = objectMapper.writeValueAsString(release);
-        final SW360Component deserialized = objectMapper.readValue(jsonBody, SW360Component.class);
-
-        assertThat(deserialized.get_Embedded())
-                .isEqualTo(release.get_Embedded());
-        assertThat(deserialized)
-                .isEqualTo(release);
+    @Override
+    public Class<SW360Component> getHandledClassType() {
+        return SW360Component.class;
     }
 }

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/licenses/SW360LicenseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/licenses/SW360LicenseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resources.licenses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SW360LicenseTest {
+    public SW360License prepareLicense() {
+        SW360License sw360License = new SW360License();
+        sw360License.setShortName("Test-2.0");
+        sw360License.setFullName("Test License 2.0");
+        sw360License.setText("Full License Text");
+        return sw360License;
+    }
+
+    @Test
+    public void serializationTest() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        final SW360License release = prepareLicense();
+
+        final String jsonBody = objectMapper.writeValueAsString(release);
+        final SW360License deserialized = objectMapper.readValue(jsonBody, SW360License.class);
+
+        assertThat(deserialized.get_Embedded())
+                .isEqualTo(release.get_Embedded());
+        assertThat(deserialized)
+                .isEqualTo(release);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/licenses/SW360LicenseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/licenses/SW360LicenseTest.java
@@ -10,15 +10,12 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resources.licenses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
-import org.junit.Test;
+import org.eclipse.sw360.antenna.sw360.rest.resources.SW360ResourcesTestUtils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class SW360LicenseTest {
-    public SW360License prepareLicense() {
+public class SW360LicenseTest extends SW360ResourcesTestUtils<SW360License> {
+    @Override
+    public SW360License prepareItem() {
         SW360License sw360License = new SW360License();
         sw360License.setShortName("Test-2.0");
         sw360License.setFullName("Test License 2.0");
@@ -26,19 +23,8 @@ public class SW360LicenseTest {
         return sw360License;
     }
 
-    @Test
-    public void serializationTest() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
-        final SW360License release = prepareLicense();
-
-        final String jsonBody = objectMapper.writeValueAsString(release);
-        final SW360License deserialized = objectMapper.readValue(jsonBody, SW360License.class);
-
-        assertThat(deserialized.get_Embedded())
-                .isEqualTo(release.get_Embedded());
-        assertThat(deserialized)
-                .isEqualTo(release);
+    @Override
+    public Class<SW360License> getHandledClassType() {
+        return SW360License.class;
     }
 }

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/projects/SW360ProjectTests.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/projects/SW360ProjectTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resources.projects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Visibility;
+import org.eclipse.sw360.antenna.sw360.rest.resource.projects.*;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SW360ProjectTests {
+    public SW360Project prepareProject() {
+        SW360Project sw360Project = new SW360Project();
+        sw360Project.setName("Project Name");
+        sw360Project.setVersion("1.0.0-SNAPSHOT");
+        sw360Project.setCreatedOn("2019-12-09");
+        sw360Project.setBusinessUnit("TestUnit");
+        sw360Project.setClearingTeam("ClearingUnit");
+        sw360Project.setDescription("This is a test project");
+        sw360Project.setProjectType(SW360ProjectType.SERVICE);
+        sw360Project.setVisibility(SW360Visibility.EVERYONE);
+        Map<String, SW360ProjectReleaseRelationship> releaseRelationshipMap = new LinkedHashMap<>();
+                releaseRelationshipMap.put("releaseName",
+                new SW360ProjectReleaseRelationship(
+                        SW360ReleaseRelationship.OPTIONAL,
+                        SW360MainlineState.OPEN));
+        sw360Project.setReleaseIdToUsage(releaseRelationshipMap);
+        return sw360Project;
+    }
+
+    @Test
+    public void serializationTest() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        final SW360Project release = prepareProject();
+
+        final String jsonBody = objectMapper.writeValueAsString(release);
+        final SW360Project deserialized = objectMapper.readValue(jsonBody, SW360Project.class);
+
+        assertThat(deserialized.get_Embedded())
+                .isEqualTo(release.get_Embedded());
+        assertThat(deserialized)
+                .isEqualTo(release);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/projects/SW360ProjectTests.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/projects/SW360ProjectTests.java
@@ -10,19 +10,16 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resources.projects;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Visibility;
 import org.eclipse.sw360.antenna.sw360.rest.resource.projects.*;
-import org.junit.Test;
+import org.eclipse.sw360.antenna.sw360.rest.resources.SW360ResourcesTestUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class SW360ProjectTests {
-    public SW360Project prepareProject() {
+public class SW360ProjectTests extends SW360ResourcesTestUtils<SW360Project> {
+    @Override
+    public SW360Project prepareItem() {
         SW360Project sw360Project = new SW360Project();
         sw360Project.setName("Project Name");
         sw360Project.setVersion("1.0.0-SNAPSHOT");
@@ -41,19 +38,8 @@ public class SW360ProjectTests {
         return sw360Project;
     }
 
-    @Test
-    public void serializationTest() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
-        final SW360Project release = prepareProject();
-
-        final String jsonBody = objectMapper.writeValueAsString(release);
-        final SW360Project deserialized = objectMapper.readValue(jsonBody, SW360Project.class);
-
-        assertThat(deserialized.get_Embedded())
-                .isEqualTo(release.get_Embedded());
-        assertThat(deserialized)
-                .isEqualTo(release);
+    @Override
+    public Class<SW360Project> getHandledClassType() {
+        return SW360Project.class;
     }
 }

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/releases/SW360ReleaseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/releases/SW360ReleaseTest.java
@@ -10,9 +10,8 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resources.releases;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.rest.resources.SW360ResourcesTestUtils;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -21,8 +20,9 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SW360ReleaseTest {
-    public SW360Release prepareRelease() {
+public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
+    @Override
+    public SW360Release prepareItem() {
         SW360Release release = new SW360Release();
         release.setName("Release Name");
         release.setVersion("1.2.3");
@@ -33,6 +33,11 @@ public class SW360ReleaseTest {
         release.setComponentId("COMPONENT_ID");
         release.setMainLicenseIds(Stream.of("MIT","BSD-3-Clause").collect(Collectors.toSet()));
         return release;
+    }
+
+    @Override
+    public Class<SW360Release> getHandledClassType() {
+        return SW360Release.class;
     }
 
     @Test
@@ -75,23 +80,7 @@ public class SW360ReleaseTest {
 
     @Test
     public void equalsTest() {
-        assertThat(prepareRelease())
-                .isEqualTo(prepareRelease());
-    }
-
-    @Test
-    public void serializationTest() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
-        final SW360Release release = prepareRelease();
-
-        final String jsonBody = objectMapper.writeValueAsString(release);
-        final SW360Release deserialized = objectMapper.readValue(jsonBody, SW360Release.class);
-
-        assertThat(deserialized.get_Embedded())
-                .isEqualTo(release.get_Embedded());
-        assertThat(deserialized)
-                .isEqualTo(release);
+        assertThat(prepareItem())
+                .isEqualTo(prepareItem());
     }
 }


### PR DESCRIPTION
> Please provide a summary of your changes here.

This uses the object mapper from the jackson databind library to
serialize and deserialize all SW360Objects except the attachments
(they are not compatible with the format yet and this should be done
when the roundtrip pr is merged).
This is adapted to the way the releases already were serialized and
helps make the code cleaner by avoiding set attribute variables in
a separate file and instead have the serialization with the objects.
Should the components or projects get externalIds those will also
be easier to map and test.

Tests have been added for the serialization of the objects.

The SW360Project class has been modified to include a clearing state.
SW360 Licenses are not serialized with the generic function yet because
of uncertainty with the full name short name situation.

### Request Reviewer
@blaumeiser-at-bosch .

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  Improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Several unit tests have been added to test the serialization changes.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages
    no related issue

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
