### PR TITLE
Prevent NPE in Attribution Document Generator

### DIFF
--- a/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
+++ b/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
@@ -119,17 +119,19 @@ public class AttributionDocumentGenerator extends AbstractGenerator {
 
    @Override
    public void cleanup() {
-      Path cleanUpDir = docGenDir.toPath();
+      if (docGenDir != null) {
+         Path cleanUpDir = docGenDir.toPath();
 
-      if (!context.getDebug()) {
-         try {
-            Files.walk(cleanUpDir)
-                    .filter(p -> ! p.getFileName().equals(Paths.get(docName)))
-                    .map(Path::toFile)
-                    .forEach(File::delete);
-         } catch (IOException e) {
-            LOG.debug("Failed to clean up temporary directory=[" + docGenDir +
-                    "] for the generation of the attribution document");
+         if (!context.getDebug()) {
+            try {
+               Files.walk(cleanUpDir)
+                       .filter(p -> ! p.getFileName().equals(Paths.get(docName)))
+                       .map(Path::toFile)
+                       .forEach(File::delete);
+            } catch (IOException e) {
+               LOG.debug("Failed to clean up temporary directory=[" + docGenDir +
+                       "] for the generation of the attribution document");
+            }
          }
       }
    }


### PR DESCRIPTION
Fixes https://github.com/eclipse/antenna/issues/368
If the antenna workflow failed/aborted before the generators started,
the AttributionDocumentGenerator throwed an NPE. This commit just
prevents the NPE with an if condition.

### Request Reviewer
@neubs-bsi @blaumeiser-at-bosch 

### Type of Change
*bug fix*

### Checklist
Must:
- [x] All related issues are referenced in commit messages