### PR TITLE
Remove remaining references to P2 functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ The Antenna project consists of a core and multiple modules in `./modules`, whic
 
 Some of these folders contain their own `README.md`, like e.g. `./modules/sw360/README.md` which contain module specific information.
 
-#### Optional Modules
-Most of the modules are activated and used by default, but the p2-resolver in `./modules/p2/p2-resolver/`, which resolves OSGi sources via P2 repositories, is excluded from the build (since it complicates the build and is unnecessary in most cases).
-To enable it, one can call the corresponding prepare script `./modules/p2/prepareDependenciesForP2.sh` (without Bash support one has to follow the steps in the script by hand).
-To remove the P2 dependencies again you can use the script `./modules/p2/cleanupDependenciesForP2.sh`.
-
-
 ### Install and build Antenna
 
 Please note that some dependencies of SW360antenna are only available for Java 8. So you need to use Java 8 to build the project.

--- a/antenna-documentation/src/site/markdown/dev-guide.md.vm
+++ b/antenna-documentation/src/site/markdown/dev-guide.md.vm
@@ -52,27 +52,11 @@ If your machine is located behind a proxy keep in mind to configure your proxy s
 
 #[[##]]# How to build
 
-If you don't want to build the p2 parts of antenna, just use
+Just use
 ```
 mvn clean install
 ```
 on the command line.
-
-If you do want to build the p2 parts and ship them with antenna, use
-```
-cd antenna-p2/dependencies
-mvn clean package
-cd ..
-mvn clean package
-cd ..
-mvn clean install
-```
-
-This
-
-- downloads the dependencies for p2 (in `antenna-p2/dependencies`)
-- builds the p2 products (in `antenna-p2`)
-- builds ${docNameCap} activating the profile for building p2
 
 To run the application you can have a look into the example project, which shows in its pom xml how to properly configure the antenna-maven-frontend.
 

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriterImpl.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/SourceZipWriterImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -111,8 +112,7 @@ public class SourceZipWriterImpl {
     }
 
     /**
-     * Adds the content of the source zip with the specified sourceTypes. If an
-     * mvn source exists it will be added, otherwise, p2 source will be added
+     * Adds the content of the source zip with the specified sourceTypes.
      *
      * @param artifact Artifact of which the content shall be added.
      * @param zipOut   ZipOutputStream for the ZipFile.

--- a/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolverImpl.java
+++ b/modules/maven/src/main/java/org/eclipse/sw360/antenna/maven/workflow/processors/enricher/MavenArtifactResolverImpl.java
@@ -142,7 +142,7 @@ public class MavenArtifactResolverImpl {
         }
 
         if (!artifact.getSourceFile().isPresent() && !artifact.getFile().isPresent()) {
-            processingReporter.add(artifact, MessageType.MISSING_SOURCES, "Maven Artifact Coordinates present but non resolvable sources (maybe sources are available using P2).");
+            processingReporter.add(artifact, MessageType.MISSING_SOURCES, "Maven Artifact Coordinates present but non resolvable sources.");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <!-- >This is the main version applied throughout the project. Change this to increase all versions<-->
         <revision>1.0.0</revision>
-        <!-- >The qualifier can be set to any value and will set the corresponding qualifier in all projects except antenna-p2<-->
+        <!-- >The qualifier can be set to any value and will set the corresponding qualifier in all projects<-->
         <qualifier>-SNAPSHOT</qualifier>
         <gradle.version>4.1</gradle.version>
         <jackson.version>2.10.0</jackson.version>
@@ -692,11 +692,6 @@
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>0.8.4</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*p2.app.*</exclude>
-                            </excludes>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) Bosch Software Innovations GmbH 2019.
+# Copyright (c) Bosch.IO GmbH 2020.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -30,18 +31,6 @@ if [[ "$1" == "--custom-repository" ]]; then
     export M2_REPOSITORY="/tmp/run_all_tests.repository"
     mkdir -p $M2_REPOSITORY
     export MAVEN_OPTS="-Dmaven.repo.local=$M2_REPOSITORY"
-fi
-
-WITH_P2="false"
-if [[ "$1" == "--p2" ]]; then
-    shift
-    WITH_P2="true"
-    runWithScope "prepare p2 dependencies"  \
-        modules/p2/prepareDependenciesForP2.sh
-elif [[ "$1" == "--no-p2" ]]; then
-    shift
-    runWithScope "cleanup p2 dependencies"  \
-        modules/p2/cleanupDependenciesForP2.sh
 fi
 
 runWithScope "mvn install"  \


### PR DESCRIPTION
P2 functionality was removed in e3316f7.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
