### PR TITLE
Deactivate the Manifest resolver in the default workflow

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/manifest-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/manifest-resolver.md
@@ -1,7 +1,8 @@
 ## Manifest resolver
 The Manifest resolver checks the first element of the list of path names for each artifact. If a JAR file is found 
 and it contains a MANIFEST.MF file with the properties `Bundle-SymbolicName` and `Bundle-Version`, it will add a 
-`BundleCoordinates` fact to the artifact.
+`BundleCoordinates` fact to the artifact. It's deactivated in the default antenna workflow configuration, i.e. it 
+has to be activated in the workflow.xml. 
  
 
 ## HowTo use

--- a/assembly/configuration/src/main/resources/workflow.xml
+++ b/assembly/configuration/src/main/resources/workflow.xml
@@ -32,6 +32,7 @@
         <step>
             <name>Manifest Resolver</name>
             <classHint>org.eclipse.sw360.antenna.p2.workflow.processors.enricher.ManifestResolver</classHint>
+            <deactivated>true</deactivated>
         </step>
         <step>
             <name>License Resolver</name>

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/BasicConfiguration.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/BasicConfiguration.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.eclipse.sw360.antenna.frontend.testing.testProjects.TestProjectUtils.mkDeactivatedWorkflowStep;
 import static org.eclipse.sw360.antenna.frontend.testing.testProjects.TestProjectUtils.mkWorkflowStep;
 
 public final class BasicConfiguration {
@@ -35,7 +36,7 @@ public final class BasicConfiguration {
         // enricher
         WorkflowStep enricher1 = mkWorkflowStep("Maven Artifact Resolver", "org.eclipse.sw360.antenna.maven.workflow.processors.enricher.MavenArtifactResolver");
         WorkflowStep enricher3 = mkWorkflowStep("Child Jar Resolver", "org.eclipse.sw360.antenna.p2.workflow.processors.enricher.ChildJarResolver");
-        WorkflowStep enricher4 = mkWorkflowStep("Manifest Resolver", "org.eclipse.sw360.antenna.p2.workflow.processors.enricher.ManifestResolver");
+        WorkflowStep enricher4 = mkDeactivatedWorkflowStep("Manifest Resolver", "org.eclipse.sw360.antenna.p2.workflow.processors.enricher.ManifestResolver");
         WorkflowStep enricher5 = mkWorkflowStep("License Resolver", "org.eclipse.sw360.antenna.workflow.processors.LicenseResolver");
         WorkflowStep enricher6 = mkWorkflowStep("License Knowledgebase Resolver", "org.eclipse.sw360.antenna.workflow.processors.LicenseKnowledgeBaseResolver");
         // validators


### PR DESCRIPTION
Fixes https://github.com/eclipse/antenna/issues/377
The Manifest resolver was deactivated because it does not make sense
for all projects, but only for P2 projects.

### Request Reviewer
@blaumeiser-at-bosch @neubs-bsi 

### Type of Change
*fix* 

### Checklist
Must:
- [x] All related issues are referenced in commit messages