### PR TITLE
Oheger bosch/ort/#428 failing test case

### DIFF
--- a/modules/ort/pom.xml
+++ b/modules/ort/pom.xml
@@ -85,8 +85,6 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
+++ b/modules/ort/src/test/java/org/eclipse/sw360/antenna/ort/workflow/analyzers/OrtResultAnalyzerTest.java
@@ -96,7 +96,7 @@ public class OrtResultAnalyzerTest {
                 .map(artifact -> artifact.askFor(ArtifactVcsInfo.class))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .anyMatch(o -> "https://github.com/babel/babel/tree/master/packages/babel-generator"
+                .anyMatch(o -> "https://github.com/babel/babel.git"
                         .equals(o.getVcsInfo().getUrl())))
                 .isTrue();
 


### PR DESCRIPTION
This PR fixes a problem with the pom file of the ort module and a failing test case in this module (which was not detected before because of this problem).

Issue #428 

Due to an incorrect configuration in the build section of the pom test classes written in Java are not compiled, and the tests are therefore not executed. This PR makes sure that classes under ./src/test/java are correctly compiled. After that, the test case OrtResultAnalyzerTest.testParseOrtDataWithScanResultsToArtifacts() is failing because it expects a wrong VCS URI. This has been fixed as well.

### Request Reviewer
@blaumeiser-at-bosch @neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
CI

### How Has This Been Tested?
Actually, the problem was affecting tests. The detection of the failing test case is prove that tests are now executed correctly. After fixing the test case, the build is successful again.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
