### PR TITLE
Switch dependency of maven module and maven frontend stubs

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -1,5 +1,6 @@
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -38,6 +39,12 @@
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360.antenna</groupId>
+            <artifactId>maven-module</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/core/frontend-stubs/maven-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/mojo/AbstractAntennaMojoFrontend.java
+++ b/core/frontend-stubs/maven-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/mojo/AbstractAntennaMojoFrontend.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -39,6 +40,8 @@ import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.core.AntennaCore;
 import org.eclipse.sw360.antenna.frontend.AntennaFrontend;
 import org.eclipse.sw360.antenna.frontend.AntennaFrontendHelper;
+import org.eclipse.sw360.antenna.maven.WrappedDependencyNodes;
+import org.eclipse.sw360.antenna.maven.WrappedMavenProject;
 import org.eclipse.sw360.antenna.model.xml.generated.Workflow;
 import org.eclipse.sw360.antenna.util.TemplateRenderer;
 import org.eclipse.sw360.antenna.workflow.WorkflowFileLoader;

--- a/modules/maven/pom.xml
+++ b/modules/maven/pom.xml
@@ -1,5 +1,6 @@
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -35,12 +36,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.sw360.antenna</groupId>
-			<artifactId>maven-frontend-stub</artifactId>
-			<version>${project.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<scope>compile</scope>
@@ -52,6 +47,10 @@
 		<dependency>
 			<groupId>org.apache.maven.shared</groupId>
 			<artifactId>maven-invoker</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-dependency-tree</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/WrappedDependencyNodes.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/WrappedDependencyNodes.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -8,7 +9,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.sw360.antenna.frontend.stub.mojo;
+package org.eclipse.sw360.antenna.maven;
 
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/WrappedMavenProject.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/WrappedMavenProject.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -8,7 +9,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.sw360.antenna.frontend.stub.mojo;
+package org.eclipse.sw360.antenna.maven;
 
 import org.apache.maven.project.MavenProject;
 import org.eclipse.sw360.antenna.api.IProject;

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/analyzers/MvnDependencyTreeAnalyzer.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/analyzers/MvnDependencyTreeAnalyzer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -14,7 +15,7 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractAnalyzer;
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
-import org.eclipse.sw360.antenna.frontend.stub.mojo.WrappedDependencyNodes;
+import org.eclipse.sw360.antenna.maven.WrappedDependencyNodes;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFile;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactMatchingMetadata;

--- a/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/WrappedMavenProjectTest.java
+++ b/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/WrappedMavenProjectTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.maven;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WrappedMavenProjectTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testWrappedMavenProject() throws IOException {
+        String artifactId = "test";
+        String version = "x.x.x";
+        File pomFile = folder.newFile("pom.xml");
+        String outputDir = folder.newFolder("outputdir").getName();
+
+        Build build = new Build();
+        build.setOutputDirectory(outputDir);
+
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setArtifactId(artifactId);
+        mavenProject.setVersion(version);
+        mavenProject.setFile(pomFile);
+        mavenProject.setBuild(build);
+
+        WrappedMavenProject wrappedMavenProject = new WrappedMavenProject(mavenProject);
+
+        assertThat(wrappedMavenProject.getBuildDirectory()).isEqualTo(outputDir);
+        assertThat(wrappedMavenProject.getConfigFile()).isEqualTo(pomFile);
+        assertThat(wrappedMavenProject.getRawProject()).isEqualTo(mavenProject);
+        assertThat(wrappedMavenProject.getProjectId()).isEqualTo(artifactId);
+        assertThat(wrappedMavenProject.getVersion()).isEqualTo(version);
+    }
+}

--- a/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/workflow/analyzers/MvnDependencyTreeAnalyzerTest.java
+++ b/modules/maven/src/test/java/org/eclipse/sw360/antenna/maven/workflow/analyzers/MvnDependencyTreeAnalyzerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,7 +16,7 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyNode;
 import org.eclipse.sw360.antenna.api.configuration.AntennaContext;
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
-import org.eclipse.sw360.antenna.frontend.stub.mojo.WrappedDependencyNodes;
+import org.eclipse.sw360.antenna.maven.WrappedDependencyNodes;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactFile;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactMatchingMetadata;


### PR DESCRIPTION
Issue: #399

Maven frontend stubs now depends on maven module for the
WrappedDependencyNodes and Wrappedproject.
This avoids the maven module having the transitive dependencies
of the frontend stub.

The dependency on `maven-dependency-tree` was not removed
from the `maven-frontend-stubs` pom, because of the maven flatten
problem described in commit 3d9b9f45eafef0f01bd0a966baca9c48d2a6b9e8

### Request Reviewer
> You can add desired reviewers here with an @mention.
@sschuberth @blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages
