### PR TITLE
Add categories as a field to components

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/components/SW360Component.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/components/SW360Component.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018-2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,12 +19,15 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.SW360HalResourceUtility;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 public class SW360Component extends SW360HalResource<LinkObjects, SW360ComponentEmbedded> {
     private String name;
     private SW360ComponentType componentType;
     private String createdOn;
     private String homepage;
+
+    private Set<String> categories;
 
     @JsonIgnore
     public String getComponentId() {
@@ -70,6 +74,16 @@ public class SW360Component extends SW360HalResource<LinkObjects, SW360Component
 
     public SW360Component setHomepage(String homepage) {
         this.homepage = homepage;
+        return this;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Set<String> getCategories() {
+        return categories;
+    }
+
+    public SW360Component setCategories(Set<String> categories) {
+        this.categories = categories;
         return this;
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtils.java
@@ -15,6 +15,8 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 
+import java.util.Collections;
+
 public class SW360ComponentAdapterUtils {
 
     private SW360ComponentAdapterUtils() {}
@@ -31,10 +33,14 @@ public class SW360ComponentAdapterUtils {
         SW360Component sw360Component = new SW360Component();
         sw360Component.setName(release.getName());
         setComponentType(sw360Component, release.isProprietary());
+        sw360Component.setCategories(Collections.singleton("Antenna"));
         return sw360Component;
     }
 
     public static boolean isValidComponent(SW360Component component) {
-        return component.getName() != null && !component.getName().isEmpty();
+        return component.getName() != null &&
+                !component.getName().isEmpty() &&
+                component.getCategories() != null &&
+                !component.getCategories().isEmpty();
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapterTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ComponentClientAdapterTest.java
@@ -84,6 +84,7 @@ public class SW360ComponentClientAdapterTest {
         SW360Component componentFromRelease = mock(SW360Component.class);
         when(componentFromRelease.getComponentId()).thenReturn(null);
         when(componentFromRelease.getName()).thenReturn(COMPONENT_NAME);
+        when(componentFromRelease.getCategories()).thenReturn(Collections.singleton("Antenna"));
         when(componentClient.searchByName(COMPONENT_NAME))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         when(componentClient.createComponent(componentFromRelease))
@@ -96,6 +97,7 @@ public class SW360ComponentClientAdapterTest {
     @Test
     public void testCreateComponent() {
         component.setName(COMPONENT_NAME);
+        component.setCategories(Collections.singleton("Antenna"));
         when(componentClient.createComponent(component))
                 .thenReturn(CompletableFuture.completedFuture(component));
 

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtilsTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/utils/SW360ComponentAdapterUtilsTest.java
@@ -16,6 +16,8 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.components.SW360ComponentTy
 import org.eclipse.sw360.antenna.sw360.rest.resource.releases.SW360Release;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SW360ComponentAdapterUtilsTest {
@@ -56,6 +58,7 @@ public class SW360ComponentAdapterUtilsTest {
     public void testIsValidComponentWithValidComponent() {
         SW360Component component = new SW360Component();
         component.setName("test");
+        component.setCategories(Collections.singleton("Antenna"));
 
         boolean validComponent = SW360ComponentAdapterUtils.isValidComponent(component);
 


### PR DESCRIPTION
Issue: #489

Since sw360 has added a check for categories when adding or
updating components, the field categories needed to be added
to components.

When checking if a component is valid a check for categories
was added.

Categories were added to the tests.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Unit tests were adapted.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
