### PR TITLE
Maven: Upgrade ORT to a version that partially uses JGit for downloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>5.1.2.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ort.rev>f91202964b</ort.rev>
+        <ort.rev>3f85d301f7</ort.rev>
     </properties>
 
     <scm>


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

> * Did you add or update any new dependencies that are required for your change?

Yes, ORT is updated, which introduces a new dependency on [JGit](https://github.com/eclipse/jgit) which is an Eclipse project licensed under [Eclipse Distribution License 1.0](http://www.eclipse.org/org/documents/edl-v10.php) (*not* EPL-1.0).

### Type of Change
> improvements