### PR TITLE
Replace Maven Default Repo Url to use better Repo

### DIFF
--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/HttpRequester.java
@@ -31,7 +31,7 @@ public class HttpRequester extends IArtifactRequester {
     private static final String GROUP_ID_PLACEHOLDER = "{groupId}";
     private static final String ARTIFACT_ID_PLACEHOLDER = "{artifactId}";
     private static final String VERSION_PLACEHOLDER = "{version}";
-    private static final String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/" + GROUP_ID_PLACEHOLDER + "/" + ARTIFACT_ID_PLACEHOLDER + "/" + VERSION_PLACEHOLDER + "/";
+    private static final String MAVEN_CENTRAL_URL = "https://repo.maven.apache.org/maven2/" + GROUP_ID_PLACEHOLDER + "/" + ARTIFACT_ID_PLACEHOLDER + "/" + VERSION_PLACEHOLDER + "/";
 
     private HttpHelper httpHelper;
     private Optional<URL> sourceRepositoryUrl;


### PR DESCRIPTION
This is the default repo url used by the mvn cli. The previous one
doesn't contain a lot of dependencies.

According to this documentation page [last published state: 2020-02-13]
https://maven.apache.org/guides/mini/guide-mirror-settings.html
This is the default repo.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@bs-ondem 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix
