### PR TITLE
add Generic Type Extension SW360HalResource to T in RestUtils

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Attributes;
+import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +34,7 @@ public class RestUtils {
             throw new ExecutionException("Error when attempting to serialise the request body.", e);
         }
     }
-    public static <T> HttpEntity<String> convertSW360ResourceToHttpEntity(T itemToConvert, HttpHeaders header) {
+    public static <T extends SW360HalResource<?, ?>> HttpEntity<String> convertSW360ResourceToHttpEntity(T itemToConvert, HttpHeaders header) {
         try {
             String jsonBody = objectMapper.writeValueAsString(itemToConvert);
             return new HttpEntity<>(jsonBody, header);


### PR DESCRIPTION
This ensures that no objects that are not children of SW360
HalResource use this method, since we only want SW360 related
objects to use this.

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  improvement

### How Has This Been Tested?
Example Project was run with local SW360 instance
