### PR TITLE
Only specify the "compile" scope where needed

### DIFF
--- a/assembly/compliance-tool/pom.xml
+++ b/assembly/compliance-tool/pom.xml
@@ -89,7 +89,6 @@
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>core-workflow-steps</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/core/core-workflow-steps/pom.xml
+++ b/core/core-workflow-steps/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/core/frontend-stubs-testing/pom.xml
+++ b/core/frontend-stubs-testing/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -69,6 +70,12 @@
     </build>
 
     <dependencies>
+        <!--
+            Explicitly declare the scope for compile dependencies! As this is a module that contains code to be used by
+            tests, dependencies that usually are typical test scope dependencies, like JUnit, must be compile
+            dependencies in the context of this module. To avoid any scope being inherited from the parent POM, always
+            be explicit here.
+        -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>model</artifactId>
@@ -154,6 +161,7 @@
             <artifactId>spdx-utils</artifactId>
             <scope>compile</scope>
         </dependency>
+
         <!-- ################################ compliance dependency ########################### -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>

--- a/core/frontend-stubs/gradle-frontend-stub/pom.xml
+++ b/core/frontend-stubs/gradle-frontend-stub/pom.xml
@@ -1,5 +1,6 @@
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -30,7 +31,6 @@
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>cli-frontend-stub</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.gradle</groupId>

--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -44,7 +44,6 @@
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>maven-module</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
@@ -177,7 +176,6 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/core/model-testing/pom.xml
+++ b/core/model-testing/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -42,14 +43,22 @@
     </build>
 
     <dependencies>
+        <!--
+            Explicitly declare the scope for compile dependencies! As this is a module that contains code to be used by
+            tests, dependencies that usually are typical test scope dependencies, like JUnit, must be compile
+            dependencies in the context of this module. To avoid any scope being inherited from the parent POM, always
+            be explicit here.
+        -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>model</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -61,11 +70,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+
         <!-- ################################ compliance dependency ########################### -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -26,22 +26,18 @@
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -70,7 +71,6 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.heremaps.oss-review-toolkit</groupId>

--- a/modules/maven/pom.xml
+++ b/modules/maven/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -55,7 +54,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>compile</scope>
         </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>

--- a/modules/policy/engine-testing/pom.xml
+++ b/modules/policy/engine-testing/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2019.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
@@ -21,30 +22,41 @@
     <name>policy-engine-testing</name>
 
     <dependencies>
+        <!--
+            Explicitly declare the scope for compile dependencies! As this is a module that contains code to be used by
+            tests, dependencies that usually are typical test scope dependencies, like JUnit, must be compile
+            dependencies in the context of this module. To avoid any scope being inherited from the parent POM, always
+            be explicit here.
+        -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>model</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>policy-engine</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
             <version>4.2.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <version>4.2.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-picocontainer</artifactId>
             <version>4.2.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -62,7 +74,9 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.11</version>
+            <scope>compile</scope>
         </dependency>
+
         <!-- ################################ compliance dependency ########################### -->
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>

--- a/modules/simple-validators/pom.xml
+++ b/modules/simple-validators/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>compile</scope>
         </dependency>
         <!-- ################################ testing dependencies ################################ -->
         <dependency>

--- a/modules/sw360/sw360-workflow/pom.xml
+++ b/modules/sw360/sw360-workflow/pom.xml
@@ -35,13 +35,11 @@
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>sw360-client</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION
To align with the majority of places where the default scope is not
explicitly specified.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>