### PR TITLE
Add "/token" to all authentication urls

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
+++ b/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
@@ -20,7 +20,7 @@ Add the following step into the `<generators>` section of your workflow.xml
     <classHint>org.eclipse.sw360.antenna.sw360.workflow.generators.SW360Updater</classHint>
     <configuration>
         <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-        <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+        <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
         <entry key="user.id" value="admin@sw360.org"/>
         <entry key="user.password" value="12345"/>
         <entry key="client.id" value="trusted-sw360-client"/>

--- a/antenna-documentation/src/site/markdown/processors/sw360-enricher.md
+++ b/antenna-documentation/src/site/markdown/processors/sw360-enricher.md
@@ -13,7 +13,7 @@ Add the following step into the `<processors>` section of your workflow.xml
     <classHint>org.eclipse.sw360.antenna.sw360.workflow.processors.SW360Enricher</classHint>
     <configuration>
         <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-        <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+        <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
         <entry key="user.id" value="admin@sw360.org"/>
         <entry key="user.password" value="12345"/>
         <entry key="client.id" value="trusted-sw360-client"/>

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
@@ -118,7 +118,7 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
         WorkflowStep enricher = mkWorkflowStep("SW360 Enricher", "org.eclipse.sw360.antenna.sw360.workflow.processors.SW360Enricher",
                 Stream.of(new String[][] {
                         { "rest.server.url", "http://localhost:8080/resource/api" },
-                        { "auth.server.url", "http://localhost:8080/authorization/oauth" },
+                        { "auth.server.url", "http://localhost:8080/authorization/oauth/token" },
                         { "user.id", "admin@sw360.org" },
                         { "user.password", "12345" },
                         { "client.id", "trusted-sw360-client" },
@@ -141,7 +141,7 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
         WorkflowStep generator = mkWorkflowStep("SW360 Updater", "org.eclipse.sw360.antenna.sw360.workflow.generators.SW360Updater",
                 Stream.of(new String[][] {
                         { "rest.server.url", "http://localhost:8080/resource/api" },
-                        { "auth.server.url", "http://localhost:8080/authorization/oauth" },
+                        { "auth.server.url", "http://localhost:8080/authorization/oauth/token" },
                         { "user.id", "admin@sw360.org" },
                         { "user.password", "12345" },
                         { "client.id", "trusted-sw360-client" },

--- a/example-projects/example-project/src/workflow.xml
+++ b/example-projects/example-project/src/workflow.xml
@@ -44,7 +44,7 @@
             <classHint>org.eclipse.sw360.antenna.sw360.workflow.processors.SW360Enricher</classHint>
             <configuration>
                 <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
                 <entry key="user.id" value="admin@sw360.org"/>
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>
@@ -66,7 +66,7 @@
             <classHint>org.eclipse.sw360.antenna.sw360.workflow.generators.SW360Updater</classHint>
             <configuration>
                 <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
                 <entry key="user.id" value="admin@sw360.org"/>
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>

--- a/example-projects/mvn-test-project/src/workflow.xml
+++ b/example-projects/mvn-test-project/src/workflow.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+  ~ Copyright (c) Bosch.IO GmbH 2020.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0

--- a/example-projects/mvn-test-project/src/workflow.xml
+++ b/example-projects/mvn-test-project/src/workflow.xml
@@ -38,7 +38,7 @@
             <classHint>org.eclipse.sw360.antenna.sw360.workflow.processors.SW360Enricher</classHint>
             <configuration>
                 <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
                 <entry key="user.id" value="admin@sw360.org"/>
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>
@@ -60,7 +60,7 @@
             <classHint>org.eclipse.sw360.antenna.sw360.workflow.generators.SW360Updater</classHint>
             <configuration>
                 <entry key="rest.server.url" value="http://localhost:8080/resource/api"/>
-                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth"/>
+                <entry key="auth.server.url" value="http://localhost:8080/authorization/oauth/token"/>
                 <entry key="user.id" value="admin@sw360.org"/>
                 <entry key="user.password" value="12345"/>
                 <entry key="client.id" value="trusted-sw360-client"/>


### PR DESCRIPTION
Since the suffix "/token" is not added automatically
to the authentication url in the sw360authentication
client anymore, it needs to be added to the authentication
url in the configuration to work with an out of the box
locally set up sw360.

Changes were made in minimal example project, example
project, ExampleTestProject and the documentation.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch @oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  documentation update and example projects update


