### PR TITLE
Allow unverified access to ssl resource

### DIFF
--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
@@ -41,7 +41,20 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
             Proxy proxy = createProxy(config.proxySettings());
             builder.proxy(proxy);
         }
+        if (unverifiedSSLCertificate()) {
+            builder.hostnameVerifier((s, sslSession) -> true);
+        }
         return builder.build();
+    }
+
+    /**
+     * Using the Property "sw360.client.access.unverified", the connection to
+     * SW360 can be done without verification of the ssl certificate
+     *
+     * @return True, if the client access to SW360 should be done with a self-certified call
+     */
+    private static boolean unverifiedSSLCertificate() {
+        return "true".equalsIgnoreCase(System.getProperty("sw360.client.access.unverified", "false"));
     }
 
     /**

--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
@@ -24,6 +24,12 @@ import java.net.Proxy;
  * </p>
  */
 public class HttpClientFactoryImpl implements HttpClientFactory {
+
+    /**
+     * Property to switch access to not verify the certificates
+     */
+    static final String CLIENT_ACCESS_UNVERIFIED_PROPERTY = "client.access.unverified";
+
     @Override
     public HttpClient newHttpClient(HttpClientConfig config) {
         return new HttpClientImpl(createClient(config), config.getOrCreateObjectMapper());
@@ -48,13 +54,13 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
     }
 
     /**
-     * Using the Property "sw360.client.access.unverified", the connection to
-     * SW360 can be done without verification of the ssl certificate
+     * Using the Property CLIENT_ACCESS_UNVERIFIED_PROPERTY, the connection to
+     * the client can be done without verification of the ssl certificate
      *
-     * @return True, if the client access to SW360 should be done with a self-certified call
+     * @return True, if the client access should be done with a self-certified call
      */
     private static boolean unverifiedSSLCertificate() {
-        return "true".equalsIgnoreCase(System.getProperty("sw360.client.access.unverified", "false"));
+        return Boolean.parseBoolean(System.getProperty(CLIENT_ACCESS_UNVERIFIED_PROPERTY));
     }
 
     /**

--- a/http-support/src/site/markdown/index.md.vm
+++ b/http-support/src/site/markdown/index.md.vm
@@ -70,7 +70,9 @@ The properties that can be changed in a client configuration are the following:
 * Proxy settings: Requests can be routed through an HTTP proxy. For this 
   purpose, the _ProxySettings_ class exists that collects the properties of the
   proxy server.
-  
+* SSL Certificate Verification: Dynmically, ssl certificate verification can be
+  disabled by setting the system property _client.access.unverified_ to true.
+
 Below is a code fragment that shows the construction of an _HttpClientConfig_ 
 instance and the creation of a new HTTP client based on this configuration. For
 this example we use a very verbose configuration that sets all the properties

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImplTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImplTest.java
@@ -74,4 +74,19 @@ public class HttpClientFactoryImplTest {
         assertThat(address.getPort()).isEqualTo(port);
         assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     }
+
+    @Test
+    public void testNewClientWithoutCertificateCheck() {
+        try {
+            System.setProperty(HttpClientFactoryImpl.CLIENT_ACCESS_UNVERIFIED_PROPERTY, "true");
+            ObjectMapper mapper = mock(ObjectMapper.class);
+            HttpClientConfig config = HttpClientConfig.basicConfig()
+                    .withObjectMapper(mapper);
+
+            HttpClientImpl client = createClient(config);
+            assertThat(client.getClient().hostnameVerifier().verify("", null)).isTrue();
+        } finally {
+            System.clearProperty(HttpClientFactoryImpl.CLIENT_ACCESS_UNVERIFIED_PROPERTY);
+        }
+    }
 }


### PR DESCRIPTION
Needed for example to access SW360 in a local instance that has a self certificate.

### Request Reviewer
@oheger-bosch 

### Type of Change
*Type of change*:  Improvement

### How Has This Been Tested?
Additional test has been added.

### Checklist
Must:
- [x] All related issues are referenced in commit messages
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
