### PR TITLE
Improvements on the license model implementation

### DIFF
--- a/.ci-scripts/Vagrantfile
+++ b/.ci-scripts/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 # Copyright (c) Bosch Software Innovations GmbH 2019.
+# Copyright (c) Bosch.IO GmbH 2020.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -35,7 +36,7 @@ Vagrant.configure("2") do |config|
     v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     v.customize ["modifyvm", :id, "--memory", "4096"]
     v.customize ["modifyvm", :id, "--cpus", "2"]
-    v.name = "tinaBox"
+    v.name = "antennaBox"
   end
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverImpl.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverImpl.java
@@ -105,16 +105,16 @@ public class LicenseKnowledgeBaseResolverImpl {
     private void setThreatGroup(License license) {
         Optional<String> threatGroupOfLicense = license.getThreatGroup();
         if (!threatGroupOfLicense.isPresent() || threatGroupOfLicense.get().isEmpty()) {
-            String threatGroupOfKb = this.knowledgeBase.getThreatGroupForId(license.getId());
-            license.setThreatGroup(threatGroupOfKb);
+            Optional.ofNullable(this.knowledgeBase.getThreatGroupForId(license.getId()))
+                    .ifPresent(license::setThreatGroup);
         }
     }
 
     private void setClassification(License license) {
         Optional<String> classificationOfLicense = license.getClassification();
         if (!classificationOfLicense.isPresent() || classificationOfLicense.get().isEmpty()) {
-            String classificationOfKb = this.knowledgeBase.getClassificationById(license.getId());
-            license.setClassification(classificationOfKb);
+            Optional.ofNullable(this.knowledgeBase.getClassificationById(license.getId()))
+                    .ifPresent(license::setClassification);
         }
     }
 }

