### PR TITLE
Oheger bosch/sw360/#397 proxy support

### DIFF
--- a/.ci-scripts/test-for-licenseHeaders.sh
+++ b/.ci-scripts/test-for-licenseHeaders.sh
@@ -59,7 +59,7 @@ getFiles() {
     fi |
         grep -Ev '^./.git' |
         grep -Ev 'META-INF/services' |
-        grep -Ev '\.(csv|rdf|ent|dtd|png|gitignore|gitattributes|md|bat|jar|json|couch|view|MF|xz|index|pdf|odt)' |
+        grep -Ev '\.(csv|rdf|ent|dtd|png|gitignore|gitattributes|md|bat|jar|json|couch|view|MF|xz|index|pdf|odt|MockMaker)' |
         grep -Ev '(gradlew|build.gradle|settings.gradle|gradle.properties|gradle/wrapper)' |
         grep -Ev '(LICENSE|NOTICE|README)' |
         grep -v 'antenna-testing/antenna-system-test/src/test/resources/analyzer'

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360Configuration.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360Configuration.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360;
 
 import org.eclipse.sw360.antenna.api.workflow.ConfigurableWorkflowItem;
 import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfigurationFactory;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -51,7 +52,8 @@ public class SW360Configuration extends ConfigurableWorkflowItem {
                 {"download.attachments", getConfigValue("sw360downloadSources", properties, "false")},
                 {"proxy.use", getConfigValue("proxyUse", properties)}})
                 .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1]));
