### PR TITLE
Update SPDX tools to 2.1.20

### DIFF
--- a/assembly/spdx-license-knowledge-base/pom.xml
+++ b/assembly/spdx-license-knowledge-base/pom.xml
@@ -61,10 +61,6 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.github.jsonld-java.jsonld-java</groupId>
-                    <artifactId>jsonld-java</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <!-- ################################ compliance dependency ########################### -->

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
             <dependency>
                 <groupId>org.spdx</groupId>
                 <artifactId>spdx-tools</artifactId>
-                <version>2.1.15</version>
+                <version>2.1.20</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Fixes https://github.com/eclipse/antenna/issues/369
The transitive dependency jena-arq of spdx-tools is using jsonld-java
which could not be downloaded from Maven central due to a
misconfiguration. The update of spdx-tools solved the dependency
issue.

### Request Reviewer
@neubs-bsi 

### Type of Change
*bug fix*

### How Has This Been Tested?
- Build antenna from this branch `mvn clean install`
- Build the example-project -> No dependency problem

### Checklist
Must:
- [x] All related issues are referenced in commit messages
