### PR TITLE
Oheger bosch/compliance tool/clearing

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
@@ -11,7 +11,7 @@
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360;
 
 import org.eclipse.sw360.antenna.api.exceptions.ConfigurationException;
-import org.eclipse.sw360.antenna.csvreader.CSVReader;
+import org.eclipse.sw360.antenna.csvreader.CSVArtifactMapper;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 
 import java.io.File;
@@ -76,7 +76,7 @@ public class ComplianceFeatureUtils {
         }
         Charset encoding = Charset.forName(properties.get("encoding"));
 
-        return new CSVReader(csvFile.toPath(), encoding, delimiter, csvFile.getParentFile().toPath()).createArtifactsList();
+        return new CSVArtifactMapper(csvFile.toPath(), encoding, delimiter, csvFile.getParentFile().toPath()).createArtifactsList();
     }
 
     /**

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
@@ -19,10 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -92,8 +89,7 @@ public class ComplianceFeatureUtils {
      */
     public static String mapEnvironmentVariable(String value) {
         if (value.startsWith(VARIABLE_PREFIX) &&
-                value.endsWith(VARIABLE_SUFFIX) &&
-                value.toUpperCase().equals(value)) {
+                value.endsWith(VARIABLE_SUFFIX)) {
             return Optional.ofNullable(System.getenv(value.substring(2, value.length() - 1)))
                     .orElse(value);
         }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
+import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ClearingState;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
@@ -109,9 +110,12 @@ public class SW360Exporter {
     }
 
     private boolean isApproved(SW360Release sw360Release) {
-        return sw360Release.getClearingState() == null ||
-                Optional.of(sw360Release.getClearingState())
-                        .map(clearingState -> clearingState.equals(ArtifactClearingState.ClearingState.OSM_APPROVED.toString()))
+        return Optional.ofNullable(sw360Release.getClearingState())
+                        .map(clearingState -> ArtifactClearingState.ClearingState.valueOf(clearingState) != ArtifactClearingState.ClearingState.INITAL)
+                        .orElse(false) &&
+                Optional.ofNullable(sw360Release.getSw360ClearingState())
+                        .map(sw360ClearingState -> sw360ClearingState.equals(SW360ClearingState.APPROVED) ||
+                                sw360ClearingState.equals(SW360ClearingState.REPORT_AVAILABLE))
                         .orElse(false);
     }
 

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.exporter;
 
-import org.eclipse.sw360.antenna.csvreader.CSVReader;
+import org.eclipse.sw360.antenna.csvreader.CSVArtifactMapper;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactClearingState;
@@ -61,12 +61,12 @@ public class SW360Exporter {
                 .resolve(configuration.getCsvFileName())
                 .toFile();
 
-        CSVReader csvReader = new CSVReader(csvFile.toPath(),
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(),
                 Charset.forName(configuration.getProperties().get("encoding")),
                 configuration.getProperties().get("delimiter").charAt(0),
                 Paths.get(configuration.getProperties().get("basedir")));
 
-        csvReader.writeArtifactsToCsvFile(artifacts);
+        csvArtifactMapper.writeArtifactsToCsvFile(artifacts);
     }
 
     private Artifact releaseAsArtifact(SW360Release release, HttpHeaders headers) {

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -24,9 +24,11 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseCompo
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ClearingState;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
+import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
 import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -46,6 +48,8 @@ public class SW360Exporter {
     public void execute() {
         connectionConfiguration = configuration.getConnectionConfiguration();
         HttpHeaders headers = connectionConfiguration.getHttpHeaders();
+        HttpHeaders downloadHeader = RestUtils.deepCopyHeaders(headers);
+        downloadHeader.setAccept(Collections.singletonList(MediaType.APPLICATION_OCTET_STREAM));
 
         Collection<SW360SparseComponent> components = connectionConfiguration.getSW360ComponentClientAdapter().getComponents(headers);
 
@@ -54,7 +58,7 @@ public class SW360Exporter {
         Collection<SW360Release> sw360ReleasesNotApproved = getNonApprovedReleasesFromSpareReleases(sw360SparseReleases, headers);
 
         List<Artifact> artifacts = sw360ReleasesNotApproved.stream()
-                .map(release -> releaseAsArtifact(release, headers))
+                .map(release -> releaseAsArtifact(release, downloadHeader))
                 .collect(Collectors.toList());
 
         File csvFile = configuration.getTargetDir()

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -111,7 +111,7 @@ public class SW360Exporter {
 
     private boolean isApproved(SW360Release sw360Release) {
         return Optional.ofNullable(sw360Release.getClearingState())
-                        .map(clearingState -> ArtifactClearingState.ClearingState.valueOf(clearingState) != ArtifactClearingState.ClearingState.INITAL)
+                        .map(clearingState -> ArtifactClearingState.ClearingState.valueOf(clearingState) != ArtifactClearingState.ClearingState.INITIAL)
                         .orElse(false) &&
                 Optional.ofNullable(sw360Release.getSw360ClearingState())
                         .map(sw360ClearingState -> sw360ClearingState.equals(SW360ClearingState.APPROVED) ||

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -105,7 +105,7 @@ public class SW360Exporter {
                 .map(id -> connectionConfiguration.getSW360ReleaseClientAdapter().getReleaseById(id, headers))
                 .map(Optional::get)
                 .filter(sw360Release -> !isApproved(sw360Release))
-                .sorted(Comparator.comparing(rel -> new Date(rel.getCreatedOn())))
+                .sorted(Comparator.comparing(SW360Release::getCreatedOn).reversed())
                 .collect(Collectors.toList());
     }
 

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -13,8 +13,6 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,7 +20,6 @@ import java.nio.file.Path;
 
 class ClearingReportGenerator {
     private static final String CLEARING_DOC_SUFFIX = "_clearing.json";
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClearingReportGenerator.class);
 
     Path createClearingDocument(SW360Release release, Path targetDir) {
         Path clearingDocument = targetDir.resolve(release.getReleaseId() + CLEARING_DOC_SUFFIX);
@@ -31,7 +28,6 @@ class ClearingReportGenerator {
             mapper.writeValue(Files.newBufferedWriter(clearingDocument), release);
             return clearingDocument;
         } catch (IOException e) {
-            LOGGER.error("Could not write clearing document", e);
             throw new ExecutionException("Could not create clearing document " + clearingDocument.toString(), e);
         }
     }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
+import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class ClearingReportGenerator {
+    private static final String CLEARING_DOC_SUFFIX = "_clearing.json";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClearingReportGenerator.class);
+
+    Path createClearingDocument(SW360Release release, Path targetDir) {
+        Path clearingDocument = targetDir.resolve(release.getReleaseId() + CLEARING_DOC_SUFFIX);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writeValue(Files.newBufferedWriter(clearingDocument), release);
+            return clearingDocument;
+        } catch (IOException e) {
+            LOGGER.error("Could not write clearing document", e);
+            throw new ExecutionException("Could not create clearing document " + clearingDocument.toString(), e);
+        }
+    }
+}

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils.getArtifactsFromCsvFile;
 
@@ -58,7 +57,7 @@ public class SW360Updater {
 
         if (release.getClearingState() != null &&
                 !release.getClearingState().isEmpty() &&
-                ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITAL) {
+                ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITIAL) {
             Map<Path, SW360AttachmentType> attachmentPathMap =
                     Collections.singletonMap(getOrGenerateClearingDocument(release, artifact),
                             SW360AttachmentType.CLEARING_REPORT);

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactClearingDocument;
+import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactClearingState;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
@@ -46,10 +47,15 @@ public class SW360Updater {
     private void uploadReleaseWithClearingDocumentFromArtifact(Artifact artifact, HttpHeaders headers) {
         SW360Release release = updater.artifactToReleaseInSW360(artifact);
         SW360ReleaseClientAdapter releaseClientAdapter = configuration.getConnectionConfiguration().getSW360ReleaseClientAdapter();
-        artifact.askFor(ArtifactClearingDocument.class)
-                .map(ArtifactClearingDocument::get)
-                .map(acd -> Collections.singletonMap(acd, SW360AttachmentType.CLEARING_REPORT))
-                .ifPresent(attachmentPathMap -> releaseClientAdapter
-                        .uploadAttachments(release, attachmentPathMap, headers));
+
+        if (release.getClearingState() != null &&
+                !release.getClearingState().isEmpty() &&
+                ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITAL) {
+            artifact.askFor(ArtifactClearingDocument.class)
+                    .map(ArtifactClearingDocument::get)
+                    .map(acd -> Collections.singletonMap(acd, SW360AttachmentType.CLEARING_REPORT))
+                    .ifPresent(attachmentPathMap -> releaseClientAdapter
+                            .uploadAttachments(release, attachmentPathMap, headers));
+        }
     }
 }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
@@ -40,8 +40,8 @@ public class SW360ConfigurationTest {
         String propertiesFilePath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-exporter.properties")).getPath();
         File propertiesFile = new File(propertiesFilePath);
         SW360Configuration configuration = new SW360Configuration(propertiesFile);
-        assertThat(configuration.getTargetDir()).isEqualTo(Paths.get("build/compliancetool/"));
-        assertThat(configuration.getCsvFileName()).isEqualTo("<example-path>");
+        assertThat(configuration.getTargetDir()).isEqualTo(Paths.get("./"));
+        assertThat(configuration.getCsvFileName()).isEqualTo("sample.csv");
         assertThat(configuration.getConnectionConfiguration().getSW360ReleaseClientAdapter()).isNotNull();
         assertThat(configuration.getConnectionConfiguration().getSW360ComponentClientAdapter()).isNotNull();
     }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
@@ -52,7 +52,7 @@ public class SW360ConfigurationTest {
         File propertiesFile = new File(propertiesFilePath);
         SW360Configuration configuration = new SW360Configuration(propertiesFile);
         assertThat(new File(configuration.getCsvFileName()).getName()).isEqualTo("compliancetool_updater_test.csv");
-        assertThat(configuration.getProperties().get("delimiter")).isEqualTo(";");
+        assertThat(configuration.getProperties().get("delimiter")).isEqualTo(",");
         assertThat(configuration.getProperties().get("sw360updateReleases")).isEqualTo("true");
         assertThat(configuration.getProperties().get("sw360uploadSources")).isEqualTo("false");
     }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
@@ -55,6 +55,7 @@ public class SW360TestUtils {
 
         sw360Release.setName(name);
         sw360Release.setVersion(RELEASE_VERSION1);
+        sw360Release.setCreatedOn("yyyy-mm-dd");
 
         sw360Release.setDownloadurl(RELEASE_DOWNLOAD_URL);
         sw360Release.setClearingState(RELEASE_CLEARING_STATE);

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 
 public class SW360TestUtils {
@@ -97,7 +98,7 @@ public class SW360TestUtils {
         component.setName(name);
         component.setComponentType(COMPONENT_TYPE);
         SW360ComponentEmbedded componentEmbedded = new SW360ComponentEmbedded();
-        componentEmbedded.setReleases(Collections.singletonList(mkSW3SparseRelease(name)));
+        componentEmbedded.setReleases(Arrays.asList(mkSW3SparseRelease(name), mkSW3SparseRelease(name)));
         component.set_Embedded(componentEmbedded);
         return component;
     }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
@@ -49,11 +49,11 @@ public class SW360ExporterTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {"INITAL", SW360ClearingState.NEW_CLEARING, 1},
-                {"INITAL", SW360ClearingState.SENT_TO_CLEARING_TOOL, 1},
-                {"INITAL", SW360ClearingState.REPORT_AVAILABLE, 1},
-                {"INITAL", SW360ClearingState.APPROVED, 1},
-                {"INITAL", null, 1},
+                {"INITIAL", SW360ClearingState.NEW_CLEARING, 1},
+                {"INITIAL", SW360ClearingState.SENT_TO_CLEARING_TOOL, 1},
+                {"INITIAL", SW360ClearingState.REPORT_AVAILABLE, 1},
+                {"INITIAL", SW360ClearingState.APPROVED, 1},
+                {"INITIAL", null, 1},
                 {"EXTERNAL_SOURCE", SW360ClearingState.NEW_CLEARING, 1},
                 {"EXTERNAL_SOURCE", SW360ClearingState.SENT_TO_CLEARING_TOOL, 1},
                 {"EXTERNAL_SOURCE", SW360ClearingState.REPORT_AVAILABLE, 0},

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
@@ -28,8 +28,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,8 +108,7 @@ public class SW360ExporterTest {
     @Mock
     SW360ConnectionConfiguration connectionConfigurationMock = mock(SW360ConnectionConfiguration.class);
 
-    @Mock
-    HttpHeaders headers = mock(HttpHeaders.class);
+    HttpHeaders headers = new HttpHeaders();
 
     @Before
     public void setUp() throws IOException {
@@ -166,10 +167,12 @@ public class SW360ExporterTest {
         List<CSVRecord> records = csvParser.getRecords();
 
         assertThat(records.size()).isEqualTo(expectedNumOfReleases);
-        verify(releaseClientAdapterMock, atLeast(expectedNumOfReleases)).downloadAttachment(any(), any(),any() , eq(headers));
+        ArgumentCaptor<HttpHeaders> captor = ArgumentCaptor.forClass(HttpHeaders.class);
+        verify(releaseClientAdapterMock, atLeast(expectedNumOfReleases)).downloadAttachment(any(), any(),any() , captor.capture());
 
         if (expectedNumOfReleases == 2) {
             assertThat(records.get(1).get("Copyrights")).isEqualTo(release.getCopyrights());
+            assertThat(captor.getValue().getAccept()).containsExactly(MediaType.APPLICATION_OCTET_STREAM);
         }
     }
 }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
+import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360TestUtils;
+import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClearingReportGeneratorTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ClearingReportGenerator generator;
+
+    @Before
+    public void setUp() {
+        generator = new ClearingReportGenerator();
+    }
+
+    @Test
+    public void createClearingDocument() throws IOException {
+        File targetFolder = folder.newFolder();
+        SW360Release release = SW360TestUtils.mkSW360Release("testRelease");
+        release.setOverriddenLicense("overridden");
+
+        Path clearingDocument = generator.createClearingDocument(release, targetFolder.toPath());
+        assertThat(Files.exists(clearingDocument)).isTrue();
+        assertThat(clearingDocument.getFileName().toString()).isEqualTo(release.getReleaseId() + "_clearing.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.readValue(clearingDocument.toFile(), SW360Release.class);
+
+        String content = String.join("", Files.readAllLines(clearingDocument));
+        assertThat(content).contains(release.getDeclaredLicense());
+        assertThat(content).contains(release.getObservedLicense());
+        assertThat(content).contains(release.getOverriddenLicense());
+
+        System.out.println(content);
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testExceptionIsThrownOnFailedCreation() {
+        Path nonExistingFolder = Paths.get("non", "existing", "folder");
+        SW360Release release = SW360TestUtils.mkSW360Release("crash");
+        generator.createClearingDocument(release, nonExistingFolder);
+    }
+}

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -73,13 +73,13 @@ public class SW360UpdaterTest {
                 {"EXTERNAL_SOURCE", true, true},
                 {"AUTO_EXTRACT", true, true},
                 {"PROJECT_APPROVED", true, true},
-                {"INITAL", true, false},
+                {"INITIAL", true, false},
                 {"", true, false},
                 {"OSM_APPROVED", false, true},
                 {"EXTERNAL_SOURCE", false, true},
                 {"AUTO_EXTRACT", false, true},
                 {"PROJECT_APPROVED", false, true},
-                {"INITAL", false, false},
+                {"INITIAL", false, false},
                 {"", false, false}
 
         });

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 
+import org.apache.commons.io.FileUtils;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
@@ -18,36 +19,75 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
 import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.http.HttpHeaders;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@RunWith(Parameterized.class)
 public class SW360UpdaterTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     private SW360Configuration configurationMock = mock(SW360Configuration.class);
     private SW360ReleaseClientAdapter releaseClientAdapter = mock(SW360ReleaseClientAdapter.class);
     private SW360UpdaterImpl updater = mock(SW360UpdaterImpl.class);
-    HttpHeaders header = new HttpHeaders();
+    private HttpHeaders header = new HttpHeaders();
+    private String clearingDocName = "clearing.doc";
+
+    private final String clearingState;
+    private final boolean clearingDocAvailable;
+    private final boolean expectUpload;
+
+    public SW360UpdaterTest(String clearingState, boolean clearingDocAvailable, boolean expectUpload) {
+        this.clearingState = clearingState;
+        this.clearingDocAvailable = clearingDocAvailable;
+        this.expectUpload = expectUpload;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {"OSM_APPROVED", true, true},
+                {"EXTERNAL_SOURCE", true, true},
+                {"AUTO_EXTRACT", true, true},
+                {"PROJECT_APPROVED", true, true},
+                {"INITAL", true, false},
+                {"", true, false},
+                {"OSM_APPROVED", false, false},
+                {"EXTERNAL_SOURCE", false, false},
+                {"AUTO_EXTRACT", false, false},
+                {"PROJECT_APPROVED", false, false},
+                {"INITAL", false, false},
+                {"", false, false}
+
+        });
+    }
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         String propertiesFilePath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).getPath();
         Map<String, String> propertiesMap = ComplianceFeatureUtils.mapPropertiesFile(new File(propertiesFilePath));
+
+        Path csvFile = writeCsvFile();
+        propertiesMap.put("csvFilePath", csvFile.toString());
+
         when(configurationMock.getProperties()).
                 thenReturn(propertiesMap);
 
         SW360ConnectionConfiguration connectionConfiguration = mock(SW360ConnectionConfiguration.class);
 
-        when(releaseClientAdapter.uploadAttachments(any(), any(), eq(header)))
-                .thenReturn(new SW360Release());
         when(connectionConfiguration.getSW360ReleaseClientAdapter())
                 .thenReturn(releaseClientAdapter);
         when(connectionConfiguration.getHttpHeaders())
@@ -63,16 +103,39 @@ public class SW360UpdaterTest {
 
     @Test
     public void testExecute() {
+        SW360Release release = mock(SW360Release.class);
+        when(release.getClearingState()).thenReturn(clearingState);
+        when(updater.artifactToReleaseInSW360(any()))
+                .thenReturn(release);
+
         SW360Updater sw360Updater = new SW360Updater();
         sw360Updater.setUpdater(updater);
         sw360Updater.setConfiguration(configurationMock);
 
         sw360Updater.execute();
 
-        Map<Path, SW360AttachmentType> testAttachmentMap = Collections
-                .singletonMap(configurationMock.getBaseDir().resolve("test-source.txt"),SW360AttachmentType.CLEARING_REPORT);
+        Map<Path, SW360AttachmentType> testAttachmentMap;
+        if(clearingDocAvailable) {
+        testAttachmentMap = Collections
+                .singletonMap(configurationMock.getBaseDir().resolve(clearingDocName),SW360AttachmentType.CLEARING_REPORT);
+        } else {
+            testAttachmentMap = Collections.emptyMap();
+        }
 
-        verify(updater, atLeast(1)).artifactToReleaseInSW360(any());
-        verify(releaseClientAdapter, atLeast(1)).uploadAttachments(any(), eq(testAttachmentMap), eq(header));
+        verify(updater).artifactToReleaseInSW360(any());
+        verify(releaseClientAdapter, times(expectUpload ? 1 : 0)).uploadAttachments(any(), eq(testAttachmentMap), eq(header));
+    }
+
+    private Path writeCsvFile() throws IOException {
+        final File tempCsvFile = folder.newFile("test.csv");
+        String clearingDocPath = "";
+        if (clearingDocAvailable) {
+            File clearingDoc = folder.newFile(clearingDocName);
+            clearingDocPath = clearingDoc.getPath();
+        }
+        String csvContent = String.format("Artifact Id,Group Id,Version,Coordinate Type,Clearing State,Clearing Document%s" +
+                "test,test,x.x.x,mvn,%s,%s%s", System.lineSeparator(), clearingState, clearingDocPath, System.lineSeparator());
+        FileUtils.writeStringToFile(tempCsvFile, csvContent);
+        return tempCsvFile.toPath();
     }
 }

--- a/assembly/compliance-tool/src/test/resources/compliancetool-exporter.properties
+++ b/assembly/compliance-tool/src/test/resources/compliancetool-exporter.properties
@@ -8,9 +8,9 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-targetDir=build/compliancetool/
-sourcesDirectory=/sources
-csvFilePath=<example-path>
+targetDir=./
+sourcesDirectory=./sources
+csvFilePath=sample.csv
 encoding=UTF-8
 delimiter=;
 basedir=

--- a/assembly/compliance-tool/src/test/resources/compliancetool-updater.properties
+++ b/assembly/compliance-tool/src/test/resources/compliancetool-updater.properties
@@ -13,7 +13,7 @@ targetDir=build/compliancetool/
 sourcesDirectory=/sources
 basedir=
 csvFilePath=src/test/resources/compliancetool_updater_test.csv
-delimiter=;
+delimiter=,
 encoding=UTF-8
 # proxy
 proxyHost=

--- a/assembly/compliance-tool/src/test/resources/compliancetool_updater_test.csv
+++ b/assembly/compliance-tool/src/test/resources/compliancetool_updater_test.csv
@@ -1,3 +1,0 @@
-Group Id;Artifact Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Clearing Document;Change Status;CPE;File Name
-com.sun.xml.bind;jaxb-xjc;2.2.10;mvn;;;;;;;;;;;;;
-org.infinispan;infinispan-cachestore-remote;9.4.14.Final;mvn;Apache-2.0;Apache-2.0;Apache-2.0;;;https://repo.bosch-si.com/service/local/repositories/inst-thirdparty-sources/content/org/infinispan/infinispan-cachestore-remote/9.4.14.Final/infinispan-cachestore-remote-9.4.14.Final-sources.jar;;;OSM_APPROVED;test-source.txt;;;infinispan-cachestore-remote-9.4.14.Final-sources.jar

--- a/assembly/compliance-tool/src/test/resources/compliancetool_updater_test.csv
+++ b/assembly/compliance-tool/src/test/resources/compliancetool_updater_test.csv
@@ -1,3 +1,3 @@
-Group Id;Artifact Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Change Status;CPE;File Name
-com.sun.xml.bind;jaxb-xjc;2.2.10;mvn;;;;;;;;;;;;
-org.infinispan;infinispan-cachestore-remote;9.4.14.Final;mvn;Apache-2.0;Apache-2.0;Apache-2.0;;;https://repo.bosch-si.com/service/local/repositories/inst-thirdparty-sources/content/org/infinispan/infinispan-cachestore-remote/9.4.14.Final/infinispan-cachestore-remote-9.4.14.Final-sources.jar;;;OSM_APPROVED;;;infinispan-cachestore-remote-9.4.14.Final-sources.jar
+Group Id;Artifact Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Clearing Document;Change Status;CPE;File Name
+com.sun.xml.bind;jaxb-xjc;2.2.10;mvn;;;;;;;;;;;;;
+org.infinispan;infinispan-cachestore-remote;9.4.14.Final;mvn;Apache-2.0;Apache-2.0;Apache-2.0;;;https://repo.bosch-si.com/service/local/repositories/inst-thirdparty-sources/content/org/infinispan/infinispan-cachestore-remote/9.4.14.Final/infinispan-cachestore-remote-9.4.14.Final-sources.jar;;;OSM_APPROVED;test-source.txt;;;infinispan-cachestore-remote-9.4.14.Final-sources.jar

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapper.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapper.java
@@ -36,8 +36,8 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class CSVReader {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CSVReader.class);
+public class CSVArtifactMapper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CSVArtifactMapper.class);
 
     private static final String NAME = "Artifact Id";
     private static final String GROUP = "Group Id";
@@ -63,7 +63,7 @@ public class CSVReader {
     private Path baseDir;
 
 
-    public CSVReader(Path csvFile, Charset encoding, char delimiter, Path baseDir) {
+    public CSVArtifactMapper(Path csvFile, Charset encoding, char delimiter, Path baseDir) {
         this.csvFile = csvFile;
         this.encoding = encoding;
         this.delimiter = delimiter;
@@ -422,7 +422,7 @@ public class CSVReader {
     private static String getFilepathAsString(Artifact artifact) {
         return artifact.askFor(ArtifactSourceFile.class)
                 .map(ArtifactFactWithPayload::get)
-                .map(pth -> CSVReader.getPathAsStringIfExists(pth, artifact))
+                .map(pth -> getPathAsStringIfExists(pth, artifact))
                 .orElse("");
     }
 

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVReader.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVReader.java
@@ -86,10 +86,10 @@ public class CSVReader {
                      RELEASE_ARTIFACT_URL,
                      SWH_ID,
                      CLEARING_STATE,
+                     CLEARING_DOCUMENT_PATH,
                      CHANGES_STATUS,
                      CPE,
-                     PATH_NAME,
-                     CLEARING_DOCUMENT_PATH
+                     PATH_NAME
              ))
         ) {
             for (Artifact artifact : artifacts) {
@@ -163,6 +163,7 @@ public class CSVReader {
         csvRecordString.add(mapReleaseTagUrlToString(artifact));
         csvRecordString.add(mapSoftwareHeritagToString(artifact));
         csvRecordString.add(mapClearingStatusToString(artifact));
+        csvRecordString.add(mapClearingDocumentToString(artifact));
         csvRecordString.add(mapChangeStatusToString(artifact));
         csvRecordString.add(mapCPEIdToString(artifact));
         csvRecordString.add(getFilepathAsString(artifact));
@@ -390,6 +391,14 @@ public class CSVReader {
     private static String mapClearingStatusToString(Artifact artifact) {
         Optional<ArtifactClearingState.ClearingState> cs = artifact.askForGet(ArtifactClearingState.class);
         return cs.map(ArtifactClearingState.ClearingState::toString)
+                .orElse("");
+    }
+
+    private static String mapClearingDocumentToString(Artifact artifact) {
+        Optional<ArtifactClearingDocument> cd = artifact.askFor(ArtifactClearingDocument.class);
+        return cd.map(ArtifactClearingDocument::get)
+                .filter(Files::exists)
+                .map(Path::toString)
                 .orElse("");
     }
 

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVReader.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVReader.java
@@ -55,6 +55,7 @@ public class CSVReader {
     private static final String CHANGES_STATUS = "Change Status";
     private static final String CPE = "CPE";
     private static final String PATH_NAME = "File Name";
+    private static final String CLEARING_DOCUMENT_PATH = "Clearing Document";
 
     private Path csvFile;
     private Charset encoding;
@@ -87,7 +88,8 @@ public class CSVReader {
                      CLEARING_STATE,
                      CHANGES_STATUS,
                      CPE,
-                     PATH_NAME
+                     PATH_NAME,
+                     CLEARING_DOCUMENT_PATH
              ))
         ) {
             for (Artifact artifact : artifacts) {
@@ -261,6 +263,15 @@ public class CSVReader {
             } else {
                 artifact.getMainCoordinate().ifPresent(coordinate ->
                         LOGGER.debug("The given source file {} for artifact {} does not exist.", path, coordinate));
+            }
+        }
+        if (checkIfRecordIsMappedAndNotEmptyForParameter(record, CLEARING_DOCUMENT_PATH)) {
+            Path clearingDoc = baseDir.resolve(record.get(CLEARING_DOCUMENT_PATH));
+            if (Files.exists(clearingDoc)) {
+                artifact.addFact(new ArtifactClearingDocument(clearingDoc));
+            } else {
+                LOGGER.debug("Ignoring non existent clearing document {} for artifact {}.", clearingDoc,
+                        artifact.getMainCoordinate().map(Coordinate::getName).orElse("undefined"));
             }
         }
     }

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzer.java
@@ -14,7 +14,7 @@ package org.eclipse.sw360.antenna.workflow.analyzers;
 
 import org.eclipse.sw360.antenna.api.workflow.ManualAnalyzer;
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
-import org.eclipse.sw360.antenna.csvreader.CSVReader;
+import org.eclipse.sw360.antenna.csvreader.CSVArtifactMapper;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 
 import java.util.Collection;
@@ -31,7 +31,7 @@ public class CsvAnalyzer extends ManualAnalyzer {
 
     @Override
     public WorkflowStepResult yield() {
-        Collection<Artifact> artifacts = new CSVReader(
+        Collection<Artifact> artifacts = new CSVArtifactMapper(
                 componentInfoFile.toPath(),
                 context.getToolConfiguration().getEncoding(),
                 rowDelimiter,

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapperTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapperTest.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CSVReaderTest {
+public class CSVArtifactMapperTest {
     private static final String ARTIFACT_DOWNLOAD_URL = "https://organisation-test.org/";
     private static final String ARTIFACT_CLEARING_STATE = "PROJECT_APPROVED";
     private static final String ARTIFACT_TAG_URL = "https://gitTool.com/project/repository";
@@ -83,9 +83,9 @@ public class CSVReaderTest {
     public void testRoundTripWriteRead() {
         List<Artifact> artifacts = new ArrayList<>();
         artifacts.add(mkArtifact("test", false).addFact(new ArtifactMatchingMetadata(MatchState.EXACT)));
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(artifacts);
-        Collection<Artifact> csvReaderArtifacts = csvReader.createArtifactsList();
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(artifacts);
+        Collection<Artifact> csvReaderArtifacts = csvArtifactMapper.createArtifactsList();
         assertThat(csvReaderArtifacts).isEqualTo(artifacts);
     }
 
@@ -96,8 +96,8 @@ public class CSVReaderTest {
         artifacts.add(mkArtifact("test1", false)
                 .addCoordinate(new Coordinate("pkg:maven/test/test1@1.2.3"))
                 .addCoordinate(new Coordinate("pkg:p2/test/test1@1.2.3")));
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(artifacts);
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(artifacts);
 
         assertThat(csvFile.exists()).isTrue();
 
@@ -113,12 +113,12 @@ public class CSVReaderTest {
                                 Paths.get(this.getClass().getClassLoader().getResource("CsvAnalyzerTest/test_source.txt").toURI())));
         List<Artifact> artifacts = Collections.singletonList(artifact);
 
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(artifacts);
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(artifacts);
 
         assertThat(csvFile.exists()).isTrue();
 
-        List<Artifact> artifactsList = (List<Artifact>) csvReader.createArtifactsList();
+        List<Artifact> artifactsList = (List<Artifact>) csvArtifactMapper.createArtifactsList();
         assertThat(artifactsList).hasSize(1);
         assertThat(artifactsList.get(0).askFor(ArtifactSourceFile.class)).isPresent();
     }
@@ -130,12 +130,12 @@ public class CSVReaderTest {
                         .addFact(new ArtifactSourceFile(Paths.get("non-existent-source-file.tgz")));
         List<Artifact> artifacts = Collections.singletonList(artifact);
 
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(artifacts);
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(artifacts);
 
         assertThat(csvFile.exists()).isTrue();
 
-        List<Artifact> artifactsList = (List<Artifact>) csvReader.createArtifactsList();
+        List<Artifact> artifactsList = (List<Artifact>) csvArtifactMapper.createArtifactsList();
         assertThat(artifactsList).hasSize(1);
         assertThat(artifactsList.get(0).askFor(ArtifactSourceFile.class)).isNotPresent();
     }
@@ -144,8 +144,8 @@ public class CSVReaderTest {
     public void writeSingleReleaseListToCSVFileTest() throws IOException {
         List<Artifact> oneArtifact = Collections.singletonList(mkArtifact("test:test", true)
                 .addFact(new ArtifactCPE("cpeId")));
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(oneArtifact);
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(oneArtifact);
 
         assertThat(csvFile.exists()).isTrue();
 
@@ -163,8 +163,8 @@ public class CSVReaderTest {
     @Test
     public void writeEmptyReleaseListToCSVFileTest() throws IOException {
         List<Artifact> emptyArtifacts = new ArrayList<>();
-        CSVReader csvReader = new CSVReader(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
-        csvReader.writeArtifactsToCsvFile(emptyArtifacts);
+        CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(), StandardCharsets.UTF_8, DELIMITER, csvFile.getParentFile().toPath());
+        csvArtifactMapper.writeArtifactsToCsvFile(emptyArtifacts);
 
         assertThat(csvFile.exists()).isTrue();
 

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapperTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapperTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.sw360.antenna.csvreader;
 
-import com.here.ort.spdx.SpdxException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVReaderTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVReaderTest.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
@@ -46,6 +48,7 @@ public class CSVReaderTest {
     private static final String ARTIFACT_CHANGESTATUS = "AS_IS";
     private static final String ARTIFACT_COPYRIGHT = "Copyright xxxx Some Copyright Enterprise";
     private static final char DELIMITER = ',';
+    private static final String CLEARING_DOC_NAME = "clearing.doc";
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -71,6 +74,7 @@ public class CSVReaderTest {
             "Release Tag URL",
             "Software Heritage ID",
             "Clearing State",
+            "Clearing Document",
             "Change Status",
             "CPE",
             "File Name"};
@@ -184,10 +188,23 @@ public class CSVReaderTest {
         artifact.addFact(new ArtifactFilename(null, ("12345678" + name)));
         artifact.addFact(new ArtifactFilename(null, ("12345678" + name)));
         artifact.addFact(new ArtifactClearingState(ArtifactClearingState.ClearingState.valueOf(ARTIFACT_CLEARING_STATE)));
+        artifact.addFact(new ArtifactClearingDocument(createClearingDocument()));
         artifact.addFact(new ArtifactChangeStatus(ArtifactChangeStatus.ChangeStatus.valueOf(ARTIFACT_CHANGESTATUS)));
         artifact.addFact(new CopyrightStatement(ARTIFACT_COPYRIGHT));
 
         return artifact;
+    }
+
+    private Path createClearingDocument() {
+        Path clearingDoc = folder.getRoot().toPath().resolve(CLEARING_DOC_NAME);
+        if (!Files.exists(clearingDoc)) {
+            try {
+                folder.newFile(CLEARING_DOC_NAME);
+            } catch (IOException e) {
+                throw new AssertionError("Could not create clearing document file", e);
+            }
+        }
+        return clearingDoc;
     }
 
     private void addLicenseFact(Optional<String> licenseRawData, Artifact artifact, Function<LicenseInformation, ArtifactLicenseInformation> licenseCreator, boolean isAlreadyPresent) {

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVReaderTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/csvreader/CSVReaderTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.csvreader;
 
+import com.here.ort.spdx.SpdxException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
@@ -134,6 +134,22 @@ public class CsvAnalyzerTest extends AntennaTestWithMockedContext {
      }
 
     @Test
+    public void testExistenceOfClearingDocumentIsChecked() throws URISyntaxException {
+        configureAnalyzer("dependencies.csv", ",");
+
+        Set<Artifact> artifacts = analyzer.yield().getArtifacts();
+
+        Artifact foundArtifact = artifacts.stream()
+                .filter(artifact -> "commons-cli".equals(artifact.getCoordinateForType(PackageURL.StandardTypes.MAVEN)
+                        .map(Coordinate::getName)
+                        .orElse("")))
+                .findFirst()
+                .get();
+
+        assertThat(foundArtifact.askFor(ArtifactClearingDocument.class)).isNotPresent();
+    }
+
+    @Test
     public void testCopyrightsIsParsedCorrectly() throws URISyntaxException {
         configureAnalyzer("dependencyWithMultipleCopyrights.csv", ",");
         Set<Artifact> artifacts = analyzer.yield().getArtifacts();
@@ -251,5 +267,7 @@ public class CsvAnalyzerTest extends AntennaTestWithMockedContext {
                 new ArtifactChangeStatus(ArtifactChangeStatus.ChangeStatus.AS_IS));
 
         assertThat(foundArtifact.askFor(ArtifactCPE.class).get()).isEqualTo(new ArtifactCPE("cpe:2.3:a:apache:commons-csv:1.4"));
+
+        assertThat(foundArtifact.askFor(ArtifactClearingDocument.class).get().get().getFileName().toString()).isEqualTo("clearing.json");
     }
 }

--- a/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencies.csv
+++ b/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependencies.csv
@@ -1,8 +1,8 @@
-Artifact Id,Group Id,Version,Coordinate Type,Effective License,Declared License,Observed License,Copyrights,Hash,Source URL,Release Tag URL,Software Heritage ID,Clearing State,Change Status,CPE,File Name
-commons-csv,org.apache.commons,1.4,mvn,Apache-2.0,Apache-2.0,Apache-2.0 OR MIT,Copyright 2005-2016 The Apache Software Foundation,620580a88953cbcf4528459e485054e7c27c0889,http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip,https://github.com/apache/commons-csv/tree/csv-1.4,swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-csv:1.4,
-commons-cli,org.apache.commons,1.4,maven,Apache-2.0,Apache-2.0,,Copyright 2005-2016 The Apache Software Foundation,2a26e60c745cdeb99a96f21adec508f43b5d25a5,http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip,https://github.com/apache/commons-cli/tree/cli-1.4,swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4,OSM_APPROVED,AS_IS,cpe:2.3:a:apache:commons-cli:1.4,commons-cli.jar
-testNuget,,1.0,nuget,,,,,,,,,,,,
-testDotNet,,1.0,dotnet,,,,,,,,,,,,
-testNpm,test,1.0,npm,,,,,,,,,,,,
-testbundle	,,1.0,bundle,,,,,,,,,,,,
-testPython,,1.0,PYPI,,,,,,,,,,,,
+Artifact Id,Group Id,Version,Coordinate Type,Effective License,Declared License,Observed License,Copyrights,Hash,Source URL,Release Tag URL,Software Heritage ID,Clearing State,Clearing Document,Change Status,CPE,File Name
+commons-csv,org.apache.commons,1.4,mvn,Apache-2.0,Apache-2.0,Apache-2.0 OR MIT,Copyright 2005-2016 The Apache Software Foundation,620580a88953cbcf4528459e485054e7c27c0889,http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip,https://github.com/apache/commons-csv/tree/csv-1.4,swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda,OSM_APPROVED,CsvAnalyzerTest/clearing.json,AS_IS,cpe:2.3:a:apache:commons-csv:1.4,
+commons-cli,org.apache.commons,1.4,maven,Apache-2.0,Apache-2.0,,Copyright 2005-2016 The Apache Software Foundation,2a26e60c745cdeb99a96f21adec508f43b5d25a5,http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip,https://github.com/apache/commons-cli/tree/cli-1.4,swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4,OSM_APPROVED,non-existing-clearing.json,AS_IS,cpe:2.3:a:apache:commons-cli:1.4,commons-cli.jar
+testNuget,,1.0,nuget,,,,,,,,,,,,,
+testDotNet,,1.0,dotnet,,,,,,,,,,,,,
+testNpm,test,1.0,npm,,,,,,,,,,,,,
+testbundle	,,1.0,bundle,,,,,,,,,,,,,
+testPython,,1.0,PYPI,,,,,,,,,,,,,

--- a/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependenciesWithExcelFormat.csv
+++ b/core/core-workflow-steps/src/test/resources/CsvAnalyzerTest/dependenciesWithExcelFormat.csv
@@ -1,14 +1,14 @@
-Artifact Id;Group Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Change Status;CPE;File Name
-commons-csv;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 2005-2016 The Apache Software Foundation;620580a88953cbcf4528459e485054e7c27c0889;http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip;https://github.com/apache/commons-csv/tree/csv-1.4;swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;
-commons-csv;org.apache.commons;1.4;mvn;;;;Copyright, 2020 the fake;1,23E+16;;;;;;;
-commons-csv;org.apache.commons;1.4;mvn;;;;"Copyright fake; the third";;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;;Copyright 2005-2016 The Apache Software Foundation;2a26e60c745cdeb99a96f21adec508f43b5d25a5;http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip;https://github.com/apache/commons-cli/tree/cli-1.4;swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4;OSM_APPROVED;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;
-commons-cli;org.apache.commons;1.4;mvn;;;;copy & paste;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;this is $ it;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;!nevermind;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;§copsright;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;%gsp;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;?;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;`wer`;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;#wtewp;;;;;;;;
-commons-cli;org.apache.commons;1.4;mvn;;;;~fjd;;;;;;;;
+Artifact Id;Group Id;Version;Coordinate Type;Effective License;Declared License;Observed License;Copyrights;Hash;Source URL;Release Tag URL;Software Heritage ID;Clearing State;Clearing Document;Change Status;CPE;File Name
+commons-csv;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;Apache-2.0 OR MIT;Copyright 2005-2016 The Apache Software Foundation;620580a88953cbcf4528459e485054e7c27c0889;http://archive.apache.org/dist/commons/csv/source/commons-csv-1.4-src.zip;https://github.com/apache/commons-csv/tree/csv-1.4;swh:1:cnt:60dbac0aafd98c9ca461256a0cefd8a7aaea8bda;OSM_APPROVED;CsvAnalyzerTest/clearing.json;AS_IS;cpe:2.3:a:apache:commons-csv:1.4;
+commons-csv;org.apache.commons;1.4;mvn;;;;Copyright, 2020 the fake;1,23E+16;;;;;;;;
+commons-csv;org.apache.commons;1.4;mvn;;;;"Copyright fake; the third";;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;Apache-2.0;Apache-2.0;;Copyright 2005-2016 The Apache Software Foundation;2a26e60c745cdeb99a96f21adec508f43b5d25a5;http://archive.apache.org/dist/commons/cli/source/commons-cli-1.4-src.zip;https://github.com/apache/commons-cli/tree/cli-1.4;swh:1:cnt:fb91f0e6b0e7b2f89fe5e1a2b1b375775e4839d4;OSM_APPROVED;;AS_IS;cpe:2.3:a:apache:commons-cli:1.4;
+commons-cli;org.apache.commons;1.4;mvn;;;;copy & paste;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;this is $ it;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;!nevermind;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;§copsright;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;%gsp;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;?;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;`wer`;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;#wtewp;;;;;;;;;
+commons-cli;org.apache.commons;1.4;mvn;;;;~fjd;;;;;;;;;

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactClearingDocument.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactClearingDocument.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.model.artifact.facts;
+
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFact;
+import org.eclipse.sw360.antenna.model.artifact.ArtifactFactWithPayload;
+
+import java.nio.file.Path;
+
+public class ArtifactClearingDocument extends ArtifactFactWithPayload<Path> {
+    public ArtifactClearingDocument(Path payload) {
+        super(payload);
+    }
+
+    @Override
+    public String getFactContentName() {
+        return "Clearing document";
+    }
+
+    @Override
+    public Class<? extends ArtifactFact> getKey() {
+        return ArtifactClearingDocument.class;
+    }
+}

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactClearingState.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/artifact/facts/ArtifactClearingState.java
@@ -31,7 +31,7 @@ public class ArtifactClearingState extends ArtifactFactWithPayload<ArtifactClear
     }
 
     public enum ClearingState {
-        INITAL,
+        INITIAL,
         EXTERNAL_SOURCE,
         AUTO_EXTRACT,
         PROJECT_APPROVED,

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
@@ -107,7 +107,7 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>
             Optional<byte[]> body = Optional.of(response.getBody());
 
             return Optional.of(Files.write(downloadPath.resolve(attachment.getFilename()), body.get()));
-        } catch (HttpClientErrorException e) {
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
             LOGGER.warn("Request to get attachment {} from {} failed with {}", attachmentId, itemHref, e.getStatusCode());
             LOGGER.debug("Error: ", e);
         } catch (ExecutionException e) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ClearingState.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ClearingState.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
+
+public enum SW360ClearingState {
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ClearingState.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ClearingState.java
@@ -10,5 +10,12 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
 
+/**
+ * This enumeration class mimics the clearing states available in SW360.
+ */
 public enum SW360ClearingState {
+    NEW_CLEARING,
+    SENT_TO_CLEARING_TOOL,
+    REPORT_AVAILABLE,
+    APPROVED;
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.eclipse.sw360.antenna.model.coordinates.Coordinate;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResource;
@@ -42,6 +43,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     private String createdOn;
     private String cpeId;
     private String downloadurl;
+    private SW360ClearingState sw360ClearingState;
     private final Map<String, String> externalIds = new HashMap<>();
     @JsonSerialize
     private final Map<String, String> additionalData = new HashMap<>();
@@ -244,6 +246,15 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
     public SW360Release setClearingState(String clearingState) {
         additionalData.put(CLEARINGSTATE_KEY, clearingState);
         return this;
+    }
+
+    @JsonProperty("clearingState")
+    public SW360ClearingState getSw360ClearingState() {
+        return sw360ClearingState;
+    }
+
+    public void setSw360ClearingState(SW360ClearingState sw360ClearingState) {
+        this.sw360ClearingState = sw360ClearingState;
     }
 
     @JsonIgnore

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/releases/SW360ReleaseTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resources/releases/SW360ReleaseTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.rest.resources.releases;
 
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ClearingState;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resources.SW360ResourcesTestUtils;
 import org.junit.Test;
@@ -38,6 +39,8 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         ArrayList<SW360SparseAttachment> sparseAttachmentList = new ArrayList<>();
         sparseAttachmentList.add(new SW360SparseAttachment().setFilename("").setAttachmentType(SW360AttachmentType.SOURCE));
         release.get_Embedded().setAttachments(sparseAttachmentList);
+        release.setSw360ClearingState(SW360ClearingState.NEW_CLEARING);
+        release.setClearingState("INITIAL");
         return release;
     }
 

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360RestAdapterUtilsTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360RestAdapterUtilsTest.java
@@ -33,7 +33,7 @@ public class SW360RestAdapterUtilsTest {
         SW360Release releaseFromArtifact = SW360ReleaseAdapterUtils.convertToReleaseWithoutAttachments(artifact);
         Artifact artifactFromRelease = SW360ReleaseAdapterUtils.convertToArtifactWithoutSourceFile(releaseFromArtifact, new Artifact("SW360"));
 
-        assertThat(artifactFromRelease.askForAll(ArtifactFact.class)).isEqualTo(artifact.askForAll(ArtifactFact.class));
+        assertThat(artifactFromRelease.askForAll(ArtifactFact.class)).containsAll(artifact.askForAll(ArtifactFact.class));
         assertThat(artifactFromRelease).isEqualTo(artifact);
     }
 }


### PR DESCRIPTION
Issue: #410 

The goal of this PR is to add a new fact for a clearing document to the model for SW360, which is going to be used by the compliance tool. 

CSVReader has been updated to read and write the new property; the unit tests have been extended accordingly.
The compliance tool has a functioning round-trip regarding clearing releases when running the Updater and not downloading them again in the SW360Exporter. 

Some minor fixes to bugs discovered during development were added in separate commits. 

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch 
@oheger-bosch

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  New Feature + Bug fixes

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

Existing unit tests have been updated and extended where necessary to cover the new functionality.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes -> issue was created https://github.com/eclipse/antenna/issues/415
