### PR TITLE
changing default maven central url in http requester

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/artifact-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/artifact-resolver.md
@@ -22,3 +22,18 @@ Add the following step into the `<processors>` section of your workflow.xml
 - `preferredSourceQualifier`: *(optional)* will be used by the artifact resolver as a qualifier for source jars before trying the usual qualifier `sources`.
 This should be used together with `sourcesRepositoryUrl` providing a repository to search for artifacts with the given qualifier.
 
+#### Note
+
+As described in this [blog post](https://www.alphabot.com/security/blog/2020/java/Your-Java-builds-might-break-starting-January-13th.html) 
+a decommissioning of HTTP for several Maven repositories has taken place at the start of the year 2020. 
+If you set your own `sourceRepositoryUrl` and encounter an IOException with the reason "HTTPS Required" (exception below)
+it is likely that your chosen URL is an HTTP URL and belongs to the decommissioned URLs. 
+To get rid of this exception change your URL to a working HTTPS URL. 
+
+```
+java.io.IOException: Reason: HTTPS Required
+	at org.eclipse.sw360.antenna.util.HttpHelper.downloadFile(HttpHelper.java:49)
+	at org.eclipse.sw360.antenna.maven.HttpRequester.tryFileDownload(HttpRequester.java:87)
+	at org.eclipse.sw360.antenna.maven.HttpRequester.requestFile(HttpRequester.java:64)
+	at org.eclipse.sw360.antenna.maven.workflow.processors.enricher.MavenArtifactResolverImpl.resolve(MavenArtifactResolverImpl.java:142)
+```

--- a/assembly/gradle-plugin/src/site/markdown/index.md.vm
+++ b/assembly/gradle-plugin/src/site/markdown/index.md.vm
@@ -117,3 +117,10 @@ SECRET=password12345 gradle analyze
 
 Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
 ${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
+
+#[[####]]# Note
+
+As explained in this [Gradle blog post](https://blog.gradle.org/decommissioning-http) a decommissioning of HTTP for Gradle Services
+started in January 2020.
+Should your builds fail with the reason "HTTPS required" it is most likely that you are using a decommissioned URL and
+need to change it to HTTPS.

--- a/assembly/maven-plugin/src/site/markdown/index.md.vm
+++ b/assembly/maven-plugin/src/site/markdown/index.md.vm
@@ -97,4 +97,10 @@ SECRET=password12345 mvn clean install
 Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
 ${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
 
-Within both, your `pom.xml` or the `workflow.xml`, you can then reference the variables.
+Within both your `pom.xml` and the `workflow.xml` you can then reference the variables.
+
+#[[####]]# Note
+
+As explained in this [Sonatype statement](https://central.sonatype.org/articles/2019/Apr/30/http-access-to-repo1mavenorg-and-repomavenapacheorg-is-being-deprecated/)
+a decommissioning of HTTP for Gradle Services started in January 2020. Should your builds fail with the reason "HTTPS required" it is
+most likely that you are using a decommissioned URL and need to change it to HTTPS.

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -30,7 +31,7 @@ public class HttpRequester extends IArtifactRequester {
     private static final String GROUP_ID_PLACEHOLDER = "{groupId}";
     private static final String ARTIFACT_ID_PLACEHOLDER = "{artifactId}";
     private static final String VERSION_PLACEHOLDER = "{version}";
-    private static final String MAVEN_CENTRAL_URL = "http://repo2.maven.org/maven2/" + GROUP_ID_PLACEHOLDER + "/" + ARTIFACT_ID_PLACEHOLDER + "/" + VERSION_PLACEHOLDER + "/";
+    private static final String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/" + GROUP_ID_PLACEHOLDER + "/" + ARTIFACT_ID_PLACEHOLDER + "/" + VERSION_PLACEHOLDER + "/";
 
     private HttpHelper httpHelper;
     private Optional<URL> sourceRepositoryUrl;


### PR DESCRIPTION
issue: #401
changes the default maven central url in http requester (described in issue)

### Request Reviewer
> You can add desired reviewers here with an @mention.

@blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### Checklist
Must:
- [x] All related issues are referenced in commit messages

## Note

This is not the complete fix for the issue #401- however this might take a while to fix nicely and this would be a quick fix. 