### PR TITLE
Upgrade Kotlin to version 1.3.70

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <qualifier>-SNAPSHOT</qualifier>
         <gradle.version>4.1</gradle.version>
         <jackson.version>2.10.0</jackson.version>
-        <kotlin.version>1.3.50</kotlin.version>
+        <kotlin.version>1.3.70</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <jackson.databind.version>2.10.0</jackson.databind.version>


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
