### PR TITLE
Including namespace of Coordinate in SW360Component name

### DIFF
--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -18,6 +18,8 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ComponentAdapterUtils;
 import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 
 import java.util.ArrayList;
@@ -26,6 +28,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class SW360ComponentClientAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SW360ComponentClientAdapter.class);
+
     private final SW360ComponentClient componentClient;
 
     public SW360ComponentClientAdapter(String restUrl, ProxySettings proxySettings) {
@@ -52,9 +56,14 @@ public class SW360ComponentClientAdapter {
     }
 
     public Optional<SW360Component> getComponentByArtifact(Artifact artifact, HttpHeaders header) {
-        String componentName = SW360ComponentAdapterUtils.createComponentName(artifact);
-
-        return getComponentByName(componentName, header);
+        try {
+            String componentName = SW360ComponentAdapterUtils.createComponentName(artifact);
+            return getComponentByName(componentName, header);
+        } catch (ExecutionException e) {
+            LOGGER.debug("No component found for {}. Reason: {}", artifact.prettyPrint(), e.getMessage());
+            LOGGER.debug("Error: ", e);
+            return Optional.empty();
+        }
     }
 
     public Optional<SW360Component> getComponentByName(String componentName, HttpHeaders header) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.workflow.generators;
 
 import org.eclipse.sw360.antenna.api.IAttachable;
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
 import org.eclipse.sw360.antenna.model.xml.generated.License;
@@ -20,12 +21,16 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.utils.SW360AttachmentAdapterUtils;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class SW360UpdaterImpl {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SW360UpdaterImpl.class);
+
     private final String projectName;
     private final String projectVersion;
     private final SW360MetaDataUpdater sw360MetaDataUpdater;
@@ -49,19 +54,23 @@ public class SW360UpdaterImpl {
                         .map(SW360License::getShortName)
                         .collect(Collectors.toSet());
             }
-
-            final SW360Release sw360ReleaseFromArtifact = SW360ReleaseAdapterUtils.convertToRelease(artifact);
-            sw360ReleaseFromArtifact.setMainLicenseIds(licenseIds);
-            SW360Release sw360ReleaseFinal = sw360MetaDataUpdater.getOrCreateRelease(sw360ReleaseFromArtifact);
-            if (sw360MetaDataUpdater.isUploadSources()
-                    && sw360ReleaseFinal.get_Links().getSelf() != null
-                    && !sw360ReleaseFinal.get_Links().getSelf().getHref().isEmpty()) {
-                Map<Path, SW360AttachmentType> attachments = SW360AttachmentAdapterUtils.getAttachmentsFromArtifact(artifact);
-                if (!attachments.isEmpty()) {
-                    sw360ReleaseFinal = sw360MetaDataUpdater.uploadAttachments(sw360ReleaseFinal, attachments);
+            try {
+                final SW360Release sw360ReleaseFromArtifact = SW360ReleaseAdapterUtils.convertToRelease(artifact);
+                sw360ReleaseFromArtifact.setMainLicenseIds(licenseIds);
+                SW360Release sw360ReleaseFinal = sw360MetaDataUpdater.getOrCreateRelease(sw360ReleaseFromArtifact);
+                if (sw360MetaDataUpdater.isUploadSources()
+                        && sw360ReleaseFinal.get_Links().getSelf() != null
+                        && !sw360ReleaseFinal.get_Links().getSelf().getHref().isEmpty()) {
+                    Map<Path, SW360AttachmentType> attachments = SW360AttachmentAdapterUtils.getAttachmentsFromArtifact(artifact);
+                    if (!attachments.isEmpty()) {
+                        sw360ReleaseFinal = sw360MetaDataUpdater.uploadAttachments(sw360ReleaseFinal, attachments);
+                    }
                 }
+                releases.add(sw360ReleaseFinal);
+            } catch(ExecutionException e) {
+                LOGGER.error("Release will not be created in SW360. Reason: {}", e.getMessage());
+                LOGGER.debug("Error: ", e);
             }
-            releases.add(sw360ReleaseFinal);
         }
 
         sw360MetaDataUpdater.createProject(projectName, projectVersion, releases);

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/utils/SW360ComponentAdapterUtilsTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/utils/SW360ComponentAdapterUtilsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.utils;
+
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactCoordinates;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFilename;
+import org.eclipse.sw360.antenna.model.coordinates.Coordinate;
+import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
+import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentType;
+import org.eclipse.sw360.antenna.sw360.utils.SW360ComponentAdapterUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class SW360ComponentAdapterUtilsTest {
+    private Artifact artifact;
+    private String expectedName;
+    private SW360ComponentType expectedType;
+    private Class<? extends Exception> expectedException;
+    private String expectedExceptionMsg;
+
+    public SW360ComponentAdapterUtilsTest(Artifact artifact, String expectedName, SW360ComponentType expectedType,
+                                          Class<? extends Exception> expectedException, String expectedExceptionMsg) {
+        this.artifact = artifact;
+        this.expectedName = expectedName;
+        this.expectedType = expectedType;
+        this.expectedException = expectedException;
+        this.expectedExceptionMsg = expectedExceptionMsg;
+
+    }
+
+    @Parameterized.Parameters(name = "{index}: input={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {
+                    new Artifact()
+                            .setProprietary(true)
+                            .addFact(new ArtifactCoordinates(
+                                    new Coordinate(Coordinate.Types.MAVEN, "org.example", "lib", "1.0"))),
+                        "org.example/lib",
+                        SW360ComponentType.INTERNAL,
+                        null, null
+                },
+                {
+                    new Artifact()
+                            .setProprietary(false)
+                            .addFact(new ArtifactCoordinates(
+                                    new Coordinate(Coordinate.Types.NPM, "@organisation", "framework", "1.0"))),
+                        "@organisation/framework",
+                        SW360ComponentType.OSS,
+                        null, null
+                },
+                {
+                    new Artifact()
+                            .setProprietary(false)
+                            .addFact(new ArtifactCoordinates(
+                                    new Coordinate(Coordinate.Types.NUGET, "Org.Example", "Library", "1.0"))),
+                        "Org.Example/Library",
+                        SW360ComponentType.OSS,
+                        null, null
+                },
+                {
+                    new Artifact()
+                        .setProprietary(false)
+                        .addFact(new ArtifactFilename("library-filename.ext")),
+                        "library-filename.ext",
+                        SW360ComponentType.OSS,
+                        null, null
+                },
+                {
+                    new Artifact()
+                        .setProprietary(false),
+                        null,
+                        SW360ComponentType.OSS,
+                        ExecutionException.class, "does not have enough facts to create a component name."
+                }
+        });
+    }
+
+    @Rule
+    public ExpectedException thrownException = ExpectedException.none();
+
+    @Test
+    public void testCreateComponentFromArtifact() {
+        SW360Component component = new SW360Component();
+
+        if (expectedException != null) {
+            thrownException.expect(expectedException);
+            thrownException.expectMessage(expectedExceptionMsg);
+        }
+
+        SW360ComponentAdapterUtils.prepareComponent(component, artifact);
+
+        assertThat(component.getName()).isEqualTo(expectedName);
+        assertThat(component.getComponentType()).isEqualTo(expectedType);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generator/SW360UpdaterTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generator/SW360UpdaterTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.workflow.generator;
 
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.*;
 import org.eclipse.sw360.antenna.model.coordinates.Coordinate;
@@ -20,7 +21,9 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
 import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -31,6 +34,9 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SW360UpdaterTest extends AntennaTestWithMockedContext {
+
+    @Rule
+    public ExpectedException thrownException = ExpectedException.none();
 
     private String sourceUrl = "https://thrift.apache.org/";
     private String releaseTagUrl = "https://github.com/apache/thrift/releases/tag/0.10.0";
@@ -178,4 +184,14 @@ public class SW360UpdaterTest extends AntennaTestWithMockedContext {
         assertThat(release.getMainLicenseIds().isEmpty()).isTrue();
     }
 
+    @Test
+    public void testArtifactWithoutFacts() {
+        Artifact artifact = new Artifact()
+                .setProprietary(false);
+
+        thrownException.expect(ExecutionException.class);
+        thrownException.expectMessage("does not have enough facts to create a component name.");
+
+        SW360ReleaseAdapterUtils.convertToRelease(artifact);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse/antenna/issues/371
Creating the name of the SW360Component with the namespace and name of
the Coordinate fact of the artifact using a '/' as the delimiter
identical to the PURLs.

The SW360ComponentAdapterUtils::createComponentName method tries to
extract the component name from the ArtifactCoordinate fact first. If
it doesn't exist, it extracts it from the ArtifactFilename fact.
Otherwise it returns an empty string.

### Request Reviewer
@blaumeiser-at-bosch @neubs-bsi 

### Type of Change
*improvements*

### How Has This Been Tested?
> A new parameterised test added for `SW360ComponentAdapterUtils` class. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional:
- [x] I have provided tests for the changes (if there are changes that need additional tests)