### PR TITLE
Fix creation of working directory of attribution document generator

### DIFF
--- a/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
+++ b/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/AttributionDocumentGenerator.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.sw360.antenna.api.Attachable;
 import org.eclipse.sw360.antenna.api.IAttachable;
-import org.eclipse.sw360.antenna.api.exceptions.ConfigurationException;
 import org.eclipse.sw360.antenna.api.workflow.AbstractGenerator;
 import org.eclipse.sw360.antenna.api.workflow.ProcessingState;
 import org.eclipse.sw360.antenna.attribution.document.core.AttributionDocumentGeneratorImpl;
@@ -110,7 +109,7 @@ public class AttributionDocumentGenerator extends AbstractGenerator {
    private File createWorkDir(Path antennaDir) {
       File workDir = new File(antennaDir.toFile(), WORKING_DIR_NAME);
       if (!workDir.mkdirs()) {
-         throw new ConfigurationException("Unable to create working directory in path " + workDir);
+         LOG.debug("The working directory {} already exists. The existing files will be overwritten.", workDir);
       }
       return workDir;
    }


### PR DESCRIPTION
After running Antenna twice without cleaning the build directory, it
threw an exception and broke the build. Now it writes a debug message.

### Request Reviewer
@blaumeiser-at-bosch 

### Type of Change
*bug fix *  
