### PR TITLE
Remove maven-compiler-plugin tags that should be inherited from the parent

### DIFF
--- a/antenna-documentation/pom.xml
+++ b/antenna-documentation/pom.xml
@@ -207,7 +207,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>site-tests</id>

--- a/assembly/compliance-tool/pom.xml
+++ b/assembly/compliance-tool/pom.xml
@@ -29,10 +29,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/modules/ort/pom.xml
+++ b/modules/ort/pom.xml
@@ -117,7 +117,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>