--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverImpl.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverImpl.java
@@ -46,7 +46,7 @@ public class LicenseKnowledgeBaseResolverImpl {
                 .flatMap(List::stream)
                 .map(ArtifactLicenseInformation::get)
                 .map(LicenseInformation::getLicenses)
-                .flatMap(List::stream)
+                .flatMap(Collection::stream)
                 .forEach(license -> {
                     aliasToIdentifier(license);
                     setText(license);

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverTest.java
@@ -181,8 +181,8 @@ public class LicenseKnowledgeBaseResolverTest extends AntennaTestWithMockedConte
         assertThat(finalLicenses.stream()
                 .findAny()).hasValueSatisfying(l -> {
                     assertThat(l.getId()).isEqualTo(licenseName);
-                    assertThat(l.getCommonName()).isNull();
-                    assertThat(l.getText()).isNull();
+                    assertThat(l.getCommonName()).isBlank();
+                    assertThat(l.getText()).isBlank();
                     assertThat(l.getThreatGroup()).isNotPresent();
                     assertThat(l.getClassification()).isNotPresent();
         });

--- a/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverTest.java
+++ b/core/core-workflow-steps/src/test/java/org/eclipse/sw360/antenna/workflow/processors/LicenseKnowledgeBaseResolverTest.java
@@ -124,7 +124,7 @@ public class LicenseKnowledgeBaseResolverTest extends AntennaTestWithMockedConte
 
         knowledgeBaseResolver.process(Collections.singletonList(artifact));
 
-        final List<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
+        final Collection<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
         assertThat(finalLicenses.size()).isEqualTo(1);
         assertThat(finalLicenses.stream()
                 .findAny())
@@ -152,7 +152,7 @@ public class LicenseKnowledgeBaseResolverTest extends AntennaTestWithMockedConte
         knowledgeBaseResolver.process(Collections.singletonList(artifact));
 
 
-        final List<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
+        final Collection<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
         assertThat(finalLicenses.size()).isEqualTo(1);
         assertThat(finalLicenses.stream()
                 .findAny())
@@ -176,7 +176,7 @@ public class LicenseKnowledgeBaseResolverTest extends AntennaTestWithMockedConte
 
         knowledgeBaseResolver.process(Collections.singletonList(artifact));
 
-        final List<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
+        final Collection<License> finalLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
         assertThat(finalLicenses.size()).isEqualTo(1);
         assertThat(finalLicenses.stream()
                 .findAny()).hasValueSatisfying(l -> {

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/FromXmlLicenseInformationBuilder.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/FromXmlLicenseInformationBuilder.java
@@ -17,6 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Helper class for creation of license objects out of config xml statements, not for normal use outside
+ * of config parsing.
+ */
 public class FromXmlLicenseInformationBuilder {
     public interface ILicenseInformationBuilder {
         LicenseInformation build();

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/FromXmlLicenseInformationBuilder.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/FromXmlLicenseInformationBuilder.java
@@ -114,7 +114,7 @@ public class FromXmlLicenseInformationBuilder {
 
         @Override
         public LicenseInformation build() {
-            return new WithLicense((License) license.build(), (License) exception.build());
+            return new WithLicense(license.id, license.commonName, license.text, exception.id, exception.commonName, exception.text);
         }
     }
 }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -68,11 +68,14 @@ public class License implements LicenseInformation {
         if (properties == null) {
             return new HashMap<>();
         }
-        return properties;
+        return Collections.unmodifiableMap(properties);
     }
 
     public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
+        this.properties = new HashMap<>();
+        if (properties != null) {
+            this.properties.putAll(properties);
+        }
     }
 
     public void setProperty(String key, String property) {

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -22,22 +22,25 @@ public class License implements LicenseInformation {
     private Map<String, String> properties;
 
     public License() {
-        properties = new HashMap<>();
+        this(null, null, null, null);
     }
 
     public License(String id) {
-        this(id, "", "", new HashMap<>());
+        this(id, null, null, null);
     }
 
     public License(String id, String commonName, String text) {
-        this(id, commonName, text, new HashMap<>());
+        this(id, commonName, text, null);
     }
 
     public License(String id, String commonName, String text, Map<String, String> properties) {
-        this.id = id;
-        this.commonName = commonName;
-        this.text = text;
-        this.properties = properties;
+        this.id = id != null ? id : "";
+        this.commonName = commonName != null ? commonName : "";
+        this.text = text != null ? text : "";
+        this.properties = new HashMap<>();
+        if (properties != null) {
+            this.properties.putAll(properties);
+        }
     }
 
     public String getId() {
@@ -45,7 +48,7 @@ public class License implements LicenseInformation {
     }
 
     public void setId(String id) {
-        this.id = id;
+        this.id = id != null ? id : "";
     }
 
     public String getCommonName() {
@@ -53,7 +56,7 @@ public class License implements LicenseInformation {
     }
 
     public void setCommonName(String commonName) {
-        this.commonName = commonName;
+        this.commonName = commonName != null ? commonName : "";
     }
 
     public String getText() {
@@ -61,13 +64,10 @@ public class License implements LicenseInformation {
     }
 
     public void setText(String text) {
-        this.text = text;
+        this.text = text != null ? text : "";
     }
 
     public Map<String, String> getProperties() {
-        if (properties == null) {
-            return new HashMap<>();
-        }
         return Collections.unmodifiableMap(properties);
     }
 
@@ -79,11 +79,13 @@ public class License implements LicenseInformation {
     }
 
     public void setProperty(String key, String property) {
-        properties.put(key, property);
+        if (key != null) {
+            properties.put(key, property);
+        }
     }
 
     public Optional<String> getProperty(String key) {
-        return Optional.ofNullable(properties.get(key));
+        return Optional.ofNullable(key != null ? properties.get(key) : null);
     }
 
     public void setThreatGroup(String value) {
@@ -109,7 +111,7 @@ public class License implements LicenseInformation {
 
     @Override
     public boolean isEmpty() {
-        return this.id == null;
+        return "".equals(this.id.trim());
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -12,6 +12,17 @@ package org.eclipse.sw360.antenna.model.license;
 
 import java.util.*;
 
+/**
+ * This class reflects a single Open Source License. A license comprises of a id, which is a SPDX identifier in the
+ * normal case or something that could become an identifier for unknown licenses, a name which is a more user friendly
+ * name of the license, e.g., for the id 'Apache-2.0', the name could be 'Apache License Version 2.0'. The class also
+ * stores the text and some internal properties that can be used by an organization to process licenses in their
+ * Open Source Management Process. Two properties have been predefined, a 'threat group', that can be used, e.g.,
+ * to store information whether the license is permissive or has a copyleft effect. The 'classification' can be used
+ * to mark a license for special handling, e.g., marking a 'BSD-4-Clause' to need special treatment in fulfilling
+ * the obligations. The class is mutable, so constructors are reflected by additional setters to change a license during
+ * the usage of the license in a workflow.
+ */
 public class License implements LicenseInformation {
     private static final String THREAT_GROUP_KEY = "threatGroup";
     private static final String CLASSIFICATION_KEY = "classification";
@@ -21,18 +32,44 @@ public class License implements LicenseInformation {
     private String text;
     private Map<String, String> properties;
 
+    /**
+     * Constructor to create an empty license object.
+     */
     public License() {
         this(null, null, null, null);
     }
 
+    /**
+     * Constructor to create a license with only a license id. This is enough to identify a license, within the
+     * workflow. Corresponding to this, the {@link #equalLicense(License)} method checks for equality of licenses
+     * only based on the id.
+     *
+     * @param id The id of the license, normally a SPDX identifier, must not be null.
+     */
     public License(String id) {
         this(id, null, null, null);
     }
 
+    /**
+     * Constructor for a full license, including id, name and license text.
+     *
+     * @param id The id of the license, normally a SPDX identifier, must not be null.
+     * @param commonName The name of the license in a more verbal form, must not be null.
+     * @param text The license text of the license as a formatted text string, must not be null.
+     */
     public License(String id, String commonName, String text) {
         this(id, commonName, text, null);
     }
 
+    /**
+     * Constructor for a full license including in addition to id, name and license text also a map of properties,
+     * like the threat group or the classification.
+     *
+     * @param id The id of the license, normally a SPDX identifier, must not be null.
+     * @param commonName The name of the license in a more verbal form, must not be null.
+     * @param text The license text of the license as a formatted text string, must not be null.
+     * @param properties A map with properties of the license, must not be null.
+     */
     public License(String id, String commonName, String text, Map<String, String> properties) {
         this.id = id != null ? id : "";
         this.commonName = commonName != null ? commonName : "";
@@ -43,34 +80,59 @@ public class License implements LicenseInformation {
         }
     }
 
+    /**
+     * @return The id of the license, normally a SPDX identifier, never null, but could be empty.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * @param id The id of the license, normally a SPDX identifier, must not be null.
+     */
     public void setId(String id) {
         this.id = id != null ? id : "";
     }
 
+    /**
+     * @return The name of the license, a more verbal form of the id, never null, but could be empty.
+     */
     public String getCommonName() {
         return commonName;
     }
 
+    /**
+     * @param commonName The name of the license in a more verbal form, must not be null.
+     */
     public void setCommonName(String commonName) {
         this.commonName = commonName != null ? commonName : "";
     }
 
+    /**
+     * @return The license text of the license as a preformatted text string, never null, but could be empty.
+     */
     public String getText() {
         return text;
     }
 
+    /**
+     * @param text The license text of the license as a formatted text string, must not be null.
+     */
     public void setText(String text) {
         this.text = text != null ? text : "";
     }
 
+    /**
+     * @return The unmodifiable map of properties of the license, never null, but could be empty.
+     */
     public Map<String, String> getProperties() {
         return Collections.unmodifiableMap(properties);
     }
 
+    /**
+     * @param properties Replace the current properties by the new property map, if given map is null, an empty map is
+     *                   created.
+     */
     public void setProperties(Map<String, String> properties) {
         this.properties = new HashMap<>();
         if (properties != null) {
@@ -78,28 +140,60 @@ public class License implements LicenseInformation {
         }
     }
 
+    /**
+     * Set a new property or replace an existing one.
+     *
+     * @param key The key of the property to set, must not be null.
+     * @param property The new value of the property, must not be null.
+     */
     public void setProperty(String key, String property) {
         if (key != null) {
             properties.put(key, property);
         }
     }
 
+    /**
+     * Return the value of a property or an empty Optional.
+     *
+     * @param key The key of the queried property, must not be null.
+     * @return The property value stored or an empty Optional.
+     */
     public Optional<String> getProperty(String key) {
         return Optional.ofNullable(key != null ? properties.get(key) : null);
     }
 
+    /**
+     * A convenience setter for the predefined property 'threat group'.
+     *
+     * @param value The new value of the property, must not be null.
+     */
     public void setThreatGroup(String value) {
         setProperty(THREAT_GROUP_KEY, value);
     }
 
+    /**
+     * A convenience getter for the predefined property 'threat group'.
+     *
+     * @return The property value stored or an empty Optional.
+     */
     public Optional<String> getThreatGroup() {
         return getProperty(THREAT_GROUP_KEY);
     }
 
+    /**
+     * A convenience setter for the predefined property 'classification'.
+     *
+     * @param value The new value of the property, must not be null.
+     */
     public void setClassification(String value) {
         setProperty(CLASSIFICATION_KEY, value);
     }
 
+    /**
+     * A convenience getter for the predefined property 'classification'.
+     *
+     * @return The property value stored or an empty Optional.
+     */
     public Optional<String> getClassification() {
         return getProperty(CLASSIFICATION_KEY);
     }
@@ -130,6 +224,13 @@ public class License implements LicenseInformation {
                 Objects.equals(properties, license.properties);
     }
 
+    /**
+     * Compares the license to another license. The licenses are equals, if the license ids are the same,
+     * independent whether one license is complete or not.
+     *
+     * @param license The license to compare this license to.
+     * @return True, if both licenses have the same license id.
+     */
     public boolean equalLicense(License license) {
         return Objects.equals(getId(), license.getId());
     }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -82,6 +82,10 @@ public class License implements LicenseInformation {
         properties.put(key, property);
     }
 
+    public Optional<String> getProperty(String key) {
+        return Optional.ofNullable(properties.get(key));
+    }
+
     public void setThreatGroup(String value) {
         setProperty(THREAT_GROUP_KEY, value);
     }
@@ -96,10 +100,6 @@ public class License implements LicenseInformation {
 
     public Optional<String> getClassification() {
         return getProperty(CLASSIFICATION_KEY);
-    }
-
-    public Optional<String> getProperty(String key) {
-        return Optional.ofNullable(properties.get(key));
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -115,7 +115,7 @@ public class License implements LicenseInformation {
     }
 
     @Override
-    public List<License> getLicenses() {
+    public Collection<License> getLicenses() {
         return Collections.singletonList(this);
     }
 

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/License.java
@@ -130,6 +130,10 @@ public class License implements LicenseInformation {
                 Objects.equals(properties, license.properties);
     }
 
+    public boolean equalLicense(License license) {
+        return Objects.equals(getId(), license.getId());
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(id, commonName, text, properties);

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseInformation.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseInformation.java
@@ -12,8 +12,30 @@ package org.eclipse.sw360.antenna.model.license;
 
 import java.util.Collection;
 
+/**
+ * A general interface for a license expression. It is implemented by {@link LicenseStatement} which reflects a SPDX
+ * license expression or a single {@link License}, resp. a {@link WithLicense}, i.e., a license with an exception
+ * according to the SPDX expression standard.
+ */
 public interface LicenseInformation {
+    /**
+     * Give a canonical form of the license expression, i.e., this returns a string with the SPDX expression of the
+     * license statement. In cases where the licenses referenced are not referenced by a SPDX identifier, the expression
+     * reflects something close to a SPDX expression but with unstandardized identifiers.
+     *
+     * @return An SPDX license expression, never null.
+     *
+     */
     String evaluate();
+
+    /**
+     * @return True, if the license expression is an empty string, false, if it contains data.
+     */
     boolean isEmpty();
+
+    /**
+     * @return A flat list of all licenses referenced in the license expression, loosing the information on how licenses
+     * are combined in the expression, never null.
+     */
     Collection<License> getLicenses();
 }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseInformation.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseInformation.java
@@ -10,10 +10,10 @@
  */
 package org.eclipse.sw360.antenna.model.license;
 
-import java.util.List;
+import java.util.Collection;
 
 public interface LicenseInformation {
     String evaluate();
     boolean isEmpty();
-    List<License> getLicenses();
+    Collection<License> getLicenses();
 }

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseOperator.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseOperator.java
@@ -10,6 +10,10 @@
  */
 package org.eclipse.sw360.antenna.model.license;
 
+/**
+ * Simple operator for license expression according to the SPDX license expression standard. The WITH operator is
+ * missing, because with expressions are handled by a special class {@link WithLicense}
+ */
 public enum LicenseOperator {
     AND,
     OR;

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -56,12 +56,9 @@ public class LicenseStatement implements LicenseInformation {
         if (isEmpty()) {
             return "";
         }
-        return "( " +
-                licenses
-                        .stream()
-                        .map(LicenseInformation::evaluate)
-                        .collect(Collectors.joining(" " + this.op.toString() + " "))
-                + " )";
+        return licenses.stream()
+                .map(LicenseInformation::evaluate)
+                .collect(Collectors.joining(" " + this.op.toString() + " ", "( ", " )"));
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -73,7 +73,7 @@ public class LicenseStatement implements LicenseInformation {
     }
 
     @Override
-    public List<License> getLicenses() {
+    public Collection<License> getLicenses() {
         return licenses
                 .stream()
                 .map(LicenseInformation::getLicenses)

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -10,10 +10,7 @@
  */
 package org.eclipse.sw360.antenna.model.license;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class LicenseStatement implements LicenseInformation {
@@ -70,6 +67,17 @@ public class LicenseStatement implements LicenseInformation {
     @Override
     public boolean isEmpty() {
         return licenses.isEmpty() || licenses.stream().allMatch(LicenseInformation::isEmpty);
+    }
+
+    /**
+     * This method returns the first level of operands of this operation. This can be either licenses or embedded
+     * license operations. In comparison to getLicenses, this method does not dig into the expression to return
+     * all licenses, but reflects the expression tree by returning only the next level.
+     *
+     * @return The direct operands of the license expression.
+     */
+    public Collection<LicenseInformation> getStatementOperands() {
+        return Collections.unmodifiableCollection(licenses);
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -14,14 +14,14 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class LicenseStatement implements LicenseInformation {
-    private List<LicenseInformation> licenses;
+    private Collection<LicenseInformation> licenses;
     private LicenseOperator op;
 
     public LicenseStatement() {
         this(null, null);
     }
 
-    public LicenseStatement(List<LicenseInformation> licenses, LicenseOperator op) {
+    public LicenseStatement(Collection<LicenseInformation> licenses, LicenseOperator op) {
         this.licenses = new ArrayList<>();
         if (licenses != null) {
             this.licenses.addAll(licenses);
@@ -29,7 +29,7 @@ public class LicenseStatement implements LicenseInformation {
         this.op = op != null ? op : LicenseOperator.AND;
     }
 
-    public void setLicenses(List<LicenseInformation> licenses) {
+    public void setLicenses(Collection<LicenseInformation> licenses) {
         this.licenses.clear();
         if (licenses != null) {
             this.licenses.addAll(licenses);

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -13,14 +13,27 @@ package org.eclipse.sw360.antenna.model.license;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * This class reflects an operation in a SPDX license expression. It combines a set of {@link LicenseInformation}
+ * objects with an operation, either 'AND' or 'OR'.
+ */
 public class LicenseStatement implements LicenseInformation {
     private Collection<LicenseInformation> licenses;
     private LicenseOperator op;
 
+    /**
+     * Constructor for an empty statement, can be enriched by setters below.
+     */
     public LicenseStatement() {
         this(null, null);
     }
 
+    /**
+     * The standard constructor to create a license expression with the given license operands and the given operator.
+     *
+     * @param licenses The license operands of the expression, must not be null.
+     * @param op The operator of the expression, must not be null.
+     */
     public LicenseStatement(Collection<LicenseInformation> licenses, LicenseOperator op) {
         this.licenses = new ArrayList<>();
         if (licenses != null) {
@@ -29,6 +42,11 @@ public class LicenseStatement implements LicenseInformation {
         this.op = op != null ? op : LicenseOperator.AND;
     }
 
+    /**
+     * Replace the license operands of the expression by the given Collection.
+     *
+     * @param licenses The license operands of the expression, must not be null.
+     */
     public void setLicenses(Collection<LicenseInformation> licenses) {
         this.licenses.clear();
         if (licenses != null) {
@@ -36,14 +54,28 @@ public class LicenseStatement implements LicenseInformation {
         }
     }
 
+    /**
+     * @return The operator of the expression, never null
+     */
     public LicenseOperator getOp() {
         return op;
     }
 
+    /**
+     * Reset the operator of the expression.
+     *
+     * @param operator The new operator, must not be null.
+     */
     public void setOp(LicenseOperator operator) {
         this.op = operator != null ? operator : LicenseOperator.AND;
     }
 
+    /**
+     * Add a single operand to the expression.
+     *
+     * @param license The new operand to be added to the expression, must not be null.
+     * @return The result of the add operation to the internal collection.
+     */
     public boolean addLicenseInformation(LicenseInformation license) {
         if (license != null) {
             return licenses.add(license);
@@ -67,9 +99,9 @@ public class LicenseStatement implements LicenseInformation {
     }
 
     /**
-     * This method returns the first level of operands of this operation. This can be either licenses or embedded
-     * license operations. In comparison to getLicenses, this method does not dig into the expression to return
-     * all licenses, but reflects the expression tree by returning only the next level.
+     * This method returns the first level of operands of this operation. This can be either {@link License} objects
+     * or embedded {@link LicenseStatement} objects. In comparison to getLicenses, this method does not dig into the
+     * expression to return all licenses, but reflects the expression tree by returning only the next level.
      *
      * @return The direct operands of the license expression.
      */

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/LicenseStatement.java
@@ -21,16 +21,22 @@ public class LicenseStatement implements LicenseInformation {
     private LicenseOperator op;
 
     public LicenseStatement() {
-        this(new ArrayList<>(), null);
+        this(null, null);
     }
 
     public LicenseStatement(List<LicenseInformation> licenses, LicenseOperator op) {
-        this.licenses = licenses;
-        this.op = op;
+        this.licenses = new ArrayList<>();
+        if (licenses != null) {
+            this.licenses.addAll(licenses);
+        }
+        this.op = op != null ? op : LicenseOperator.AND;
     }
 
     public void setLicenses(List<LicenseInformation> licenses) {
-        this.licenses = licenses;
+        this.licenses.clear();
+        if (licenses != null) {
+            this.licenses.addAll(licenses);
+        }
     }
 
     public LicenseOperator getOp() {
@@ -38,11 +44,14 @@ public class LicenseStatement implements LicenseInformation {
     }
 
     public void setOp(LicenseOperator operator) {
-        this.op = operator;
+        this.op = operator != null ? operator : LicenseOperator.AND;
     }
 
     public boolean addLicenseInformation(LicenseInformation license) {
-        return licenses.add(license);
+        if (license != null) {
+            return licenses.add(license);
+        }
+        return false;
     }
 
     @Override
@@ -60,14 +69,11 @@ public class LicenseStatement implements LicenseInformation {
 
     @Override
     public boolean isEmpty() {
-        return licenses == null || licenses.isEmpty() || licenses.stream().allMatch(LicenseInformation::isEmpty);
+        return licenses.isEmpty() || licenses.stream().allMatch(LicenseInformation::isEmpty);
     }
 
     @Override
     public List<License> getLicenses() {
-        if (licenses == null || this.isEmpty()) {
-            licenses =  new ArrayList<>();
-        }
         return licenses
                 .stream()
                 .map(LicenseInformation::getLicenses)

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
@@ -20,12 +20,12 @@ public class WithLicense implements LicenseInformation {
     private License exception;
 
     public WithLicense() {
-        this(new License(), new License());
+        this(null, null);
     }
 
     public WithLicense(License license, License exception) {
-        this.license = license;
-        this.exception = exception;
+        this.license = license != null ? license : new License();
+        this.exception = exception != null ? exception : new License();
     }
 
     public License getLicense() {
@@ -33,7 +33,7 @@ public class WithLicense implements LicenseInformation {
     }
 
     public void setLicense(License license) {
-        this.license = license;
+        this.license = license != null ? license : new License();
     }
 
     public License getException() {
@@ -41,7 +41,7 @@ public class WithLicense implements LicenseInformation {
     }
 
     public void setException(License exception) {
-        this.exception = exception;
+        this.exception = exception != null ? exception : new License();
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.sw360.antenna.model.license;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -55,7 +55,7 @@ public class WithLicense implements LicenseInformation {
     }
 
     @Override
-    public List<License> getLicenses() {
+    public Collection<License> getLicenses() {
         return Stream.of(license, exception).collect(Collectors.toList());
     }
 

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
@@ -51,7 +51,7 @@ public class WithLicense implements LicenseInformation {
 
     @Override
     public boolean isEmpty() {
-        return this.license.isEmpty() && this.exception.isEmpty();
+        return license.isEmpty() && exception.isEmpty();
     }
 
     @Override

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/license/WithLicense.java
@@ -13,6 +13,14 @@ package org.eclipse.sw360.antenna.model.license;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+/**
+ * This class reflects a with license, i.e., a classical Open Source license with an exception. A widely known example
+ * is the 'GPL-2.0-or-later WITH Classpath-exception-2.0'. The class is setup to handle both parts of the licenses
+ * separately, the main license by using the inherited license properties, the exception information internally.
+ * It can handle input as separate parts for the two parts or as combined expressions. The underlying assumption is
+ * that a with license is expressed as 'main_license_id WITH exception_id'. The case of the WITH statement matters, so
+ * only upper case WITH is allowed. For the license texts the separator is 'with exception:' with embedding whitespaces.
+ */
 public class WithLicense extends License implements LicenseInformation {
     private static final String SEPARATOR = " WITH ";
     private static final String TEXT_SEPARATOR = "with exception:";
@@ -23,15 +31,35 @@ public class WithLicense extends License implements LicenseInformation {
     private String exceptionName;
     private String exceptionText;
 
+    /**
+     * Creates an empty license
+     */
     public WithLicense() {
         this(null, null);
     }
 
-
+    /**
+     * Constructor to create a license with only license ids. This is enough to identify a license, within the
+     * workflow. Corresponding to this, the {@link #equalLicense(License)} method checks for equality of licenses
+     * only based on the ids.
+     *
+     * @param licenseId The id of the main license in the with expression, must not be null.
+     * @param exceptionId The id of the exception, must not be null.
+     */
     public WithLicense(String licenseId, String exceptionId) {
         this(licenseId, null, null, exceptionId, null, null);
     }
 
+    /**
+     * Constructor for a full license, including ids, names and license texts.
+     *
+     * @param licenseId The id of the main license, normally a SPDX identifier, must not be null.
+     * @param licenseName The name of the main license in a more verbal form, must not be null.
+     * @param licenseText The license text of the main license as a formatted text string, must not be null.
+     * @param exceptionId The id of the exception, normally a SPDX identifier, must not be null.
+     * @param exceptionName The name of the exception in a more verbal form, must not be null.
+     * @param exceptionText The license text of the exception as a formatted text string, must not be null.
+     */
     public WithLicense(String licenseId, String licenseName, String licenseText, String exceptionId,
             String exceptionName, String exceptionText) {
         super(licenseId, licenseName, licenseText);
@@ -40,6 +68,15 @@ public class WithLicense extends License implements LicenseInformation {
         this.exceptionText = exceptionText != null ? exceptionText : "";
     }
 
+    /**
+     * Constructor for combined expressions, i.e., for a with license that is already build together according to
+     * the conventions above.
+     *
+     * @param licenseId A with license id, e.g., 'mainId WITH exceptionId', must not be null.
+     * @param licenseName A with license name, e.g., 'mainName WITH exceptionName', must not be null.
+     * @param licenseText A with license text, e.g,, 'mainText with exception: exceptionText', must not be null.
+     * @throws IllegalArgumentException If the given parameters cannot be splitted according to the spec.
+     */
     public WithLicense(String licenseId, String licenseName, String licenseText) {
         super();
         exceptionId = separateStringAndSetFirst(licenseId, SEPARATOR, super::setId);
@@ -56,16 +93,28 @@ public class WithLicense extends License implements LicenseInformation {
         return splitted[1].trim();
     }
 
+    /**
+     * @return The with license id, i.e., 'licenseId WITH exceptionId'.
+     */
     @Override
     public String getId() {
         return evaluate();
     }
 
+    /**
+     * Set the with license id
+     *
+     * @param id A with license id, e.g., 'mainId WITH exceptionId', must not be null.
+     * @throws IllegalArgumentException If the given parameters cannot be splitted according to the spec.
+     */
     @Override
     public void setId(String id) {
         exceptionId = separateStringAndSetFirst(id, SEPARATOR, super::setId);
     }
 
+    /**
+     * @return The with license name, i.e., 'mainName WITH exceptionName'.
+     */
     @Override
     public String getCommonName() {
         if ("".equals(super.getCommonName()) || "".equals(exceptionName)) {
@@ -74,11 +123,20 @@ public class WithLicense extends License implements LicenseInformation {
         return super.getCommonName() + SEPARATOR + exceptionName;
     }
 
+    /**
+     * Set the with license name.
+     *
+     * @param commonName A with license name, e.g., 'mainName WITH exceptionName', must not be null.
+     * @throws IllegalArgumentException If the given parameters cannot be splitted according to the spec.
+     */
     @Override
     public void setCommonName(String commonName) {
         exceptionName = separateStringAndSetFirst(commonName, SEPARATOR, super::setCommonName);
     }
 
+    /**
+     * @return The with license text, i.e., 'mainText with exception: exceptionText'.
+     */
     @Override
     public String getText() {
         if ("".equals(super.getText()) || "".equals(exceptionText)) {
@@ -87,54 +145,109 @@ public class WithLicense extends License implements LicenseInformation {
         return super.getText() + "\n\n" + TEXT_SEPARATOR + "\n\n" + exceptionText;
     }
 
+    /**
+     * Set the with license text.
+     *
+     * @param text A with license text, e.g,, 'mainText with exception: exceptionText', must not be null.
+     * @throws IllegalArgumentException If the given parameters cannot be splitted according to the spec.
+     */
     @Override
     public void setText(String text) {
         exceptionText = separateStringAndSetFirst(text, TEXT_SEPARATOR, super::setText);
     }
 
+    /**
+     * @return The id of the main license
+     */
     public String getLicenseId() {
         return super.getId();
     }
 
+    /**
+     * Set the main license id.
+     *
+     * @param licenseId The id of the main license, normally a SPDX identifier, must not be null.
+     */
     public void setLicenseId(String licenseId) {
         super.setId(licenseId);
     }
 
+    /**
+     * @return The name of the main license
+     */
     public String getLicenseName() {
         return super.getCommonName();
     }
 
+    /**
+     * Set the main license name.
+     *
+     * @param licenseName The name of the main license in a more verbal form, must not be null.
+     */
     public void setLicenseName(String licenseName) {
         super.setCommonName(licenseName);
     }
 
+    /**
+     * @return The text of the main license
+     */
     public String getLicenseText() {
         return super.getText();
     }
+
+    /**
+     * Set the main license text.
+     *
+     * @param licenseText The license text of the main license as a formatted text string, must not be null.
+     */
     public void setLicenseText(String licenseText) {
         super.setText(licenseText);
     }
 
+    /**
+     * @return The id of the exception
+     */
     public String getExceptionId() {
         return exceptionId;
     }
 
+    /**
+     * Set the exception id.
+     *
+     * @param exceptionId The id of the exception, normally a SPDX identifier, must not be null.
+     */
     public void setExceptionId(String exceptionId) {
         this.exceptionId = exceptionId != null ? exceptionId : "";
     }
 
+    /**
+     * @return The name of the exception
+     */
     public String getExceptionName() {
         return exceptionName;
     }
 
+    /**
+     * Set the exception name.
+     *
+     * @param exceptionName The name of the exception in a more verbal form, must not be null.
+     */
     public void setExceptionName(String exceptionName) {
         this.exceptionName = exceptionName != null ? exceptionName : "";
     }
 
+    /**
+     * @return The text of the exception
+     */
     public String getExceptionText() {
         return exceptionText;
     }
 
+    /**
+     * Set the exception text.
+     *
+     * @param exceptionText The license text of the exception as a formatted text string, must not be null.
+     */
     public void setExceptionText(String exceptionText) {
         this.exceptionText = exceptionText != null ? exceptionText : "";
     }

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/LicenseStatementTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/LicenseStatementTest.java
@@ -88,6 +88,24 @@ public class LicenseStatementTest {
     }
 
     @Test
+    public void testComplexStatement() {
+        License license1 = new License("Apache-2.0");
+        License license2 = new License("EPL-2.0");
+        License license3 = new License("GPL-2.0-later");
+        License license4 = new License("MIT");
+
+        LicenseStatement andStmt = new LicenseStatement(Stream.of(license1, license2, license4).collect(Collectors.toList()), LicenseOperator.AND);
+        LicenseStatement orStmt = new LicenseStatement(Stream.of(license3, andStmt).collect(Collectors.toList()), LicenseOperator.OR);
+
+        assertThat(orStmt.isEmpty()).isFalse();
+        assertThat(andStmt.isEmpty()).isFalse();
+        assertThat(orStmt.getLicenses().size()).isEqualTo(4);
+        assertThat(orStmt.getStatementOperands().size()).isEqualTo(2);
+        assertThat(orStmt.getStatementOperands()).contains(license3);
+        assertThat(orStmt.getStatementOperands()).contains(andStmt);
+    }
+
+    @Test
     public void pushCoverageForEqualsAndHashcode() {
         EqualsVerifier.forClass(LicenseStatement.class)
                 .withRedefinedSuperclass()

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/LicenseTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/LicenseTest.java
@@ -40,6 +40,16 @@ public class LicenseTest {
     }
 
     @Test
+    public void testEqualLicense() {
+        License license1 = new License ("Apache-2.0");
+        License license2 = new License ("Apache-2.0", "Apache License Version 2.0", "Some license text");
+        License license3 = new License ("MIT");
+
+        assertThat(license1.equalLicense(license2)).isTrue();
+        assertThat(license1.equalLicense(license3)).isFalse();
+    }
+
+    @Test
     public void testLicenseWithoutProperties() {
         String licenseId = "Apache-2.0";
         String licenseName = "Apache License 2.0";

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/WithLicenseTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/license/WithLicenseTest.java
@@ -26,24 +26,93 @@ public class WithLicenseTest {
 
     @Test
     public void testSpecifiedWithLicense() {
-        String licenseId = "Apache-2.0";
-        String licenseName = "Apache License 2.0";
-        String licenseText = "Too long";
-        License license = new License(licenseId, licenseName, licenseText);
-        String exceptionId = "Exp.";
-        String exceptionName = "Exception";
-        String exceptionText = "Text of Exception.";
-        License exception = new License(exceptionId, exceptionName, exceptionText);
-        WithLicense withLicense = new WithLicense(license, exception);
+        String licenseId = "GPL-2.0-or-later";
+        String licenseName = "Gnu Public License 2.0 or later";
+        String licenseText = "Text of GPL";
+        String exceptionId = "Classpath-Exception";
+        String exceptionName = "Classpath exception";
+        String exceptionText = "Text of Exception";
+        WithLicense withLicense = new WithLicense(licenseId, licenseName, licenseText, exceptionId,exceptionName, exceptionText);
+        String threatGroup = "TestGroup";
+        String classification = "TestClassification";
+        withLicense.setThreatGroup(threatGroup);
+        withLicense.setClassification(classification);
 
         assertThat(withLicense.isEmpty()).isFalse();
         assertThat(withLicense.getLicenses().size())
-                .isEqualTo(2);
+                .isEqualTo(1);
 
-        assertThat(withLicense.getLicense()).isEqualTo(license);
-        assertThat(withLicense.getException()).isEqualTo(exception);
+        assertThat(withLicense.getId()).isEqualTo(licenseId + " WITH " + exceptionId);
+        assertThat(withLicense.getLicenseId()).isEqualTo(licenseId);
+        assertThat(withLicense.getExceptionId()).isEqualTo(exceptionId);
 
-        assertThat(withLicense.evaluate()).isEqualTo("Apache-2.0 WITH Exp.");
+        assertThat(withLicense.toString()).isEqualTo(licenseId + " WITH " + exceptionId);
+        assertThat(withLicense.evaluate()).isEqualTo(licenseId + " WITH " + exceptionId);
+
+        assertThat(withLicense.getCommonName()).isEqualTo(licenseName + " WITH " + exceptionName);
+        assertThat(withLicense.getText()).contains(licenseText);
+        assertThat(withLicense.getText()).contains(exceptionText);
+
+        assertThat(withLicense.getThreatGroup().orElseThrow(NullPointerException::new)).isEqualTo(threatGroup);
+        assertThat(withLicense.getClassification().orElseThrow(NullPointerException::new)).isEqualTo(classification);
+    }
+
+    @Test
+    public void testEqualLicense() {
+        WithLicense license1 = new WithLicense("GPL-2.0-or-later", "Classpath-Exception");
+        WithLicense license2 = new WithLicense("GPL-2.0-or-later", "Gnu Public License 2.0 or later", "GPL Text", "Classpath-Exception", "Classpath exception", "Text of Exception");
+        WithLicense license3 = new WithLicense("GPL-2.0-or-later", "Autoconf-Exception");
+
+
+        assertThat(license1.equalLicense(license2)).isTrue();
+        assertThat(license1.equalLicense(license3)).isFalse();
+    }
+
+    @Test
+    public void testWithLicenseBuildFromAssembledInput() {
+        String licenseId = "GPL-2.0-or-later WITH Classpath-Exception";
+        String licenseName = "Gnu Public License or later WITH Classpath Exception";
+        String licenseText = "Gnu license text\n\nwith exception:\n\nException text";
+
+        WithLicense withLicense1 = new WithLicense();
+        assertThat(withLicense1.isEmpty()).isTrue();
+
+        withLicense1.setId(licenseId);
+        withLicense1.setCommonName(licenseName);
+        withLicense1.setText(licenseText);
+        assertThat(withLicense1.isEmpty()).isFalse();
+
+        WithLicense withLicense2 = new WithLicense(licenseId, licenseName, licenseText);
+
+        assertThat(withLicense1).isEqualTo(withLicense2);
+        assertThat(withLicense1.equalLicense(withLicense2)).isTrue();
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorWithWrongIdParameter() {
+        new WithLicense("something", "strange WITH happening", "with with exception: text");
+    }
+
+    @Test
+    public void testPartialWithLicense() {
+        WithLicense license = new WithLicense();
+
+        assertThat(license.getId()).isEqualTo("");
+        assertThat(license.getCommonName()).isEqualTo("");
+        assertThat(license.getText()).isEqualTo("");
+
+        license.setLicenseId("id1");
+        license.setLicenseName("name1");
+        license.setLicenseText("text1");
+
+        assertThat(license.getId()).isEqualTo("");
+        assertThat(license.getCommonName()).isEqualTo("");
+        assertThat(license.getText()).isEqualTo("");
+
+        license.setExceptionId("id2");
+        assertThat(license.getId()).isEqualTo("id1 WITH id2");
+        assertThat(license.getCommonName()).isEqualTo("");
+        assertThat(license.getText()).isEqualTo("");
     }
 
     @Test
@@ -52,18 +121,33 @@ public class WithLicenseTest {
 
         assertThat(withLicense.isEmpty()).isTrue();
 
-        License license = new License("Apache-2.0");
-        License exception = new License("Exception");
-        withLicense.setLicense(license);
-        withLicense.setException(exception);
+        String licenseId = "Apache-2.0";
+        String licenseName = "Apache License Version 2.0";
+        String licenseText = "Some Text";
+        String exceptionId = "Exception";
+        String exceptionName = "Test Exception";
+        String exceptionText = "Exception text";
+        withLicense.setLicenseId(licenseId);
+        withLicense.setLicenseName(licenseName);
+        withLicense.setLicenseText(licenseText);
+        withLicense.setExceptionId(exceptionId);
+        withLicense.setExceptionName(exceptionName);
+        withLicense.setExceptionText(exceptionText);
 
         assertThat(withLicense.isEmpty()).isFalse();
-        assertThat(withLicense.toString()).isEqualTo("Apache-2.0 WITH Exception");
+        assertThat(withLicense.toString()).isEqualTo(licenseId + " WITH " + exceptionId);
+        assertThat(withLicense.getLicenseId()).isEqualTo(licenseId);
+        assertThat(withLicense.getExceptionId()).isEqualTo(exceptionId);
+        assertThat(withLicense.getId()).isEqualTo(licenseId + " WITH " + exceptionId);
+        assertThat(withLicense.getCommonName()).isEqualTo(licenseName + " WITH " + exceptionName);
+        assertThat(withLicense.getText()).contains(licenseText);
+        assertThat(withLicense.getText()).contains(exceptionText);
     }
 
     @Test
     public void pushCoverageForEqualsAndHashcode() {
         EqualsVerifier.forClass(WithLicense.class)
+                .withNonnullFields("exceptionId", "exceptionName", "exceptionText")
                 .withRedefinedSuperclass()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .usingGetClass()

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactLicenseUtilsTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactLicenseUtilsTest.java
@@ -113,7 +113,6 @@ public class ArtifactLicenseUtilsTest {
 
         assertThat(finalLicenses.getLicenses().size())
                 .isEqualTo(2);
-        assertThat(finalLicenses.getLicenses().get(0).evaluate())
-                .isEqualTo(epl.getId());
+        assertThat(finalLicenses.getLicenses()).contains(epl);
     }
 }

--- a/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
+++ b/core/model/src/test/java/org/eclipse/sw360/antenna/model/test/ArtifactTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -161,7 +162,7 @@ public class ArtifactTest {
         observedLicenses.setLicenses(Stream.of(license2, declaredLicenses).collect(Collectors.toList()));
         observedLicenses.setOp(LicenseOperator.AND);
         artifact.addFact(new ObservedLicenseInformation(observedLicenses));
-        List<License> licenses = new ArrayList<>();
+        Collection<License> licenses = new ArrayList<>();
         licenses.add(license2);
         licenses.add(declaredLicenses);
 

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
@@ -122,13 +122,11 @@ public class LicenseSupport {
         final SpdxOperator operator = spdxCompoundExpression.component2();
         final SpdxExpression right = spdxCompoundExpression.component3();
 
-        if (license.getOp() == null || license.getOp().toString().isEmpty()) {
-            if (SpdxOperator.AND.equals(operator)) {
-                license.setOp(LicenseOperator.AND);
-            }
-            if (SpdxOperator.OR.equals(operator)) {
-                license.setOp(LicenseOperator.OR);
-            }
+        if (SpdxOperator.AND.equals(operator)) {
+            license.setOp(LicenseOperator.AND);
+        }
+        if (SpdxOperator.OR.equals(operator)) {
+            license.setOp(LicenseOperator.OR);
         }
         if (left instanceof SpdxCompoundExpression) {
             checkCompoundChild((SpdxCompoundExpression) left, license);

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
@@ -91,7 +91,10 @@ public class LicenseSupport {
     private static LicenseInformation fromSpdxWithLicense(SpdxCompoundExpression spdxCompoundExpression) {
         final SpdxExpression license = spdxCompoundExpression.component1();
         final SpdxExpression exception = spdxCompoundExpression.component3();
-        return new WithLicense((License) fromSPDXExpression(license), (License) fromSPDXExpression(exception));
+        final License withLicense = (License) fromSPDXExpression(license);
+        final License exceptionLicense = (License) fromSPDXExpression(exception);
+        return new WithLicense(withLicense.getId(), withLicense.getCommonName(), withLicense.getText(),
+                exceptionLicense.getId(), exceptionLicense.getCommonName(), exceptionLicense.getText());
     }
 
     public static LicenseInformation fromSpdxLicenseExceptionExpression(SpdxLicenseExceptionExpression spdxLicenseExceptionExpression) {

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
@@ -62,7 +62,7 @@ public class ConfigurationTest {
 
         ArtifactIdentifier identifier = new ArtifactFilename("overrideName.jar");
         assertThat(configuration.getFinalLicenses().keySet().stream().anyMatch(k -> k.matches(identifier))).isTrue();
-        List<LicenseInformation> list = configuration.getFinalLicenses().entrySet().stream()
+        List<License> list = configuration.getFinalLicenses().entrySet().stream()
                 .filter(e -> e.getKey().matches(identifier))
                 .map(Map.Entry::getValue)
                 .map(LicenseInformation::getLicenses)

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,7 +66,7 @@ public class ConfigurationTest {
                 .filter(e -> e.getKey().matches(identifier))
                 .map(Map.Entry::getValue)
                 .map(LicenseInformation::getLicenses)
-                .flatMap(List::stream)
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
         assertThat(list.contains(license)).isTrue();
         assertThat(configuration.isFailOnMissingSources()).isTrue();
@@ -112,7 +113,8 @@ public class ConfigurationTest {
         ).isEqualTo(LicenseOperator.AND);
         assertThat(declaredLicenseInformation
                 .getLicenses()
-                .get(0)
+                .iterator()
+                .next()
                 .evaluate()
         ).isEqualTo("testLicense");
         assertThat(declaredLicenseInformation
@@ -128,7 +130,7 @@ public class ConfigurationTest {
     @Test
     public void addArtifactTest() throws Exception {
         Artifact artifact = configuration.getAddArtifact().get(0);
-        assertThat(artifact.askForGet(DeclaredLicenseInformation.class).get().getLicenses().get(0).evaluate())
+        assertThat(artifact.askForGet(DeclaredLicenseInformation.class).get().getLicenses().iterator().next().evaluate())
                 .isEqualTo("Apache");
         assertThat(artifact.askFor(ArtifactFilename.class).get().getFilenames())
                 .contains("addArtifact.jar");

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/configuration/ConfigurationTest.java
@@ -46,7 +46,7 @@ public class ConfigurationTest {
         URL xmlUrl = ConfigurationTest.class.getResource("/antennaconf.xml");
         XMLResolverJaxB resolver = new XMLResolverJaxB(StandardCharsets.UTF_8);
         AntennaConfig config = resolver.resolveXML(new File(xmlUrl.toURI()));
-        this.configuration = new Configuration(config);
+        configuration = new Configuration(config);
     }
 
     @Test

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
@@ -27,7 +27,7 @@ public class LicenseSupportTest {
         Collection<String> license = Collections.singletonList("Single License");
         LicenseInformation actualLicenseSupport = LicenseSupport.mapLicenses(license);
 
-        assertThat(actualLicenseSupport.toString()).startsWith("Single License");
+        assertThat(actualLicenseSupport.evaluate()).startsWith("Single License");
     }
 
     @Test
@@ -35,7 +35,7 @@ public class LicenseSupportTest {
         Collection<String> license = Arrays.asList("First License", "Second License", "Third License");
         LicenseInformation actualLicenseSupport = LicenseSupport.mapLicenses(license);
 
-        assertThat(actualLicenseSupport.toString())
+        assertThat(actualLicenseSupport.evaluate())
                 .startsWith("( First License AND Second License AND Third License )");
     }
 
@@ -131,10 +131,10 @@ public class LicenseSupportTest {
     public void testSPDXParsing6() {
         final LicenseInformation licenseInformation = LicenseSupport.fromSPDXExpression("BSD WITH Exception");
         assertThat(licenseInformation.getLicenses().size())
-                .isEqualTo(2);
+                .isEqualTo(1);
         assertThat(licenseInformation).isInstanceOf(WithLicense.class);
-        assertThat(((WithLicense) licenseInformation).getLicense().getId()).isEqualTo("BSD");
-        assertThat(((WithLicense) licenseInformation).getException().getId()).isEqualTo("Exception");
+        assertThat(((WithLicense) licenseInformation).getLicenseId()).isEqualTo("BSD");
+        assertThat(((WithLicense) licenseInformation).getExceptionId()).isEqualTo("Exception");
     }
 
     @Test

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/LicenseSupportTest.java
@@ -107,7 +107,7 @@ public class LicenseSupportTest {
         final LicenseInformation licenseInformation = LicenseSupport.parseSpdxExpression(license);
         assertThat(licenseInformation.getLicenses().size())
                 .isEqualTo(1);
-        assertThat(licenseInformation.getLicenses().get(0).getId())
+        assertThat(licenseInformation.getLicenses().iterator().next().getId())
                 .isEqualTo(license);
     }
 

--- a/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/ArtifactToComponentConverter.java
+++ b/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/ArtifactToComponentConverter.java
@@ -135,13 +135,13 @@ public final class ArtifactToComponentConverter {
         }
     }
 
-    private static void addLicensesToComponent(List<License> tinaLicenses, Component c) {
+    private static void addLicensesToComponent(List<License> antennaLicenses, Component c) {
         LicenseChoice licenseChoice = new LicenseChoice();
         c.setLicenseChoice(licenseChoice);
-        for (License tinaLicense : tinaLicenses) {
+        for (License antennaLicense : antennaLicenses) {
             org.cyclonedx.model.License license = new org.cyclonedx.model.License();
-            license.setName(tinaLicense.getCommonName());
-            license.setId(tinaLicense.getId());
+            license.setName(antennaLicense.getCommonName());
+            license.setId(antennaLicense.getId());
             licenseChoice.addLicense(license);
         }
     }

--- a/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/ArtifactToComponentConverter.java
+++ b/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/ArtifactToComponentConverter.java
@@ -28,10 +28,7 @@ import org.eclipse.sw360.antenna.model.util.ArtifactLicenseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Converts an {@link Artifact} to a {@link Component}.
@@ -135,7 +132,7 @@ public final class ArtifactToComponentConverter {
         }
     }
 
-    private static void addLicensesToComponent(List<License> antennaLicenses, Component c) {
+    private static void addLicensesToComponent(Collection<License> antennaLicenses, Component c) {
         LicenseChoice licenseChoice = new LicenseChoice();
         c.setLicenseChoice(licenseChoice);
         for (License antennaLicense : antennaLicenses) {

--- a/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/workflow/processors/AntennaLicenseData.java
+++ b/modules/policy/engine/src/main/java/org/eclipse/sw360/antenna/policy/workflow/processors/AntennaLicenseData.java
@@ -30,11 +30,13 @@ class AntennaLicenseData implements LicenseData {
 
     @Override
     public Optional<String> getLicenseName() {
-        return Optional.ofNullable(license.getCommonName());
+        return Optional.ofNullable(license.getCommonName())
+                .filter(name -> !name.trim().isEmpty());
     }
 
     @Override
     public Optional<String> getLicenseText() {
-        return Optional.ofNullable(license.getText());
+        return Optional.ofNullable(license.getText())
+                .filter(text -> !text.trim().isEmpty());
     }
 }

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class SW360MetaDataUpdater {
         this.uploadSources = uploadSources;
     }
 
-    public Set<SW360License> getLicenses(List<License> licenses) {
+    public Set<SW360License> getLicenses(Collection<License> licenses) {
         return licenses.stream()
                 .filter(this::isLicenseInSW360)
                 .map(license -> licenseClientAdapter.getSW360LicenseByAntennaLicense(license.getId()))

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
@@ -84,7 +84,7 @@ public class SW360UpdaterImpl {
     }
 
     private Set<String> getSetOfLicenseIds(Artifact artifact) {
-        List<License> availableLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
+        Collection<License> availableLicenses = ArtifactLicenseUtils.getFinalLicenses(artifact).getLicenses();
 
         Set<SW360License> detectedLicenses = sw360MetaDataUpdater.getLicenses(availableLicenses);
         Set<String> licenseIds = Collections.emptySet();

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
@@ -258,8 +258,8 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
         sw360Enricher.process(artifacts);
 
         assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses()).hasSize(1);
-        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().get(0).getId()).isEqualTo("apache2");
-        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().get(0).getText()).isEqualTo("Some text");
+        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().iterator().next().getId()).isEqualTo("apache2");
+        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().iterator().next().getText()).isEqualTo("Some text");
     }
 
     @Test
@@ -315,7 +315,7 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
         sw360Enricher.process(artifacts);
 
         assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses()).hasSize(1);
-        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().get(0).evaluate()).isEqualTo("mit");
+        assertThat(ArtifactLicenseUtils.getFinalLicenses(artifacts.get(0)).getLicenses().iterator().next().evaluate()).isEqualTo("mit");
     }
 
     private SW360SparseLicense createSparseLicense(String name, String fullName) {


### PR DESCRIPTION
#### Major changes:
- Add method to return in LicenseStatement the next level of the expression, this enables the traversal through a license expression
- Reimplement the semantics of a with license with details:
  - Change the semantics to represent one license as WithLicense with two parts
  - Base WithLicense on a single license, all methods of License are adapted to meet the needs of a with license
  - The basic concept of a with license is that two SPDX identifier are matched by the term ' WITH ', this is also true for the name of the license not only the id
  - The license text is also attached to each other in the form of license text with exception: exception text and corresponding newlines
  - WithLicense can be built from two parts reflecting original license and exception and from already combined terms, e.g., 'licenseID WITH exceptionID
    - Corresponding Constructors and setters have been defined, getters are added for both as convenience 
  - Tests are added to check for the new behavior
  - Adapt places in the code that requires a change due to the changed understanding of WithLicense

#### Minor changes:
- Replace use of List by use of Collection, because a LicenseStatement is a commutative operation, so order must not be important
- Improve parameter handling to ensure non-null parameters, this prevents NullPointerExceptions in use due to immediate feedback
- Small improvement of local stream handling, using the joining collector with pre- and suffix
- Adaptations of code places where interface changes mattered

### Request Reviewer
@neubs-bsi @sschuberth 

### Type of Change
*Type of change*:  improvement

### How Has This Been Tested?
Unittests have been added, tests have been adapted to reflect the changed semantics

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes as javadoc
