### PR TITLE
Remove Spring references from POMs

### DIFF
--- a/assembly/gradle-plugin/pom.xml
+++ b/assembly/gradle-plugin/pom.xml
@@ -8,9 +8,6 @@
   ~ http://www.eclipse.org/legal/epl-v20.html
   ~
   ~ SPDX-License-Identifier: EPL-2.0
-  ~
-  ~ based on code from [1] licensed under Apache 2.0
-  ~ https://github.com/spring-projects/spring-boot/commit/9b15e6b5a3c0fc18372f532063bb43f25abcf984
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/core/frontend-stubs/gradle-frontend-stub/pom.xml
+++ b/core/frontend-stubs/gradle-frontend-stub/pom.xml
@@ -66,11 +66,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>Spring Plugins Repository</id>
-            <url>http://repo.spring.io/plugins-release/</url>
-        </repository>
-    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <wiremock.version>2.26.0</wiremock.version>
         <slf4j.version>1.7.26</slf4j.version>
         <log4j2.version>2.13.0</log4j2.version>
-        <spring.version>5.1.2.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ort.rev>3f85d301f7</ort.rev>
     </properties>
@@ -368,16 +367,8 @@
             </snapshots>
         </repository>
         <repository>
-            <id>spring.io</id>
-            <url>https://repo.spring.io/plugins-release/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-                <updatePolicy>never</updatePolicy>
-            </snapshots>
+            <id>Gradle Releases</id>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
The last dependency on Spring was removed in 8890038.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
