### PR TITLE
Fix tests with windows path problems

### DIFF
--- a/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendDebugLogTest.java
+++ b/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendDebugLogTest.java
@@ -218,9 +218,9 @@ public class AntennaCLIFrontendDebugLogTest {
 
     @Test
     public void testNonExistingConfigFileIsHandled() throws UnsupportedEncodingException {
-        String nonExistingPath = "/non/existing/config.xml";
-        String output = runAntennaAndExpectFailure(nonExistingPath);
+        Path nonExistingPath = Paths.get("non", "existing", "config.xml");
+        String output = runAntennaAndExpectFailure(nonExistingPath.toString());
 
-        assertThat(output).contains(Arrays.asList("Cannot find ", nonExistingPath));
+        assertThat(output).contains(Arrays.asList("Cannot find ", nonExistingPath.toString()));
     }
 }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/main/AntennaComplianceToolTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/main/AntennaComplianceToolTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -36,8 +37,8 @@ public class AntennaComplianceToolTest {
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
-    public void testMainInitWithExporter() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
-        Path propertiesFile = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-exporter.properties")).getFile());
+    public void testMainInitWithExporter() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException, URISyntaxException {
+        Path propertiesFile = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-exporter.properties")).toURI());
 
         Object[] obj = {new SW360Exporter(), propertiesFile};
         Class<?>[] params = new Class[obj.length];
@@ -63,8 +64,8 @@ public class AntennaComplianceToolTest {
     }
 
     @Test
-    public void testMainInitWithUpdater() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
-        Path propertiesFile = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).getFile());
+    public void testMainInitWithUpdater() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException, URISyntaxException {
+        Path propertiesFile = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).toURI());
 
         Object[] obj = {new SW360Updater(), propertiesFile};
         Class<?>[] params = new Class[obj.length];

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -115,7 +116,7 @@ public class SW360ExporterTest {
     SW360Connection connectionMock = mock(SW360Connection.class);
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, URISyntaxException {
         SW360SparseComponent sparseComponent = SW360TestUtils.mkSW360SparseComponent("testComponent");
         when(componentClientAdapterMock.getComponents())
                 .thenReturn(Collections.singletonList(sparseComponent));
@@ -135,7 +136,7 @@ public class SW360ExporterTest {
 
         when(releaseClientAdapterMock.getReleaseById(any()))
                 .thenReturn(Optional.of(release), Optional.of(release2));
-        Path path = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("test-source.txt")).getPath());
+        Path path = Paths.get(Objects.requireNonNull(this.getClass().getClassLoader().getResource("test-source.txt")).toURI());
         when(releaseClientAdapterMock.downloadAttachment(any(), any(), any()))
                 .thenReturn(Optional.of(path));
 

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/analyzers/CsvAnalyzerTest.java
@@ -115,8 +115,8 @@ public class CsvAnalyzerTest extends AntennaTestWithMockedContext {
 
          assertThat(artifactSourceFile.isPresent()).isTrue();
          assertThat(artifactSourceFile.get().get().toFile()).exists();
-         assertThat(artifactSourceFile.get().get().toAbsolutePath().toString()).
-                 isEqualTo(this.getClass().getClassLoader().getResource("CsvAnalyzerTest/test_source.txt").getPath());
+         assertThat(artifactSourceFile.get().get().toAbsolutePath()).
+                 isEqualTo(Paths.get(this.getClass().getClassLoader().getResource("CsvAnalyzerTest/test_source.txt").toURI()));
      }
 
      @Test


### PR DESCRIPTION
Currently, the build does not run through under Windows because of Path problems, these fixes clean up the usage of paths, so that os does not make a difference.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch.io>

### Request Reviewer
@bs-ondem 
@neubs-bsi 

### Type of Change

*bug fix*:  

### How Has This Been Tested?
Run builds

### Checklist
Must:
- [x] All related issues are referenced in commit messages
