### PR TITLE
Upgrade ORT to the latest version

### DIFF
--- a/core/frontend-stubs-testing/pom.xml
+++ b/core/frontend-stubs-testing/pom.xml
@@ -152,12 +152,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>model</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>spdx-utils</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/core/frontend-stubs/maven-frontend-stub/pom.xml
+++ b/core/frontend-stubs/maven-frontend-stub/pom.xml
@@ -154,11 +154,11 @@
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>model</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>spdx-utils</artifactId>
         </dependency>
         <dependency>
@@ -182,7 +182,7 @@
             <artifactId>pdfbox2-layout</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>downloader</artifactId>
         </dependency>
         <dependency>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>spdx-utils</artifactId>
         </dependency>
         <!-- ################################ testing dependencies ################################ -->

--- a/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
+++ b/core/runtime/src/main/java/org/eclipse/sw360/antenna/util/LicenseSupport.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.sw360.antenna.util;
 
-import com.here.ort.spdx.*;
+import org.ossreviewtoolkit.spdx.*;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.model.license.*;
 

--- a/modules/ort/pom.xml
+++ b/modules/ort/pom.xml
@@ -56,11 +56,11 @@
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>model</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+            <groupId>com.github.oss-review-toolkit.ort</groupId>
             <artifactId>downloader</artifactId>
         </dependency>
         <!-- ################################ testing dependencies ################################ -->

--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,14 +11,16 @@
  */
 package org.eclipse.sw360.antenna.ort.resolver
 
-import com.here.ort.model.*
-import com.here.ort.model.Package
-
 import org.eclipse.sw360.antenna.model.artifact.Artifact
 import org.eclipse.sw360.antenna.model.artifact.facts.*
 import org.eclipse.sw360.antenna.model.coordinates.Coordinate
 import org.eclipse.sw360.antenna.model.xml.generated.MatchState
 import org.eclipse.sw360.antenna.util.LicenseSupport
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.utils.collectLicenseFindings
 
 import java.io.File
 import java.util.function.Function
@@ -73,7 +76,7 @@ private fun mapHomepage(pkg: Package): ArtifactHomepage? =
     }
 
 class OrtResultArtifactResolver(result: OrtResult) : Function<Package, Artifact> {
-    private val licenseFindings = result.collectLicenseFindings(false)
+    private val licenseFindings = result.collectLicenseFindings()
 
     private fun mapObservedLicense(pkg: Package): ObservedLicenseInformation? =
         licenseFindings[pkg.id]?.keys?.map { it.license }?.let {

--- a/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
+++ b/modules/ort/src/main/kotlin/utils/ArtifactToPackageMapper.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,7 +11,7 @@
  */
 package org.eclipse.sw360.antenna.ort.utils
 
-import com.here.ort.model.*
+import org.ossreviewtoolkit.model.*
 import org.eclipse.sw360.antenna.model.artifact.Artifact
 import org.eclipse.sw360.antenna.model.artifact.ArtifactCoordinates
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceUrl

--- a/modules/ort/src/main/kotlin/workflow/analyzers/OrtResultAnalyzer.kt
+++ b/modules/ort/src/main/kotlin/workflow/analyzers/OrtResultAnalyzer.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,8 +11,8 @@
  */
 package org.eclipse.sw360.antenna.ort.workflow.analyzers
 
-import com.here.ort.model.OrtResult
-import com.here.ort.model.readValue
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.readValue
 
 import org.eclipse.sw360.antenna.api.workflow.ManualAnalyzer
 import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult

--- a/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
+++ b/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,10 +11,10 @@
  */
 package org.eclipse.sw360.antenna.ort.workflow.processors.enricher
 
-import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Downloader
-import com.here.ort.utils.encodeOrUnknown
-import com.here.ort.utils.packZip
+import org.ossreviewtoolkit.downloader.DownloadException
+import org.ossreviewtoolkit.downloader.Downloader
+import org.ossreviewtoolkit.utils.encodeOrUnknown
+import org.ossreviewtoolkit.utils.packZip
 import org.eclipse.sw360.antenna.api.exceptions.ConfigurationException
 import org.eclipse.sw360.antenna.model.artifact.Artifact
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <log4j2.version>2.13.0</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ort.rev>3f85d301f7</ort.rev>
+        <ort.rev>7daaf7c049</ort.rev>
         <cyclonedx.version>2.6.5</cyclonedx.version>
     </properties>
 
@@ -250,17 +250,17 @@
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+                <groupId>com.github.oss-review-toolkit.ort</groupId>
                 <artifactId>model</artifactId>
                 <version>${ort.rev}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+                <groupId>com.github.oss-review-toolkit.ort</groupId>
                 <artifactId>downloader</artifactId>
                 <version>${ort.rev}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.heremaps.oss-review-toolkit</groupId>
+                <groupId>com.github.oss-review-toolkit.ort</groupId>
                 <artifactId>spdx-utils</artifactId>
                 <version>${ort.rev}</version>
             </dependency>


### PR DESCRIPTION
The upgrade is required to be able read the changed ORT result files.
Several minor API changes need to be accounted for, as well as change of
package names due to the move of ORT to its own GitHub organization [1].

Also, this version of ORT includes a fix that resolves a Gradle vs. Maven
version conflict resolution issue regarding the "jsch" dependency [2].

[1] https://github.com/oss-review-toolkit/ort
[2] https://github.com/oss-review-toolkit/ort/pull/2440

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
