### PR TITLE
pom: Reintroduce the output directory for the flatten plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,6 +560,7 @@
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This was removed in f594bd4, but reintroduce it in order to put all
generated ".flattened-pom.xml" files into a directory that is already
ignored in Git.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
