### PR TITLE
Fix ORTDownloaderProcessor in case of the procotol of url is SSH

### DIFF
--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -48,7 +48,7 @@ private fun mapSourceUrl(pkg: Package): ArtifactSourceUrl? =
     }
 
 private fun mapVcsInfo(pkg: Package) : ArtifactVcsInfo? =
-        pkg.vcs.takeUnless { it == VcsInfo.EMPTY }?.let {
+        pkg.vcsProcessed.takeUnless { it == VcsInfo.EMPTY }?.let {
             ArtifactVcsInfo(it.type.toString(), it.url, it.revision)
         }
 

--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -47,7 +47,7 @@ private fun mapSourceUrl(pkg: Package): ArtifactSourceUrl? =
         ArtifactSourceUrl(it)
     }
 
-private fun mapVcsInfo(pkg: Package) : ArtifactVcsInfo? =
+private fun mapToArtifactVcsInfo(pkg: Package) : ArtifactVcsInfo? =
         pkg.vcsProcessed.takeUnless { it == VcsInfo.EMPTY }?.let {
             ArtifactVcsInfo(it.type.toString(), it.url, it.revision)
         }
@@ -91,7 +91,7 @@ class OrtResultArtifactResolver(result: OrtResult) : Function<Package, Artifact>
             a.addCoordinate(mapCoordinates(pkg))
 
             mapSourceUrl(pkg)?.let { a.addFact(it) }
-            mapVcsInfo(pkg)?.let { a.addFact(it) }
+            mapToArtifactVcsInfo(pkg)?.let { a.addFact(it) }
             mapDeclaredLicense(pkg)?.let { a.addFact(it) }
             mapFilename(pkg)?.let { a.addFact(it) }
             mapHomepage(pkg)?.let { a.addFact(it) }

--- a/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
+++ b/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
@@ -31,7 +31,7 @@ class ArtifactToPackageMapper : Function<Artifact, Package> {
                 homepageUrl = "",
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = mapSourceRemoteArtifact(artifact) ?: RemoteArtifact.EMPTY,
-                vcs = mapVcsInfo(artifact) ?: VcsInfo.EMPTY
+                vcs = mapToVcsInfo(artifact) ?: VcsInfo.EMPTY
         )
     }
 
@@ -51,7 +51,7 @@ class ArtifactToPackageMapper : Function<Artifact, Package> {
                 Identifier(type = ortType, namespace = namespace, name = name, version = version)
             }
 
-    private fun mapVcsInfo(artifact: Artifact) : VcsInfo? =
+    private fun mapToVcsInfo(artifact: Artifact) : VcsInfo? =
         artifact.askFor(ArtifactVcsInfo::class.java).takeIf { it.isPresent }?.let {
             val vcsInfo = it.get().vcsInfo
             VcsInfo(type = VcsType(vcsInfo.type), url = vcsInfo.url, revision = vcsInfo.revision)

--- a/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
+++ b/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
@@ -61,6 +61,4 @@ class ArtifactToPackageMapper : Function<Artifact, Package> {
         artifact.askForGet(ArtifactSourceUrl::class.java).takeIf { it.isPresent }?.let {
             RemoteArtifact.EMPTY.copy(url = it.get())
         }
-
-
 }


### PR DESCRIPTION
In some cases, the protocol of a VcsInfo.url is SSH, which leads to
hanging builds, because it's prompting for a password. To avoid this,
we are replacing the protocol from ssh to https for github.com hosts.


### Request Reviewer
> @sschuberth @blaumeiser-at-bosch 

### Type of Change
*bug fix*