### PR TITLE
Document the ILicenseManagementKnowledgeBase implementations

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/license-knowledgebase-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/license-knowledgebase-resolver.md
@@ -12,3 +12,28 @@ Add the following step into the `<processors>` section of your workflow.xml
     <classHint>org.eclipse.sw360.antenna.workflow.processors.LicenseKnowledgeBaseResolver</classHint>
 </step>
 ```
+
+### ILicenseManagementKnowledgeBase implementations
+#### SPDXLicenseKnowledgeBase
+The `SPDXLicenseKnowledgeBase` uses the `spdx-tools` to obtain the license information from the SPDX license 
+database. The implementation uses especially the `ListedLicenses` class from SPDX and this retrieves the license
+information from the SPDX website if possible or from the `spdx-tools` binary, which contains all license 
+information.
+
+If the `ListedLicenses` class is not able to obtain the information from the SPDX website due to a network 
+problem (e.g. proxy environment), it will log an error 
+
+`[ERROR] I/O error opening Json TOC URL, using local TOC file` 
+
+or a warning:
+
+`[WARNING] Unable to open SPDX listed license model.  Using local file copy for SPDX listed licenses.`
+
+There is no reason to worry, because afterwards it will obtain the information from the `spdx-tools` binary. 
+
+#### CSVBasedLicenseKnowledgeBase
+The `CSVBasedLicenseKnowledgeBase` obtains the license information from a CSV file with the following format:
+```csv
+Identifier;Aliases;Name;LicenseURL;OpenSource;DeliverSources;DeliverLicense;CoveredByINSTStandardProcess;ThreatGroup
+EPL-1.0;;Eclipse Public License 1.0;http://spdx.org/licenses/EPL-1.0#licenseText;;;;;
+```


### PR DESCRIPTION
Partially fixes https://github.com/eclipse/antenna/issues/352
The SPDXLicenseKnowledgeBase logs an error/warning if the license
information could not be obtained from the SPDX website due to a
network problem. This commit only documents the spdx-tools behaviour.

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
documentation update

### Checklist
Must:
- [x] All related issues are referenced in commit messages
