### PR TITLE
POM: Remove the duplicate declaration of equalsverifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,12 +346,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>nl.jqno.equalsverifier</groupId>
-                <artifactId>equalsverifier</artifactId>
-                <version>3.1.12</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.gradle</groupId>
                 <artifactId>gradle-process-services</artifactId>
                 <version>${gradle.version}</version>


### PR DESCRIPTION
This is already declared starting at line 312.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
