### PR TITLE
Fix immediate effect of antenna cli not providing log messages

### DIFF
--- a/core/runtime/src/main/resources/log4j.properties
+++ b/core/runtime/src/main/resources/log4j.properties
@@ -12,19 +12,10 @@
 # Root logger option
 log4j.rootLogger=INFO, stdout
 
-
 #  Logging level
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m%n
-
-log4j.logger.org.apache.zookeeper=WARN
-log4j.logger.org.apache.hadoop=WARN
 
 # set to INFO to enable infostream log messages
 log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/core/runtime/src/main/resources/log4j2.properties
+++ b/core/runtime/src/main/resources/log4j2.properties
@@ -8,4 +8,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-log4j2.simplelogStatusLoggerLevel=INFO
+name = PropertiesConfig
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
 Fix immediate effect of antenna cli not providing log messages

- Add a configuration to log4j2.properties to configure the log backend for antenna cli which uses log4j2 as log backend
- Remove properties from log4j.properties that have no effect on the logging of other frontends

Still open:
- The different antenna frontends use different logging configurations (log4j vs. log4j2), that needs to be harmonized -> #385
- There is a log message coming from the ORT Result Analyzer that isn't configured out, this should be done to clean the output -> #385
- The CLI should have a parameter to set the log level to default -> #383

### Request Reviewer
@bs-ondem or
@neubs-bsi or
@sschuberth 

### Type of Change

*Type of change*:  bug fix

### How Has This Been Tested?
Run different ways like CLI and Maven frontend 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

closes: #367