### PR TITLE
Fix of #374 mainLicenseIds not writing to SW360

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -103,10 +103,10 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
 
     @JsonIgnore
     public boolean isSetMainLicenseIds() {
-        return get_Embedded().getLicenses() != null;
+        return !get_Embedded().getLicenses().isEmpty();
     }
 
-    @JsonIgnore
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getMainLicenseIds() {
         return Optional.ofNullable(get_Embedded().getLicenses())
                 .map(lics -> lics
@@ -116,7 +116,6 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
                 .orElse(Collections.emptySet());
     }
 
-    @JsonIgnore
     public SW360Release setMainLicenseIds(Set<String> mainLicenseIds) {
         if (mainLicenseIds.size() > 0) {
             List<SW360SparseLicense> licenses = mainLicenseIds.stream()


### PR DESCRIPTION
Changes isMainLicenseSet to check for empty set,
since it will never be null only an empty HashSet
as is set in the orElse statement.

Additionally the JsonIgnore of the get and set
MainLicenseIds in the Release where removed and
was replaced with a JsonInclude at the get method.

### Request Reviewer
@bs-ondem @blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
Tested manually on local SW360 instance

### Checklist
Must:
- [x] All related issues are referenced in commit messages