-        return new SW360ConnectionConfiguration(
+        SW360ConnectionConfigurationFactory configurationFactory = new SW360ConnectionConfigurationFactory();
+        return configurationFactory.createConfiguration(
                 key -> getConfigValue(key, configMap),
                 key -> getBooleanConfigValue(key, configMap),
                 properties.get("proxyHost"), Integer.parseInt(properties.get("proxyPort")));

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/ProxySettings.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,7 +11,11 @@
  */
 package org.eclipse.sw360.antenna.util;
 
+import java.util.Objects;
+
 public class ProxySettings {
+    private static final ProxySettings EMPTY_SETTINGS = new ProxySettings(false, null, -1);
+
     private final boolean proxyUse;
     private final String proxyHost;
     private final int proxyPort;
@@ -21,8 +26,14 @@ public class ProxySettings {
         this.proxyPort = proxyPort;
     }
 
+    /**
+     * Returns an instance of {@code ProxySettings} that indicates that no
+     * proxy is to be used.
+     *
+     * @return an instance with an empty proxy configuration
+     */
     public static ProxySettings empty() {
-        return new ProxySettings(false, null, -1);
+        return EMPTY_SETTINGS;
     }
 
     public boolean isProxyUse() {
@@ -37,5 +48,32 @@ public class ProxySettings {
         return proxyPort;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
+        ProxySettings settings = (ProxySettings) o;
+        return proxyUse == settings.proxyUse &&
+                getProxyPort() == settings.getProxyPort() &&
+                Objects.equals(getProxyHost(), settings.getProxyHost());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(proxyUse, getProxyHost(), getProxyPort());
+    }
+
+    @Override
+    public String toString() {
+        return "ProxySettings{" +
+                "proxyUse=" + proxyUse +
+                ", proxyHost='" + proxyHost + '\'' +
+                ", proxyPort=" + proxyPort +
+                '}';
+    }
 }

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/ProxySettingsTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/ProxySettingsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxySettingsTest {
+    private static final String PROXY_HOST = "my.proxy.net";
+    private static final int PROXY_PORT = 7777;
+
+    /**
+     * Helper function to check the implementation of equals() and hashCode().
+     *
+     * @param obj1     object 1 to be compared
+     * @param obj2     object 2 to be compared
+     * @param expected the expected outcome
+     */
+    private static void checkEquals(Object obj1, Object obj2, boolean expected) {
+        assertThat(obj1.equals(obj2)).isEqualTo(expected);
+        if (obj2 != null) {
+            assertThat(obj2.equals(obj1)).isEqualTo(expected);
+            if (expected) {
+                assertThat(obj1.hashCode()).isEqualTo(obj2.hashCode());
+            }
+        }
+    }
+
+    @Test
+    public void testEqualsTrue() {
+        ProxySettings settings = new ProxySettings(true, PROXY_HOST, PROXY_PORT);
+        checkEquals(settings, settings, true);
+
+        ProxySettings settings2 = new ProxySettings(true, PROXY_HOST, PROXY_PORT);
+        checkEquals(settings, settings2, true);
+    }
+
+    @Test
+    public void testEqualsFalse() {
+        ProxySettings settings = new ProxySettings(true, PROXY_HOST, PROXY_PORT);
+        ProxySettings settings2 = new ProxySettings(false, PROXY_HOST, PROXY_PORT);
+        checkEquals(settings, settings2, false);
+
+        settings2 = new ProxySettings(true, PROXY_HOST + ".other", PROXY_PORT);
+        checkEquals(settings, settings2, false);
+
+        settings2 = new ProxySettings(true, PROXY_HOST, PROXY_PORT - 1);
+        checkEquals(settings, settings2, false);
+    }
+
+    @Test
+    public void testEqualsCornerCases() {
+        ProxySettings settings = new ProxySettings(false, PROXY_HOST, PROXY_PORT);
+
+        checkEquals(settings, this, false);
+        checkEquals(settings, null, false);
+    }
+
+    @Test
+    public void testToString() {
+        ProxySettings settings = new ProxySettings(true, PROXY_HOST, PROXY_PORT);
+        String s = settings.toString();
+
+        assertThat(s).contains("proxyHost='" + PROXY_HOST);
+        assertThat(s).contains("proxyPort=" + PROXY_PORT);
+        assertThat(s).contains("proxyUse=true");
+    }
+
+    @Test
+    public void testEmpty() {
+        ProxySettings emptySettings = ProxySettings.empty();
+
+        assertThat(emptySettings.isProxyUse()).isFalse();
+        assertThat(emptySettings.getProxyHost()).isNull();
+        assertThat(emptySettings.getProxyPort()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testEmptyReturnsACachedInstance() {
+        ProxySettings empty = ProxySettings.empty();
+
+        assertThat(ProxySettings.empty()).isSameAs(empty);
+    }
+
+    @Test
+    public void testEqualsWithEmpty() {
+        ProxySettings settings = new ProxySettings(false, "", -1);
+        checkEquals(ProxySettings.empty(), settings, false);
+
+        settings = new ProxySettings(true, null, -1);
+        checkEquals(ProxySettings.empty(), settings, false);
+
+        settings = new ProxySettings(true, "", -1);
+        checkEquals(ProxySettings.empty(), settings, false);
+    }
+
+    @Test
+    public void testIsProxyUseNullHost() {
+        ProxySettings settings = new ProxySettings(true, null, -1);
+
+        assertThat(settings.isProxyUse()).isFalse();
+    }
+
+    @Test
+    public void testIsProxyUseEmptyHost() {
+        ProxySettings settings = new ProxySettings(true, "", -1);
+
+        assertThat(settings.isProxyUse()).isFalse();
+    }
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,10 +18,10 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ComponentAdapterUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +33,8 @@ public class SW360ComponentClientAdapter {
 
     private final SW360ComponentClient componentClient;
 
-    public SW360ComponentClientAdapter(String restUrl, ProxySettings proxySettings) {
-        this.componentClient = new SW360ComponentClient(restUrl, proxySettings);
+    public SW360ComponentClientAdapter(String restUrl, RestTemplate template) {
+        this.componentClient = new SW360ComponentClient(restUrl, template);
     }
 
     public Optional<SW360Component> getOrCreateComponent(SW360Component componentFromRelease, HttpHeaders header) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360LicenseClientAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -14,8 +15,8 @@ import org.eclipse.sw360.antenna.model.xml.generated.License;
 import org.eclipse.sw360.antenna.sw360.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,8 +24,8 @@ import java.util.Optional;
 public class SW360LicenseClientAdapter {
     private final SW360LicenseClient licenseClient;
 
-    public SW360LicenseClientAdapter(String restUrl, ProxySettings proxySettings) {
-        this.licenseClient = new SW360LicenseClient(restUrl, proxySettings);
+    public SW360LicenseClientAdapter(String restUrl, RestTemplate template) {
+        this.licenseClient = new SW360LicenseClient(restUrl, template);
     }
 
     public boolean isLicenseOfArtifactAvailable(License license, HttpHeaders header) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ProjectClientAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -21,8 +22,8 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ProjectAdapterUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,8 +34,8 @@ import java.util.stream.Collectors;
 public class SW360ProjectClientAdapter {
     private final SW360ProjectClient projectClient;
 
-    public SW360ProjectClientAdapter(String restUrl, ProxySettings proxySettings) {
-        this.projectClient = new SW360ProjectClient(restUrl, proxySettings);
+    public SW360ProjectClientAdapter(String restUrl, RestTemplate template) {
+        this.projectClient = new SW360ProjectClient(restUrl, template);
     }
 
     public Optional<String> getProjectIdByNameAndVersion(IProject project, HttpHeaders header) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -22,10 +23,10 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ComponentAdapterUtils;
 import org.eclipse.sw360.antenna.sw360.utils.SW360ReleaseAdapterUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -38,9 +39,9 @@ public class SW360ReleaseClientAdapter {
     private final SW360ReleaseClient releaseClient;
     private final SW360ComponentClientAdapter sw360ComponentClientAdapter;
 
-    public SW360ReleaseClientAdapter(String restUrl, ProxySettings proxySettings) {
-        this.releaseClient = new SW360ReleaseClient(restUrl, proxySettings);
-        sw360ComponentClientAdapter = new SW360ComponentClientAdapter(restUrl, proxySettings);
+    public SW360ReleaseClientAdapter(String restUrl, RestTemplate template) {
+        this.releaseClient = new SW360ReleaseClient(restUrl, template);
+        sw360ComponentClientAdapter = new SW360ComponentClientAdapter(restUrl, template);
     }
 
     public SW360Release getOrCreateRelease(SW360Release sw360ReleaseFromArtifact, HttpHeaders header, boolean uploadSources, boolean updateReleases) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -39,9 +39,10 @@ public class SW360ReleaseClientAdapter {
     private final SW360ReleaseClient releaseClient;
     private final SW360ComponentClientAdapter sw360ComponentClientAdapter;
 
-    public SW360ReleaseClientAdapter(String restUrl, RestTemplate template) {
+    public SW360ReleaseClientAdapter(String restUrl, RestTemplate template,
+                                     SW360ComponentClientAdapter componentClientAdapter) {
         this.releaseClient = new SW360ReleaseClient(restUrl, template);
-        sw360ComponentClientAdapter = new SW360ComponentClientAdapter(restUrl, template);
+        sw360ComponentClientAdapter = componentClientAdapter;
     }
 
     public SW360Release getOrCreateRelease(SW360Release sw360ReleaseFromArtifact, HttpHeaders header, boolean uploadSources, boolean updateReleases) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360UserClientAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,15 +14,15 @@ package org.eclipse.sw360.antenna.sw360.adapter;
 
 import org.eclipse.sw360.antenna.sw360.rest.SW360UserClient;
 import org.eclipse.sw360.antenna.sw360.rest.resource.users.SW360User;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 
 public class SW360UserClientAdapter {
 
     private final SW360UserClient userClient;
 
-    public SW360UserClientAdapter(String restUrl, ProxySettings proxySettings) {
-        this.userClient= new SW360UserClient(restUrl, proxySettings);
+    public SW360UserClientAdapter(String restUrl, RestTemplate template) {
+        this.userClient= new SW360UserClient(restUrl, template);
     }
 
     public SW360User getUserByEmail(String userId, HttpHeaders header) {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,7 +19,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360Attachment
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
@@ -27,6 +27,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,8 +41,8 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>
     private static final Logger LOGGER = LoggerFactory.getLogger(SW360AttachmentAwareClient.class);
     private static final String ATTACHMENTS_ENDPOINT = "/attachments";
 
-    public SW360AttachmentAwareClient(ProxySettings proxySettings) {
-        super(proxySettings);
+    protected SW360AttachmentAwareClient(RestTemplate template) {
+        super(template);
     }
 
     public abstract Class<T> getHandledClassType();

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AttachmentAwareClient.java
@@ -74,7 +74,7 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>
     private T uploadAndAttachAttachment(T itemToModify, Path fileToAttach, HttpEntity<MultiValueMap<String, Object>> requestEntity) {
         final String self = itemToModify.get_Links().getSelf().getHref();
         try {
-            ResponseEntity<T> response = restTemplate.postForEntity(self + ATTACHMENTS_ENDPOINT, requestEntity, getHandledClassType());
+            ResponseEntity<T> response = getRestTemplate().postForEntity(self + ATTACHMENTS_ENDPOINT, requestEntity, getHandledClassType());
 
             checkRestStatus(response);
             Validate.validState(response.getBody() != null);
@@ -100,7 +100,7 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?,?>
         String url = itemHref + "/attachments/" + attachmentId;
         try {
             HttpEntity<String> httpEntity = new HttpEntity<>(header);
-            ResponseEntity<byte[]> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, byte[].class);
+            ResponseEntity<byte[]> response = getRestTemplate().exchange(url, HttpMethod.GET, httpEntity, byte[].class);
             checkRestStatus(response);
             Validate.validState(response.getBody() != null);
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360AuthenticationClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2019.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,10 +16,14 @@ package org.eclipse.sw360.antenna.sw360.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360Attributes;
-import org.eclipse.sw360.antenna.util.ProxySettings;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -39,8 +44,8 @@ public class SW360AuthenticationClient extends SW360Client {
 
     private final String authServerUrl;
 
-    public SW360AuthenticationClient(String authServerUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360AuthenticationClient(String authServerUrl, RestTemplate template) {
+        super(template);
         this.authServerUrl = authServerUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360Client.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -12,20 +13,14 @@
 package org.eclipse.sw360.antenna.sw360.rest;
 
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-
 public abstract class SW360Client {
-    private final boolean proxyUse;
     private final RestTemplate restTemplate;
 
     /**
@@ -36,23 +31,9 @@ public abstract class SW360Client {
      */
     protected SW360Client(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
-        proxyUse = false;
     }
 
     public abstract String getEndpoint();
-
-
-    public SW360Client(ProxySettings proxySettings) {
-        proxyUse = proxySettings.isProxyUse();
-        if (proxyUse) {
-            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxySettings.getProxyHost(), proxySettings.getProxyPort()));
-            requestFactory.setProxy(proxy);
-            this.restTemplate = new RestTemplate(requestFactory);
-        } else {
-            this.restTemplate = new RestTemplate();
-        }
-    }
 
     protected <T> ResponseEntity<T> doRestCall(String url, HttpMethod method, HttpEntity<?> httpEntity, Class<T> responseType) {
         return this.getRestTemplate().

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ComponentClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,7 +18,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -27,21 +27,24 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.*;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.checkRestStatus;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSaveOrThrow;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSw360SparseComponents;
 
 public class SW360ComponentClient extends SW360Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(SW360ComponentClient.class);
     private static final String COMPONENTS_ENDPOINT = "/components";
     private final String restUrl;
 
-    public SW360ComponentClient(String restUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360ComponentClient(String restUrl, RestTemplate template) {
+        super(template);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360LicenseClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -16,7 +17,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360LicenseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -26,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +40,8 @@ public class SW360LicenseClient extends SW360Client {
     private static final String LICENSES_ENDPOINT = "/licenses";
     private final String restUrl;
 
-    public SW360LicenseClient(String restUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360LicenseClient(String restUrl, RestTemplate template) {
+        super(template);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -19,29 +20,34 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360ProjectList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.*;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.checkRestStatus;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSaveOrThrow;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSw360SparseReleases;
 
 public class SW360ProjectClient extends SW360Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(SW360ProjectClient.class);
     private static final String PROJECTS_ENDPOINT = "/projects";
     private final String restUrl;
 
-    public SW360ProjectClient(String restUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360ProjectClient(String restUrl, RestTemplate template) {
+        super(template);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360ReleaseClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018-2019.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -16,7 +17,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -26,21 +26,27 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.*;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.checkRestStatus;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSaveOrThrow;
+import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSw360SparseReleases;
 
 public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SW360ReleaseClient.class);
     private static final String RELEASES_ENDPOINT_APPENDIX = "/releases";
     private final String restUrl;
 
-    public SW360ReleaseClient(String restUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360ReleaseClient(String restUrl, RestTemplate template) {
+        super(template);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360RestTemplateFactory.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360RestTemplateFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * <p>
+ * A helper class that allows the creation of a {@code RestTemplate} that is
+ * correctly configured with a request factory supporting the current proxy
+ * settings.
+ * </p>
+ */
+public class SW360RestTemplateFactory {
+    /**
+     * Creates a new {@code RestTemplate} that is initialized with the given
+     * settings.
+     *
+     * @param proxySettings the proxy configuration
+     * @return the initialized {@code RestTemplate}
+     */
+    public RestTemplate createRestTemplate(ProxySettings proxySettings) {
+        return new RestTemplate(createRequestFactory(proxySettings));
+    }
+
+    /**
+     * Creates the request factory for the {@code RestTemplate} managed by this
+     * factory. This implementation creates a factory based on Apache HTTP
+     * client that is properly configured.
+     *
+     * @param proxySettings the proxy configuration
+     * @return the {@code ClientHttpRequestFactory} to create request objects
+     */
+    ClientHttpRequestFactory createRequestFactory(ProxySettings proxySettings) {
+        return new HttpComponentsClientHttpRequestFactory(createHttpClient(proxySettings));
+    }
+
+    /**
+     * Creates the HTTP client for the REST template managed by this factory.
+     *
+     * @param proxySettings the proxy configuration
+     * @return the HTTP client
+     */
+    HttpClient createHttpClient(ProxySettings proxySettings) {
+        HttpClientBuilder builder = newClientBuilder();
+        if (proxySettings.isProxyUse()) {
+            builder.setRoutePlanner(new DefaultProxyRoutePlanner(
+                    new HttpHost(proxySettings.getProxyHost(), proxySettings.getProxyPort())));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns a new builder object for creating HTTP client instances.
+     *
+     * @return the new HTTP client builder
+     */
+    HttpClientBuilder newClientBuilder() {
+        return HttpClients.custom();
+    }
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/rest/SW360UserClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
  * Copyright (c) Verifa Oy 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -14,13 +15,13 @@ package org.eclipse.sw360.antenna.sw360.rest;
 
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.rest.resource.users.SW360User;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.checkRestStatus;
 import static org.eclipse.sw360.antenna.sw360.rest.SW360ClientUtils.getSaveOrThrow;
@@ -29,8 +30,8 @@ public class SW360UserClient extends SW360Client {
     private static final String USERS_ENDPOINT = "/users";
     private final String restUrl;
 
-    public SW360UserClient(String restUrl, ProxySettings proxySettings) {
-        super(proxySettings);
+    public SW360UserClient(String restUrl, RestTemplate template) {
+        super(template);
         this.restUrl = restUrl;
     }
 

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/utils/RestUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -28,7 +29,7 @@ public class RestUtils {
 
     public static HttpEntity<String> getHttpEntity(Map<String, Object> resourceMap, HttpHeaders authBearerHeader) {
         try {
-            String jsonBody = objectMapper.writeValueAsString(resourceMap);
+            String jsonBody = (resourceMap != null) ? objectMapper.writeValueAsString(resourceMap) : null;
             return new HttpEntity<>(jsonBody, authBearerHeader);
         } catch (JsonProcessingException e) {
             throw new ExecutionException("Error when attempting to serialise the request body.", e);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
@@ -15,7 +15,6 @@ import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ProjectClientAdapter;
 import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.springframework.http.HttpHeaders;
 
 public class SW360ConnectionConfiguration {
@@ -27,67 +26,65 @@ public class SW360ConnectionConfiguration {
     public static final String CLIENT_PASSWORD_KEY = "client.password";
     public static final String PROXY_USE = "proxy.use";
 
-    private final String restServerUrl;
-    private final String authServerUrl;
+    private final SW360AuthenticationClient authenticationClient;
+    private final SW360ComponentClientAdapter componentClientAdapter;
+    private final SW360ReleaseClientAdapter releaseClientAdapter;
+    private final SW360LicenseClientAdapter licenseClientAdapter;
+    private final SW360ProjectClientAdapter projectClientAdapter;
     private final String user;
     private final String password;
     private final String clientId;
     private final String clientPassword;
 
-    private final SW360AuthenticationClient authenticationClient;
-
     public SW360ConnectionConfiguration(Getter<String> getConfigValue, Getter<Boolean> getBooleanConfigValue, String proxyHost, int proxyPort) {
         // SW360 Connection configuration
-        restServerUrl = getConfigValue.apply(SW360ConnectionConfiguration.REST_SERVER_URL_KEY);
-        authServerUrl = getConfigValue.apply(SW360ConnectionConfiguration.AUTH_SERVER_URL_KEY);
-        user = getConfigValue.apply(SW360ConnectionConfiguration.USERNAME_KEY);
-        password = getConfigValue.apply(SW360ConnectionConfiguration.PASSWORD_KEY);
-        clientId = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_USER_KEY);
-        clientPassword = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY);
-
-        // Proxy configuration
-        //TODO use proxy setting for template creation
-        boolean proxyUse = getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE);
-        ProxySettings proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
-        System.out.println(proxySettings);
-
-        this.authenticationClient = getSW360AuthenticationClient();
+        this.authenticationClient = null;
+        this.componentClientAdapter = null;
+        this.releaseClientAdapter = null;
+        this.licenseClientAdapter = null;
+        this.projectClientAdapter = null;
+        user = null;
+        password = null;
+        clientId = null;
+        clientPassword = null;
     }
 
-    public SW360ConnectionConfiguration(String restServerUrl, String authServerUrl, String user, String password, String clientId, String clientPassword) {
-        this.restServerUrl = restServerUrl;
-        this.authServerUrl = authServerUrl;
+    public SW360ConnectionConfiguration(SW360AuthenticationClient authenticationClient,
+                                        SW360ComponentClientAdapter componentClientAdapter,
+                                        SW360ReleaseClientAdapter releaseClientAdapter,
+                                        SW360LicenseClientAdapter licenseClientAdapter,
+                                        SW360ProjectClientAdapter projectClientAdapter,
+                                        String user, String password,
+                                        String clientId, String clientPassword) {
+        this.authenticationClient = authenticationClient;
+        this.componentClientAdapter = componentClientAdapter;
+        this.releaseClientAdapter = releaseClientAdapter;
+        this.licenseClientAdapter = licenseClientAdapter;
+        this.projectClientAdapter = projectClientAdapter;
         this.user = user;
         this.password = password;
         this.clientId = clientId;
         this.clientPassword = clientPassword;
-
-        this.authenticationClient = getSW360AuthenticationClient();
     }
 
     public SW360AuthenticationClient getSW360AuthenticationClient() {
-        //TODO pass in shared REST template
-        return new SW360AuthenticationClient(authServerUrl, null);
+        return authenticationClient;
     }
 
     public SW360ComponentClientAdapter getSW360ComponentClientAdapter() {
-        //TODO pass in shared REST template
-        return new SW360ComponentClientAdapter(restServerUrl, null);
+        return componentClientAdapter;
     }
 
     public SW360ReleaseClientAdapter getSW360ReleaseClientAdapter() {
-        //TODO pass in shared REST template
-        return new SW360ReleaseClientAdapter(restServerUrl, null);
+        return releaseClientAdapter;
     }
 
     public SW360LicenseClientAdapter getSW360LicenseClientAdapter() {
-        //TODO pass in shared REST template
-        return new SW360LicenseClientAdapter(restServerUrl, null);
+        return licenseClientAdapter;
     }
 
     public SW360ProjectClientAdapter getSW360ProjectClientAdapter() {
-        //TODO pass in shared REST template
-        return new SW360ProjectClientAdapter(restServerUrl, null);
+        return projectClientAdapter;
     }
 
     public HttpHeaders getHttpHeaders() {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -35,19 +36,6 @@ public class SW360ConnectionConfiguration {
     private final String password;
     private final String clientId;
     private final String clientPassword;
-
-    public SW360ConnectionConfiguration(Getter<String> getConfigValue, Getter<Boolean> getBooleanConfigValue, String proxyHost, int proxyPort) {
-        // SW360 Connection configuration
-        this.authenticationClient = null;
-        this.componentClientAdapter = null;
-        this.releaseClientAdapter = null;
-        this.licenseClientAdapter = null;
-        this.projectClientAdapter = null;
-        user = null;
-        password = null;
-        clientId = null;
-        clientPassword = null;
-    }
 
     public SW360ConnectionConfiguration(SW360AuthenticationClient authenticationClient,
                                         SW360ComponentClientAdapter componentClientAdapter,
@@ -91,8 +79,4 @@ public class SW360ConnectionConfiguration {
         return authenticationClient.getHeadersWithBearerToken(authenticationClient.getOAuth2AccessToken(user, password, clientId, clientPassword));
     }
 
-    @FunctionalInterface
-    public interface Getter<T> {
-        T apply(String s);
-    }
 }

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfiguration.java
@@ -34,7 +34,6 @@ public class SW360ConnectionConfiguration {
     private final String clientId;
     private final String clientPassword;
 
-    private final ProxySettings proxySettings;
     private final SW360AuthenticationClient authenticationClient;
 
     public SW360ConnectionConfiguration(Getter<String> getConfigValue, Getter<Boolean> getBooleanConfigValue, String proxyHost, int proxyPort) {
@@ -47,42 +46,48 @@ public class SW360ConnectionConfiguration {
         clientPassword = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY);
 
         // Proxy configuration
+        //TODO use proxy setting for template creation
         boolean proxyUse = getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE);
-        proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
+        ProxySettings proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
+        System.out.println(proxySettings);
 
         this.authenticationClient = getSW360AuthenticationClient();
     }
 
-    public SW360ConnectionConfiguration(String restServerUrl, String authServerUrl, String user, String password, String clientId, String clientPassword, String proxyHost, int proxyPort, boolean proxyUse) {
+    public SW360ConnectionConfiguration(String restServerUrl, String authServerUrl, String user, String password, String clientId, String clientPassword) {
         this.restServerUrl = restServerUrl;
         this.authServerUrl = authServerUrl;
         this.user = user;
         this.password = password;
         this.clientId = clientId;
         this.clientPassword = clientPassword;
-        proxySettings = new ProxySettings(proxyUse, proxyHost, proxyPort);
 
         this.authenticationClient = getSW360AuthenticationClient();
     }
 
     public SW360AuthenticationClient getSW360AuthenticationClient() {
-        return new SW360AuthenticationClient(authServerUrl, proxySettings);
+        //TODO pass in shared REST template
+        return new SW360AuthenticationClient(authServerUrl, null);
     }
 
     public SW360ComponentClientAdapter getSW360ComponentClientAdapter() {
-        return new SW360ComponentClientAdapter(restServerUrl, proxySettings);
+        //TODO pass in shared REST template
+        return new SW360ComponentClientAdapter(restServerUrl, null);
     }
 
     public SW360ReleaseClientAdapter getSW360ReleaseClientAdapter() {
-        return new SW360ReleaseClientAdapter(restServerUrl, proxySettings);
+        //TODO pass in shared REST template
+        return new SW360ReleaseClientAdapter(restServerUrl, null);
     }
 
     public SW360LicenseClientAdapter getSW360LicenseClientAdapter() {
-        return new SW360LicenseClientAdapter(restServerUrl, proxySettings);
+        //TODO pass in shared REST template
+        return new SW360LicenseClientAdapter(restServerUrl, null);
     }
 
     public SW360ProjectClientAdapter getSW360ProjectClientAdapter() {
-        return new SW360ProjectClientAdapter(restServerUrl, proxySettings);
+        //TODO pass in shared REST template
+        return new SW360ProjectClientAdapter(restServerUrl, null);
     }
 
     public HttpHeaders getHttpHeaders() {

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactory.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactory.java
@@ -84,7 +84,7 @@ public class SW360ConnectionConfigurationFactory {
 
         SW360AuthenticationClient authClient = createAuthenticationClient(restTemplate, authUrl);
         SW360ComponentClientAdapter componentAdapter = createComponentAdapter(restTemplate, restUrl);
-        SW360ReleaseClientAdapter releaseAdapter = createReleaseAdapter(restTemplate, restUrl);
+        SW360ReleaseClientAdapter releaseAdapter = createReleaseAdapter(restTemplate, restUrl, componentAdapter);
         SW360LicenseClientAdapter licenseAdapter = createLicenseAdapter(restTemplate, restUrl);
         SW360ProjectClientAdapter projectAdapter = createProjectAdapter(restTemplate, restUrl);
 
@@ -127,12 +127,14 @@ public class SW360ConnectionConfigurationFactory {
     /**
      * Creates the {@code SW360ReleaseClientAdapter} for the configuration.
      *
-     * @param restTemplate the rest template
-     * @param restUrl      the URL to the REST API endpoint
+     * @param restTemplate           the rest template
+     * @param restUrl                the URL to the REST API endpoint
+     * @param componentClientAdapter the {@code SW360ComponentClientAdapter}
      * @return the {@code SW360ReleaseClientAdapter}
      */
-    SW360ReleaseClientAdapter createReleaseAdapter(RestTemplate restTemplate, String restUrl) {
-        return new SW360ReleaseClientAdapter(restUrl, restTemplate);
+    SW360ReleaseClientAdapter createReleaseAdapter(RestTemplate restTemplate, String restUrl,
+                                                   SW360ComponentClientAdapter componentClientAdapter) {
+        return new SW360ReleaseClientAdapter(restUrl, restTemplate, componentClientAdapter);
     }
 
     /**

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactory.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactory.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.workflow;
+
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ComponentClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ProjectClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
+import org.eclipse.sw360.antenna.sw360.rest.SW360RestTemplateFactory;
+import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * <p>
+ * A class for creating a new {@link SW360ConnectionConfiguration}.
+ * </p>
+ * <p>
+ * This class processes configuration settings to create all supported
+ * adapter objects to interact with a SW360 instance. The adapter objects can
+ * be shared between multiple components; so it is safe to create them once
+ * initially. They can then be obtained from the
+ * {@link SW360ConnectionConfiguration} object returned by this factory.
+ * </p>
+ */
+public class SW360ConnectionConfigurationFactory {
+    /**
+     * The factory for creating the shared Rest template.
+     */
+    private final SW360RestTemplateFactory restTemplateFactory;
+
+    /**
+     * Creates a new instance of {@code SW360ConnectionConfigurationFactory}
+     * with default settings.
+     */
+    public SW360ConnectionConfigurationFactory() {
+        this(new SW360RestTemplateFactory());
+    }
+
+    /**
+     * Creates a new instance of {@code SW360ConnectionConfigurationFactory}
+     * that uses the passed in {@code SW360RestTemplateFactory} to create the
+     * {@code RestTemplate} shared by all SW360 adapter objects.
+     *
+     * @param restTemplateFactory the factory for creating a rest template
+     */
+    public SW360ConnectionConfigurationFactory(SW360RestTemplateFactory restTemplateFactory) {
+        this.restTemplateFactory = restTemplateFactory;
+    }
+
+    /**
+     * Creates a new instance of {@code SW360ConnectionConfiguration} that is
+     * initialized from configuration data. The passed in {@code Getter}
+     * objects are used to read in configuration settings. With the
+     * {@code SW360RestTemplateFactory} provided, the central
+     * {@code RestTemplate} is created that is used by all SW360 client and
+     * adapter objects.
+     *
+     * @param getConfigValue        getter for string config settings
+     * @param getBooleanConfigValue getter for boolean config settings
+     * @param proxyHost             the proxy host
+     * @param proxyPort             the proxy port
+     * @return the new {@code SW360ConnectionConfiguration}
+     */
+    public SW360ConnectionConfiguration createConfiguration(Getter<String> getConfigValue,
+                                                            Getter<Boolean> getBooleanConfigValue,
+                                                            String proxyHost, int proxyPort) {
+        ProxySettings settings = createProxySettings(getBooleanConfigValue, proxyHost, proxyPort);
+        RestTemplate restTemplate = getRestTemplateFactory().createRestTemplate(settings);
+        String restUrl = getConfigValue.apply(SW360ConnectionConfiguration.REST_SERVER_URL_KEY);
+        String authUrl = getConfigValue.apply(SW360ConnectionConfiguration.AUTH_SERVER_URL_KEY);
+        String user = getConfigValue.apply(SW360ConnectionConfiguration.USERNAME_KEY);
+        String password = getConfigValue.apply(SW360ConnectionConfiguration.PASSWORD_KEY);
+        String clientId = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_USER_KEY);
+        String clientPassword = getConfigValue.apply(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY);
+
+        SW360AuthenticationClient authClient = createAuthenticationClient(restTemplate, authUrl);
+        SW360ComponentClientAdapter componentAdapter = createComponentAdapter(restTemplate, restUrl);
+        SW360ReleaseClientAdapter releaseAdapter = createReleaseAdapter(restTemplate, restUrl);
+        SW360LicenseClientAdapter licenseAdapter = createLicenseAdapter(restTemplate, restUrl);
+        SW360ProjectClientAdapter projectAdapter = createProjectAdapter(restTemplate, restUrl);
+
+        return new SW360ConnectionConfiguration(authClient, componentAdapter, releaseAdapter, licenseAdapter,
+                projectAdapter, user, password, clientId, clientPassword);
+    }
+
+    /**
+     * Returns the {@code SW360RestTemplateFactory} that is used by this
+     * object.
+     *
+     * @return the {@code SW360RestTemplateFactory}
+     */
+    public SW360RestTemplateFactory getRestTemplateFactory() {
+        return restTemplateFactory;
+    }
+
+    /**
+     * Creates the {@code SW360AuthenticationClient} for the configuration.
+     *
+     * @param restTemplate the rest template
+     * @param authUrl      the URL to the authentication endpoint
+     * @return the {@code SW360AuthenticationClient}
+     */
+    SW360AuthenticationClient createAuthenticationClient(RestTemplate restTemplate, String authUrl) {
+        return new SW360AuthenticationClient(authUrl, restTemplate);
+    }
+
+    /**
+     * Creates the {@code SW360ComponentClientAdapter} for the configuration.
+     *
+     * @param restTemplate the rest template
+     * @param restUrl      the URL to the REST API endpoint
+     * @return the {@code SW360ComponentClientAdapter}
+     */
+    SW360ComponentClientAdapter createComponentAdapter(RestTemplate restTemplate, String restUrl) {
+        return new SW360ComponentClientAdapter(restUrl, restTemplate);
+    }
+
+    /**
+     * Creates the {@code SW360ReleaseClientAdapter} for the configuration.
+     *
+     * @param restTemplate the rest template
+     * @param restUrl      the URL to the REST API endpoint
+     * @return the {@code SW360ReleaseClientAdapter}
+     */
+    SW360ReleaseClientAdapter createReleaseAdapter(RestTemplate restTemplate, String restUrl) {
+        return new SW360ReleaseClientAdapter(restUrl, restTemplate);
+    }
+
+    /**
+     * Creates the {@code SW360LicenseClientAdapter} for the configuration.
+     *
+     * @param restTemplate the rest template
+     * @param restUrl      the URL to the REST API endpoint
+     * @return the {@code SW360LicenseClientAdapter}
+     */
+    SW360LicenseClientAdapter createLicenseAdapter(RestTemplate restTemplate, String restUrl) {
+        return new SW360LicenseClientAdapter(restUrl, restTemplate);
+    }
+
+    /**
+     * Creates the {@code SW360ProjectClientAdapter} for the configuration.
+     *
+     * @param restTemplate the rest template
+     * @param restUrl      the URL to the REST API endpoint
+     * @return the {@code SW360ProjectClientAdapter}
+     */
+    SW360ProjectClientAdapter createProjectAdapter(RestTemplate restTemplate, String restUrl) {
+        return new SW360ProjectClientAdapter(restUrl, restTemplate);
+    }
+
+    /**
+     * Creates the proxy settings to be used from the given configuration data.
+     *
+     * @param getBooleanConfigValue getter for boolean config settings
+     * @param proxyHost             the proxy host
+     * @param proxyPort             the proxy port
+     * @return the {@code ProxySettings} to be used
+     */
+    private static ProxySettings createProxySettings(Getter<Boolean> getBooleanConfigValue,
+                                                     String proxyHost, int proxyPort) {
+        return new ProxySettings(getBooleanConfigValue.apply(SW360ConnectionConfiguration.PROXY_USE),
+                proxyHost, proxyPort);
+    }
+
+    @FunctionalInterface
+    public interface Getter<T> {
+        T apply(String s);
+    }
+}

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360Updater.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,6 +18,7 @@ import org.eclipse.sw360.antenna.model.SW360ProjectCoordinates;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.sw360.SW360MetaDataUpdater;
 import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfigurationFactory;
 
 import java.util.Collection;
 import java.util.Map;
@@ -45,9 +47,11 @@ public class SW360Updater extends AbstractGenerator {
         final String sw360ProxyHost = context.getToolConfiguration().getProxyHost();
         final int sw360ProxyPort = context.getToolConfiguration().getProxyPort();
 
-        SW360ConnectionConfiguration sw360ConnectionConfiguration = new SW360ConnectionConfiguration(key -> getConfigValue(key, configMap),
-                key -> getBooleanConfigValue(key, configMap),
-                sw360ProxyHost, sw360ProxyPort);
+        SW360ConnectionConfigurationFactory configurationFactory = new SW360ConnectionConfigurationFactory();
+        SW360ConnectionConfiguration sw360ConnectionConfiguration =
+                configurationFactory.createConfiguration(key -> getConfigValue(key, configMap),
+                        key -> getBooleanConfigValue(key, configMap),
+                        sw360ProxyHost, sw360ProxyPort);
 
         // General configuration
         final boolean updateReleases = getBooleanConfigValue(UPDATE_RELEASES, configMap);

--- a/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
+++ b/modules/sw360/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360Enricher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -16,6 +17,7 @@ import org.eclipse.sw360.antenna.api.workflow.AbstractProcessor;
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.sw360.SW360MetaDataReceiver;
 import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfiguration;
+import org.eclipse.sw360.antenna.sw360.workflow.SW360ConnectionConfigurationFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,9 +56,11 @@ public class SW360Enricher extends AbstractProcessor {
                     .toAbsolutePath();
         }
 
-        SW360ConnectionConfiguration sw360ConnectionConfiguration = new SW360ConnectionConfiguration(key -> getConfigValue(key, configMap),
-                key -> getBooleanConfigValue(key, configMap),
-                sw360ProxyHost, sw360ProxyPort);
+        SW360ConnectionConfigurationFactory configurationFactory = new SW360ConnectionConfigurationFactory();
+        SW360ConnectionConfiguration sw360ConnectionConfiguration =
+                configurationFactory.createConfiguration(key -> getConfigValue(key, configMap),
+                        key -> getBooleanConfigValue(key, configMap),
+                        sw360ProxyHost, sw360ProxyPort);
 
         connector = new SW360MetaDataReceiver(sw360ConnectionConfiguration);
     }

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ClientTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ClientTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest;
+
+import org.eclipse.sw360.antenna.sw360.utils.RestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.ContentRequestMatchers;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class SW360ClientTest {
+    private static final String TEST_URI = "https://test.server.org/v1/foo";
+    private static final String TEST_RESPONSE = "ok";
+    private static final String HEADER_NAME = "X-Test";
+    private static final String HEADER_VALUE = "success";
+
+    private static final ParameterizedTypeReference<String> TYPE_REFERENCE = new ParameterizedTypeReference<String>() {
+    };
+
+    private MockRestServiceServer mockServer;
+
+    private SW360Client client;
+
+    @Before
+    public void setUp() {
+        RestTemplate template = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(template);
+        client = new SW360Client(template) {
+            @Override
+            public String getEndpoint() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Returns a map with test headers to check whether headers are passed
+     * correctly.
+     *
+     * @return the test headers
+     */
+    private static HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HEADER_NAME, HEADER_VALUE);
+        return headers;
+    }
+
+    /**
+     * Checks a test response returned by the mock server.
+     *
+     * @param response the response to be checked
+     */
+    private static void checkTestResponse(ResponseEntity<String> response) {
+        assertThat(response.getStatusCodeValue()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getBody()).isEqualTo(TEST_RESPONSE);
+    }
+
+    @Test
+    public void testRestGET() {
+        mockServer.expect(requestTo(TEST_URI))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HEADER_NAME, HEADER_VALUE))
+                .andExpect(content().string(""))
+                .andRespond(withSuccess(TEST_RESPONSE, MediaType.TEXT_PLAIN));
+
+        ResponseEntity<String> response = client.doRestGET(TEST_URI, createHeaders(), TYPE_REFERENCE);
+        checkTestResponse(response);
+    }
+
+    @Test
+    public void testRestPOST() {
+        String content = "test POST content";
+        HttpEntity<String> entity = new HttpEntity<>(content, createHeaders());
+        mockServer.expect(requestTo(TEST_URI))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HEADER_NAME, HEADER_VALUE))
+                .andExpect(content().string(content))
+                .andRespond(withSuccess(TEST_RESPONSE, MediaType.TEXT_PLAIN));
+
+        ResponseEntity<String> response = client.doRestPOST(TEST_URI, entity, TYPE_REFERENCE);
+        checkTestResponse(response);
+    }
+
+    @Test
+    public void testRestPATCH() {
+        String content = "the PATCH content";
+        HttpEntity<String> entity = new HttpEntity<>(content, createHeaders());
+        mockServer.expect(requestTo(TEST_URI))
+                .andExpect(method(HttpMethod.PATCH))
+                .andExpect(header(HEADER_NAME, HEADER_VALUE))
+                .andExpect(content().string(content))
+                .andRespond(withSuccess(TEST_RESPONSE, MediaType.TEXT_PLAIN));
+
+        ResponseEntity<String> response = client.doRestPATCH(TEST_URI, entity, TYPE_REFERENCE);
+        checkTestResponse(response);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360ProjectClientTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,14 +16,12 @@ import com.github.cliftonlabs.json_simple.JsonArray;
 import com.github.cliftonlabs.json_simple.JsonObject;
 import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.rest.resource.projects.SW360ProjectType;
-import org.eclipse.sw360.antenna.util.ProxySettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
@@ -34,10 +33,14 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 public class SW360ProjectClientTest {
     private static final String REST_URL = "http://localhost:8080/resource/api";
@@ -71,7 +74,7 @@ public class SW360ProjectClientTest {
     private static final String PROJECT_VERSION_VALUE_2 = "2.5-RELEASE";
 
 
-    private SW360ProjectClient client = new SW360ProjectClient(REST_URL, ProxySettings.empty());
+    private SW360ProjectClient client;
 
     private MockRestServiceServer mockedServer;
 
@@ -79,7 +82,7 @@ public class SW360ProjectClientTest {
     public void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         mockedServer = MockRestServiceServer.createServer(restTemplate);
-        ReflectionTestUtils.setField(client, "restTemplate", restTemplate);
+        client = new SW360ProjectClient(REST_URL, restTemplate);
     }
 
 

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360RestTemplateFactoryTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/rest/SW360RestTemplateFactoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.BasicHttpContext;
+import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class SW360RestTemplateFactoryTest {
+    @Test
+    public void testClientBuilderIsCreated() {
+        SW360RestTemplateFactory factory = new SW360RestTemplateFactory();
+
+        assertThat(factory.newClientBuilder()).isNotNull();
+    }
+
+    /**
+     * Creates a test factory instance that is prepared to use the passed in
+     * builder for HTTP clients. This is used to test whether the HTTP client
+     * is correctly configured.
+     *
+     * @param builder the HTTP client builder
+     * @return the test factory
+     */
+    private static SW360RestTemplateFactory factoryWithClientBuilder(HttpClientBuilder builder) {
+        return new SW360RestTemplateFactory() {
+            @Override
+            HttpClientBuilder newClientBuilder() {
+                return builder;
+            }
+        };
+    }
+
+    @Test
+    public void testCreateHttpClientIfNoProxyIsUsed() {
+        ProxySettings settings = new ProxySettings(false, null, 0);
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        when(builder.build()).thenReturn(httpClient);
+        SW360RestTemplateFactory factory = factoryWithClientBuilder(builder);
+
+        assertThat(factory.createHttpClient(settings)).isEqualTo(httpClient);
+        verify(builder).build();
+        verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testCreateHttpClientWithProxyConfiguration() throws HttpException {
+        ProxySettings settings = new ProxySettings(true, "my.company.proxy", 3128);
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        when(builder.build()).thenReturn(httpClient);
+        when(builder.setRoutePlanner(any())).thenReturn(builder);
+        SW360RestTemplateFactory factory = factoryWithClientBuilder(builder);
+
+        assertThat(factory.createHttpClient(settings)).isEqualTo(httpClient);
+        ArgumentCaptor<HttpRoutePlanner> captor = ArgumentCaptor.forClass(HttpRoutePlanner.class);
+        verify(builder).setRoutePlanner(captor.capture());
+
+        HttpHost target = new HttpHost("www.eclipse.org", 443, "https");
+        HttpGet request = new HttpGet("/sw360antenna");
+        HttpRoute route = captor.getValue().determineRoute(target, request, new BasicHttpContext());
+        assertThat(route.getProxyHost().getHostName()).isEqualTo(settings.getProxyHost());
+        assertThat(route.getProxyHost().getPort()).isEqualTo(settings.getProxyPort());
+    }
+
+    @Test
+    public void testCreateRequestFactory() {
+        ProxySettings settings = new ProxySettings(true, "proxy.net", 8080);
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        SW360RestTemplateFactory factory = new SW360RestTemplateFactory() {
+            @Override
+            HttpClient createHttpClient(ProxySettings proxySettings) {
+                assertThat(proxySettings).isEqualTo(settings);
+                return client;
+            }
+        };
+
+        ClientHttpRequestFactory requestFactoryIfc = factory.createRequestFactory(settings);
+        assertThat(requestFactoryIfc).isInstanceOf(HttpComponentsClientHttpRequestFactory.class);
+        HttpComponentsClientHttpRequestFactory requestFactory =
+                (HttpComponentsClientHttpRequestFactory) requestFactoryIfc;
+        assertThat(requestFactory.getHttpClient()).isEqualTo(client);
+    }
+
+    @Test
+    public void testCreateRestTemplate() {
+        ProxySettings settings = new ProxySettings(true, "foo.bar", 1234);
+        ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
+        SW360RestTemplateFactory factory = new SW360RestTemplateFactory() {
+            @Override
+            ClientHttpRequestFactory createRequestFactory(ProxySettings proxySettings) {
+                assertThat(proxySettings).isEqualTo(settings);
+                return requestFactory;
+            }
+        };
+
+        RestTemplate restTemplate = factory.createRestTemplate(settings);
+        assertThat(restTemplate.getRequestFactory()).isEqualTo(requestFactory);
+    }
+}

--- a/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactoryTest.java
+++ b/modules/sw360/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/SW360ConnectionConfigurationFactoryTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.workflow;
+
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ComponentClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360LicenseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ProjectClientAdapter;
+import org.eclipse.sw360.antenna.sw360.adapter.SW360ReleaseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.rest.SW360AuthenticationClient;
+import org.eclipse.sw360.antenna.sw360.rest.SW360Client;
+import org.eclipse.sw360.antenna.sw360.rest.SW360RestTemplateFactory;
+import org.eclipse.sw360.antenna.util.ProxySettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SW360ConnectionConfigurationFactoryTest {
+    private static final String REST_URL = "https://www.sw360.org/api";
+    private static final String AUTH_URL = "https://auth.sw360.org/token";
+    private static final String USER = "scott";
+    private static final String PASSWORD = "tiger";
+    private static final String CLIENT_ID = "oauth_client";
+    private static final String CLIENT_SECRET = "oauth_client_secret";
+    private static final String PROXY_HOST = "my.proxy.org";
+    private static final int PROXY_PORT = 8888;
+
+    /**
+     * Mock for the Rest template.
+     */
+    private RestTemplate template;
+
+    @Before
+    public void setUp() {
+        template = mock(RestTemplate.class);
+    }
+
+    /**
+     * Returns an object allowing access to string-based test configuration
+     * properties.
+     *
+     * @return the accessor for properties
+     */
+    private static SW360ConnectionConfigurationFactory.Getter<String> stringConfigGetter() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SW360ConnectionConfiguration.REST_SERVER_URL_KEY, REST_URL);
+        props.put(SW360ConnectionConfiguration.AUTH_SERVER_URL_KEY, AUTH_URL);
+        props.put(SW360ConnectionConfiguration.USERNAME_KEY, USER);
+        props.put(SW360ConnectionConfiguration.PASSWORD_KEY, PASSWORD);
+        props.put(SW360ConnectionConfiguration.CLIENT_USER_KEY, CLIENT_ID);
+        props.put(SW360ConnectionConfiguration.CLIENT_PASSWORD_KEY, CLIENT_SECRET);
+
+        return props::get;
+    }
+
+    /**
+     * Returns an object allowing access to boolean test configuration
+     * properties. The only boolean property that is supported is the flag
+     * whether a proxy should be used.
+     *
+     * @param useProxy the proxy flag
+     * @return the accessor for boolean properties
+     */
+    private static SW360ConnectionConfigurationFactory.Getter<Boolean> booleanConfigGetter(boolean useProxy) {
+        return key -> {
+            if (!SW360ConnectionConfiguration.PROXY_USE.equals(key)) {
+                fail("Unsupported boolean property: " + key);
+            }
+            return useProxy;
+        };
+    }
+
+    /**
+     * Checks whether the given client object has been correctly initialized.
+     *
+     * @param client  the client to be checked
+     * @param baseUri the expected base URI for this client
+     */
+    private void checkClient(SW360Client client, String baseUri) {
+        assertThat(client).isNotNull();
+        assertThat(client.getEndpoint()).startsWith(baseUri);
+        Object restTemplate = ReflectionTestUtils.getField(client, "restTemplate");
+        assertThat(restTemplate).isEqualTo(template);
+    }
+
+    /**
+     * Checks whether the given SW360 adapter object has been correctly
+     * initialized. This is done by checking the wrapped client object.
+     *
+     * @param adapter     the adapter to be checked
+     * @param clientField the name of the field containing the client
+     */
+    private void checkAdapter(Object adapter, String clientField) {
+        SW360Client client = (SW360Client) ReflectionTestUtils.getField(adapter, clientField);
+        checkClient(client, SW360ConnectionConfigurationFactoryTest.REST_URL);
+    }
+
+    /**
+     * Creates a configuration instance with test settings and the given flag
+     * for proxy usage.
+     *
+     * @param useProxy the use proxy flag
+     * @return the test configuration
+     */
+    private SW360ConnectionConfiguration createConfiguration(boolean useProxy) {
+        ProxySettings settings = new ProxySettings(useProxy, PROXY_HOST, PROXY_PORT);
+        SW360RestTemplateFactory restFactory = mock(SW360RestTemplateFactory.class);
+        when(restFactory.createRestTemplate(settings)).thenReturn(template);
+
+        SW360ConnectionConfigurationFactory factory = new SW360ConnectionConfigurationFactory(restFactory);
+        return factory.createConfiguration(stringConfigGetter(), booleanConfigGetter(useProxy),
+                PROXY_HOST, PROXY_PORT);
+    }
+
+    @Test
+    public void testDefaultRestTemplateFactoryIsCreated() {
+        SW360ConnectionConfigurationFactory factory = new SW360ConnectionConfigurationFactory();
+
+        assertThat(factory.getRestTemplateFactory()).isNotNull();
+    }
+
+    @Test
+    public void testAuthenticationClientFromConfiguration() {
+        SW360ConnectionConfiguration configuration = createConfiguration(false);
+
+        checkClient(configuration.getSW360AuthenticationClient(), AUTH_URL);
+    }
+
+    @Test
+    public void testProxySettingsAreEvaluated() {
+        SW360ConnectionConfiguration configuration = createConfiguration(true);
+
+        checkClient(configuration.getSW360AuthenticationClient(), AUTH_URL);
+    }
+
+    @Test
+    public void testComponentClientAdapter() {
+        SW360ConnectionConfiguration configuration = createConfiguration(false);
+
+        checkAdapter(configuration.getSW360ComponentClientAdapter(), "componentClient");
+    }
+
+    @Test
+    public void testReleaseClientAdapter() {
+        SW360ConnectionConfiguration configuration = createConfiguration(false);
+
+        checkAdapter(configuration.getSW360ReleaseClientAdapter(), "releaseClient");
+    }
+
+    @Test
+    public void testLicenseClientAdapter() {
+        SW360ConnectionConfiguration configuration = createConfiguration(false);
+
+        checkAdapter(configuration.getSW360LicenseClientAdapter(), "licenseClient");
+    }
+
+    @Test
+    public void testProjectClientAdapter() {
+        SW360ConnectionConfiguration configuration = createConfiguration(false);
+
+        checkAdapter(configuration.getSW360ProjectClientAdapter(), "projectClient");
+    }
+
+    @Test
+    public void testAuthenticationHeaders() {
+        SW360AuthenticationClient authenticationClient = mock(SW360AuthenticationClient.class);
+        HttpHeaders headers = mock(HttpHeaders.class);
+        String token = "<theAccessTokenForSW360>";
+        when(authenticationClient.getOAuth2AccessToken(USER, PASSWORD, CLIENT_ID, CLIENT_SECRET))
+                .thenReturn(token);
+        when(authenticationClient.getHeadersWithBearerToken(token)).thenReturn(headers);
+        SW360ConnectionConfiguration configuration = new SW360ConnectionConfiguration(authenticationClient,
+                mock(SW360ComponentClientAdapter.class), mock(SW360ReleaseClientAdapter.class),
+                mock(SW360LicenseClientAdapter.class), mock(SW360ProjectClientAdapter.class),
+                USER, PASSWORD, CLIENT_ID, CLIENT_SECRET);
+
+        assertThat(configuration.getHttpHeaders()).isEqualTo(headers);
+    }
+}

--- a/modules/sw360/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/modules/sw360/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR fixes issue #397, the missing support of the HTTP PATCH method in SW360 clients when a proxy server is configured. It also refactors the usage of Spring rest templates that are used for sending HTTP requests to SW360. This affects multiple classes; therefore this PR is a bit larger.

All communication with SW360 is done via the SW360Client class or a class derived from this base class. This class executes HTTP requests via Spring's RestTemplate mechanism. In the original implementation, SW360Client created a RestTemplate for each instance and configured it with a ClientHttpRequestFactory depending on the proxy configuration: if a proxy was used, a SimpleClientHttpRequestFactory was set, which could be passed the proxy configuration to be used; otherwise, no special ClientHttpRequestFactory was set.

Unfortunately, the simple request factory does not support PATCH requests, which are needed for some SW360 update operations. Therefore, there was a special treatment of this method that created a new RestTemplate per call and configured it with a HttpComponentsClientHttpRequestFactory. This request factory can deal with PATCH request, but its proxy configuration was obviously not known to the original author; so in case that a proxy is used, the code just throws an exception.

The solution implemented by this PR is to always use an HttpComponentsClientHttpRequestFactory that is properly configured to work with or without a proxy. Such a factory is, however, more complex and expensive to create, as it is associated with an HttpClient object. Constructing a factory for every SW360 client would be a waste of resources. It is also not needed because all the objects involved (rest templates, HTTP clients, request factories, and even the SW360 clients) are thread-safe and can safely be shared between multiple components. Therefore, this PR contains a major rework of the way these objects are handled: there is only a single, correctly configured RestTemplate that is used by all SW360 client instances. In addition, the different clients are created once initially and then reused for all requests. (Previously, they have been re-created on a per-request basis.)

The changes related to this goal are mainly located in the SW360ConnectionConfiguration class. Here the SW360 client objects used to be created and initialized. The class has been simplified to merely hold the different client objects and provide access to them. An instance is now created via the new SW360ConnectionConfigurationFactory class, which does all the one-time initializations; it produces a configuration object with all SW360 client objects ready to use.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch @neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
bug fix (and partly improvements)

### How Has This Been Tested?
The test coverage in this module is pretty low in general. New tests were added where code was modified or extended. Especially, test classes have been created for SW360Client and ProxySettings that were missing originally.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
