### PR TITLE
Fix license check to handle deleted files properly

### DIFF
--- a/.ci-scripts/test-for-licenseHeaders.sh
+++ b/.ci-scripts/test-for-licenseHeaders.sh
@@ -29,8 +29,7 @@ testFile() {
     local file="$1"
 
     if [[ ! -f "$file" ]]; then
-        echo "FAIL: the file=[$file] could not be found"
-        failure=true
+        echo "INFO: the file=[$file] has been deleted"
         return
     fi
 


### PR DESCRIPTION
Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch.io>

Fixes the issue that deleted files are now in the list of changed files in the license header test. Deleted files are therefore an acceptable issue which must not fail the test. This has been adapted from the previous result of a failed scan.

### Request Reviewer
@neubs-bsi 

### Type of Change
*bug fix*:  

### How Has This Been Tested?
PR build is green

### Checklist
Must:
- [x] All related issues are referenced in commit messages
