### PR TITLE
Add attribution document generator to documentation overview

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/generators.md
+++ b/antenna-documentation/src/site/markdown/generators/generators.md
@@ -2,6 +2,7 @@
 The third phase of the workflow pipeline continues with the generators.
 Antenna already provides the five following generators:
 
+- [Attribution Document generator](./attribution-document-generator-step.html)
 - [HTML generator](./HTML-report-generator-step.html)
 - [CSV generator](./csv-generator-step.html)
 - [Source Zip Generator](./source-zip-generator-step.html)


### PR DESCRIPTION
Fixes https://github.com/eclipse/antenna/issues/407

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
*documentation update*

### Checklist
Must:
- [x] All related issues are referenced in commit messages