### PR TITLE
Oheger bosch/sw360/bug 480 no content handling

### DIFF
--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpConstants.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpConstants.java
@@ -42,6 +42,12 @@ public final class HttpConstants {
     public static final int STATUS_ACCEPTED = 202;
 
     /**
+     * Constant for the HTTP status code 204 NO_CONTENT indicating that a
+     * request has a null body.
+     */
+    public static final int STATUS_NO_CONTENT = 204;
+
+    /**
      * Constant for the HTTP status code 400 BAD REQUEST indicating a general
      * problem with a request sent by a client.
      */

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -86,8 +86,8 @@ public class SW360ComponentClient extends SW360Client {
      * @return a future with a list with all existing components
      */
     public CompletableFuture<List<SW360SparseComponent>> getComponents() {
-        return executeJsonRequest(HttpUtils.get(resourceUrl(COMPONENTS_ENDPOINT)), SW360ComponentList.class,
-                TAG_GET_COMPONENTS)
+        return executeJsonRequestWithDefault(HttpUtils.get(resourceUrl(COMPONENTS_ENDPOINT)), SW360ComponentList.class,
+                TAG_GET_COMPONENTS, SW360ComponentList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseComponents);
     }
 
@@ -101,7 +101,8 @@ public class SW360ComponentClient extends SW360Client {
     public CompletableFuture<List<SW360SparseComponent>> searchByName(String name) {
         String url = HttpUtils.addQueryParameter(resourceUrl(COMPONENTS_ENDPOINT),
                 SW360Attributes.COMPONENT_SEARCH_BY_NAME, name);
-        return executeJsonRequest(HttpUtils.get(url), SW360ComponentList.class, TAG_GET_COMPONENTS_BY_NAME)
+        return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ComponentList.class,
+                TAG_GET_COMPONENTS_BY_NAME, SW360ComponentList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseComponents);
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClient.java
@@ -60,8 +60,8 @@ public class SW360LicenseClient extends SW360Client {
      * @return a future with the list of licenses
      */
     public CompletableFuture<List<SW360SparseLicense>> getLicenses() {
-        return executeJsonRequest(HttpUtils.get(resourceUrl(LICENSES_ENDPOINT)), SW360LicenseList.class,
-                TAG_GET_LICENSES)
+        return executeJsonRequestWithDefault(HttpUtils.get(resourceUrl(LICENSES_ENDPOINT)), SW360LicenseList.class,
+                TAG_GET_LICENSES, SW360LicenseList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseLicenses);
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClient.java
@@ -77,7 +77,8 @@ public class SW360ProjectClient extends SW360Client {
     public CompletableFuture<List<SW360Project>> searchByName(String name) {
         String queryUrl = HttpUtils.addQueryParameter(resourceUrl(PROJECTS_ENDPOINT),
                 SW360Attributes.PROJECT_SEARCH_BY_NAME, name);
-        return executeJsonRequest(HttpUtils.get(queryUrl), SW360ProjectList.class, TAG_GET_BY_NAME)
+        return executeJsonRequestWithDefault(HttpUtils.get(queryUrl), SW360ProjectList.class,
+                TAG_GET_BY_NAME, SW360ProjectList::new)
                 .thenApply(SW360ResourceUtils::getSw360Projects);
     }
 
@@ -122,7 +123,8 @@ public class SW360ProjectClient extends SW360Client {
         String uri = HttpUtils.addQueryParameter(resourceUrl(PROJECTS_ENDPOINT, projectId,
                 SW360Attributes.PROJECT_RELEASES),
                 SW360Attributes.PROJECT_RELEASES_TRANSITIVE, transitive);
-        return executeJsonRequest(HttpUtils.get(uri), SW360ReleaseList.class, TAG_GET_LINKED_RELEASES)
+        return executeJsonRequestWithDefault(HttpUtils.get(uri), SW360ReleaseList.class,
+                TAG_GET_LINKED_RELEASES, SW360ReleaseList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseReleases);
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClient.java
@@ -97,7 +97,8 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
     // but can change in the order of the values
     public CompletableFuture<List<SW360SparseRelease>> getReleasesByExternalIds(Map<String, ?> externalIds) {
         String url = getExternalIdUrl(externalIds);
-        return executeJsonRequest(HttpUtils.get(url), SW360ReleaseList.class, TAG_GET_RELEASES_BY_EXTERNAL_IDS)
+        return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ReleaseList.class,
+                TAG_GET_RELEASES_BY_EXTERNAL_IDS, SW360ReleaseList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseReleases);
     }
 

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -73,11 +74,20 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
     }
 
     @Test
-    public void testGetComponentsNoContent() {
+    public void testGetComponentsNoBody() {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
 
         extractException(componentClient.getComponents(), IOException.class);
+    }
+
+    @Test
+    public void testGetComponentsStatusNoContent() throws IOException {
+        wireMockRule.stubFor(get(urlPathEqualTo("/components"))
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360SparseComponent> components = waitFor(componentClient.getComponents());
+        assertThat(components).isEmpty();
     }
 
     @Test
@@ -110,6 +120,15 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
 
         List<SW360SparseComponent> components = waitFor(componentClient.searchByName("foo"));
         assertThat(components).hasSize(0);
+    }
+
+    @Test
+    public void testSearchByNameStatusNoContent() throws IOException {
+        wireMockRule.stubFor(get(anyUrl())
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360SparseComponent> components = waitFor(componentClient.searchByName("test"));
+        assertThat(components).isEmpty();
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClientIT.java
@@ -70,6 +70,15 @@ public class SW360LicenseClientIT extends AbstractMockServerTest {
     }
 
     @Test
+    public void testGetLicensesStatusNoContent() throws IOException {
+        wireMockRule.stubFor(get(urlPathEqualTo("/licenses"))
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360SparseLicense> licenses = waitFor(licenseClient.getLicenses());
+        assertThat(licenses).isEmpty();
+    }
+
+    @Test
     public void testGetLicensesError() {
         wireMockRule.stubFor(get(urlPathEqualTo("/licenses"))
                 .willReturn(aJsonResponse(HttpConstants.STATUS_ERR_BAD_REQUEST)));

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClientIT.java
@@ -77,11 +77,20 @@ public class SW360ProjectClientIT extends AbstractMockServerTest {
     }
 
     @Test
-    public void testSearchByNameNoContent() {
+    public void testSearchByNameEmptyResult() {
         wireMockRule.stubFor(get(urlPathEqualTo("/projects"))
                 .willReturn(aResponse().withStatus(HttpConstants.STATUS_ACCEPTED)));
 
         extractException(projectClient.searchByName("foo"), IOException.class);
+    }
+
+    @Test
+    public void testSearchByNameNoContent() throws IOException {
+        wireMockRule.stubFor(get(urlPathEqualTo("/projects"))
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360Project> projects = waitFor(projectClient.searchByName("some project"));
+        assertThat(projects).isEmpty();
     }
 
     @Test
@@ -169,5 +178,14 @@ public class SW360ProjectClientIT extends AbstractMockServerTest {
                 expectFailedRequest(projectClient.getLinkedReleases("projectID", false),
                         HttpConstants.STATUS_ERR_BAD_REQUEST);
         assertThat(exception.getTag()).isEqualTo(SW360ProjectClient.TAG_GET_LINKED_RELEASES);
+    }
+
+    @Test
+    public void testGetLinkedReleasesNoContent() throws IOException {
+        wireMockRule.stubFor(get(anyUrl())
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360SparseRelease> releases = waitFor(projectClient.getLinkedReleases(PROJECT_NAMES[0], false));
+        assertThat(releases).isEmpty();
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClientIT.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -112,6 +113,15 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
 
         List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(idMap));
         checkReleaseData(releases);
+    }
+
+    @Test
+    public void testGetReleasesByExternalIdsStatusNoContent() throws IOException {
+        wireMockRule.stubFor(get(urlPathEqualTo("/releases/searchByExternalIds"))
+                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
+
+        List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(new HashMap<>()));
+        assertThat(releases).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Issue #480 
This PR deals with changes in the SW360 REST API related to status codes for query requests: If a request does not yield results, the response has status code 204 (no content) and no response body.

The solution assumes that a no content response is valid only for queries that result in empty lists. Other requests, e.g. POSTs for creating new entities, should always return a body. Therefore, the solution does not implement a central handling of the 204 status, but there is now a new method in SW360Client for sending requests which checks for the 204 response status and returns a default object (typically an empty list) in this case. The concrete SW360 client implementations are responsible of using the correct method for their queries; they have been updated accordingly in this PR.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
bug fix

### How Has This Been Tested?
For each query of a client that may yield a 204 response, a test case has been added.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
