### PR TITLE
Match CSV Analyzer coordinate types to purl type names

### DIFF
--- a/antenna-documentation/src/site/markdown/analyzers/csv-analyzer-step.md.vm
+++ b/antenna-documentation/src/site/markdown/analyzers/csv-analyzer-step.md.vm
@@ -3,7 +3,7 @@ This analyzer investigates a given *csv* file. The format of this csv file follo
 
 ```csv
 "Artifact Id","Group Id","Version","Coordinate Type","Effective License","Declared License","Observed License","Copyrights","Hash","Source URL","Release Tag URL","Software Heritage ID","Clearing State","Change Status","CPE","File Name"
-commons-csv,org.apache.commons,1.4,mvn,Apache-2.0,Apache-2.0,Apache-2.0 OR MIT,Copyright 2005-2016 The Apache Software Foundation,620580a88953cbcf4528459e485054e7c27c0889,http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip,https://github.com/apache/commons-csv/tree/csv-1.4,swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-csv:1.4,commons-csv.jar
+commons-csv,org.apache.commons,1.4,maven,Apache-2.0,Apache-2.0,Apache-2.0 OR MIT,Copyright 2005-2016 The Apache Software Foundation,620580a88953cbcf4528459e485054e7c27c0889,http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip,https://github.com/apache/commons-csv/tree/csv-1.4,swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-csv:1.4,commons-csv.jar
 ```
 
 Note:
@@ -48,7 +48,9 @@ Within the CSV file there are attributes (= columns) that are required:
 * `Artifact Id`: Name of the component.
 * `Group Id`: Group it belongs to. This value isn't always necessary. For example .NET does not use groups.
 * `Version`: Version of the release.
-* `Coordinate Type`
+* `Coordinate Type`: The type of the coordinate, corresponding to the purl coordinate type names.
+    * Currently supported coordinate types: `maven`, `nuget`, `dotnet`, `npm`, `p2`
+    * Everything else will be handled with the coordinate type `generic`
 
 #[[###]]# Optional Attributes
 
@@ -83,8 +85,8 @@ If you have an artifact you associate multiple hashes with, this can be done in 
 
 ```csv
 "Artifact Id","Group Id","Version","Coordinate Type","Hash"
-commons-csv,org.apache.commons,1.4,mvn,620580a88953cbcf4528459e485054e7c27c0889
-commons-csv,org.apache.commons,1.4,mvn,b0060ed8397bfec39b397807f63e778618f324ce
+commons-csv,org.apache.commons,1.4,maven,620580a88953cbcf4528459e485054e7c27c0889
+commons-csv,org.apache.commons,1.4,maven,b0060ed8397bfec39b397807f63e778618f324ce
 ```
 
 You can simply insert the new hash in a new row with the same artifact coordinates.
@@ -98,7 +100,7 @@ There are three copyrights in total, each separated by "/n", the copyright separ
 
 ```csv
 "Artifact Id","Group Id","Version","Coordinate Type","Copyrights"
-commons-csv,org.apache.commons,1.4,mvn,"Copyright 2005-2016 The Apache Software Foundation/nCopyright 2020 Fake Company/nCopyright 2020 Fake the 2nd"
+commons-csv,org.apache.commons,1.4,maven,"Copyright 2005-2016 The Apache Software Foundation/nCopyright 2020 Fake Company/nCopyright 2020 Fake the 2nd"
 ```
 
 #[[###]]# CSV File created by Excel Application Example
@@ -107,7 +109,7 @@ Note that all special cases (Multiple hashes and copyrights per artifact) are al
 
 ```csv
 Artifact Id;Group Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Change Status;CPE;File Name
-commons-csv;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 1/nCopyright 2;#hash1#;source.url;release.tag/url;swh:1:cnt:#;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;commons-csv.jar
-commons-csv;org.apache.commons;1.4;mvn;;;;;#hash2#;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;;Copyright 1/nCopyright 3;#hash#;source.url;release.tag/url;swh:1:cnt:#;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;commons-cli.jar
+commons-csv;org.apache.commons;1.4;maven;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 1/nCopyright 2;#hash1#;source.url;release.tag/url;swh:1:cnt:#;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;commons-csv.jar
+commons-csv;org.apache.commons;1.4;maven;;;;;#hash2#;;;;;;;
+commons-cli;org.apache.commons;1.4;maven;Apache-2.0;Apache-2.0;;Copyright 1/nCopyright 3;#hash#;source.url;release.tag/url;swh:1:cnt:#;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;commons-cli.jar
 ```

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerImpl.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016-2017,2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -135,12 +136,15 @@ public class CsvAnalyzerImpl {
             final String type = record.get(COORDINATE_TYPE);
             switch (type) {
                 case "mvn":
+                case "maven":
                     builder.withType(Coordinate.Types.MAVEN);
                     builder.withNamespace(record.get(GROUP));
                     break;
+                case "nuget":
                 case "dotnet":
                     builder.withType(Coordinate.Types.NUGET);
                     break;
+                case "npm":
                 case "javascript":
                     builder.withType(Coordinate.Types.NPM);
                     builder.withNamespace(record.get(GROUP));

--- a/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencies.csv
+++ b/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencies.csv
@@ -1,4 +1,8 @@
 Artifact Id,Group Id,Version,Coordinate Type,Effective License,Declared License,Observed License,Copyrights,Hash,Source URL,Release Tag URL,Software Heritage ID,Clearing State,Change Status,CPE,File Name
 commons-csv,org.apache.commons,1.4,mvn,Apache-2.0,Apache-2.0,Apache-2.0 OR MIT,Copyright 2005-2016 The Apache Software Foundation,620580a88953cbcf4528459e485054e7c27c0889,http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip,https://github.com/apache/commons-csv/tree/csv-1.4,swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-csv:1.4,commons-csv.jar
-commons-cli,org.apache.commons,1.4,mvn,Apache-2.0,Apache-2.0,,Copyright 2005-2016 The Apache Software Foundation,2a26e60c745cdeb99a96f21adec508f43b5d25a5,http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip,https://github.com/apache/commons-cli/tree/cli-1.4,swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-cli:1.4,commons-cli.jar
-
+commons-cli,org.apache.commons,1.4,maven,Apache-2.0,Apache-2.0,,Copyright 2005-2016 The Apache Software Foundation,2a26e60c745cdeb99a96f21adec508f43b5d25a5,http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip,https://github.com/apache/commons-cli/tree/cli-1.4,swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-cli:1.4,commons-cli.jar
+testNuget,,1.0,nuget,,,,,,,,,,,,
+testDotNet,,1.0,dotnet,,,,,,,,,,,,
+testNpm,test,1.0,npm,,,,,,,,,,,,
+testbundle	,,1.0,bundle,,,,,,,,,,,,
+testPython,,1.0,PYPI,,,,,,,,,,,,


### PR DESCRIPTION
Add purl type names to the CSV Analyzer coordinate creation.
Currently the old names are not yet deleted to avoid
compatibility issues.

Added tests for the individual coordinate types.

Updated documentation.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Additional test was added in CSVAnalyzerTest to test individual coordinates

### Checklist
Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
