### PR TITLE
improve license header tests

### DIFF
--- a/.ci-scripts/test-for-licenseHeaders.sh
+++ b/.ci-scripts/test-for-licenseHeaders.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) Bosch Software Innovations GmbH 2018.
+# Copyright (c) Bosch.IO GmbH 2020.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -36,6 +37,9 @@ testFile() {
     if ! head -15 $file | grep -q 'Copyright (c)'; then
         echo "ERROR: No copyright remark found in $file"
         failure=true
+    elif ! head -15 $file | grep -q "^.*Copyright (c) .* $(date +%Y).*$"; then
+        echo "ERROR: The year of your copyright remark is not correct in $file"
+        failure=true
     fi
     if ! head -15 $file | grep -q 'SPDX-License-Identifier:'; then
         echo "ERROR: no 'SPDX-License-Identifier' in $file"
@@ -55,7 +59,7 @@ getFiles() {
     if [ "$noGit" = true ]; then
         find . -type f -print
     else
-        git ls-files
+        git diff --name-only `git rev-parse --abbrev-ref HEAD` origin/master
     fi |
         grep -Ev '^./.git' |
         grep -Ev 'META-INF/services' |


### PR DESCRIPTION
This PR only improves the `.ci-scripts/test-for-licenseHeaders.sh` script. Before this improvement it listed all files indexed in the repository with `git ls-files`, but now only modified files are checked.

### Request Reviewer
@blaumeiser-at-bosch 


### Type of Change
*CI*