### PR TITLE
Add attachment merging to SW360Release mergeWith()

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -83,7 +83,7 @@ public class SW360Exporter {
     }
 
     private Set<SW360SparseAttachment> getSparseAttachmentsSource(SW360Release release) {
-        List<SW360SparseAttachment> attachments = release.get_Embedded().getAttachments();
+        Set<SW360SparseAttachment> attachments = release.get_Embedded().getAttachments();
 
         return attachments.stream()
                 .filter(attachment -> attachment.getAttachmentType() == SW360AttachmentType.SOURCE)

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360TestUtils.java
@@ -78,7 +78,7 @@ public class SW360TestUtils {
     private static SW360ReleaseEmbedded mkReleaseEmbedded() {
         SW360ReleaseEmbedded sw360ReleaseEmbedded = new SW360ReleaseEmbedded();
         sw360ReleaseEmbedded.setAttachments
-                (Collections.singletonList(new SW360SparseAttachment().setAttachmentType(SW360AttachmentType.SOURCE)));
+                (Collections.singleton(new SW360SparseAttachment().setAttachmentType(SW360AttachmentType.SOURCE)));
         return sw360ReleaseEmbedded;
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapter.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils.block;
 import static org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils.optionalFuture;
@@ -102,7 +103,7 @@ public class SW360ReleaseClientAdapter {
         return sw360item;
     }
 
-    private boolean attachmentIsPotentialDuplicate(Path attachment, List<SW360SparseAttachment> attachments) {
+    private boolean attachmentIsPotentialDuplicate(Path attachment, Set<SW360SparseAttachment> attachments) {
         return attachments.stream()
                 .anyMatch(attachment1 -> attachment1.getFilename().equals(attachment.getFileName().toString()));
     }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360AttachmentSetEmbedded.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360AttachmentSetEmbedded.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,24 +16,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.eclipse.sw360.antenna.sw360.rest.resource.Embedded;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
-@JsonDeserialize(as = SW360AttachmentListEmbedded.class)
-public class SW360AttachmentListEmbedded implements Embedded {
+@JsonDeserialize(as = SW360AttachmentSetEmbedded.class)
+public class SW360AttachmentSetEmbedded implements Embedded {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("sw360:attachments")
-    private List<SW360SparseAttachment> attachments;
+    private Set<SW360SparseAttachment> attachments;
 
-    public List<SW360SparseAttachment> getAttachments() {
+    public Set<SW360SparseAttachment> getAttachments() {
         return Optional.ofNullable(attachments)
-                .map(ArrayList::new)
-                .orElse(new ArrayList<>());
+                .map(HashSet::new)
+                .orElse(new HashSet<>());
     }
 
-    public SW360AttachmentListEmbedded setAttachments(List<SW360SparseAttachment> attachments) {
+    public SW360AttachmentSetEmbedded setAttachments(Set<SW360SparseAttachment> attachments) {
         this.attachments = attachments;
         return this;
     }
@@ -41,7 +42,7 @@ public class SW360AttachmentListEmbedded implements Embedded {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SW360AttachmentListEmbedded that = (SW360AttachmentListEmbedded) o;
+        SW360AttachmentSetEmbedded that = (SW360AttachmentSetEmbedded) o;
         return Objects.equals(attachments, that.attachments);
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -341,8 +341,8 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
             get_Links().setSelfComponent(componentIdWithPrecedence);
         }
         final List<SW360SparseAttachment> releaseWithPrecedenceAttachments = releaseWithPrecedence.get_Embedded().getAttachments();
-        if (releaseWithPrecedenceAttachments != null && !releaseWithPrecedenceAttachments.isEmpty()) {
-            if (get_Embedded().getAttachments() == null || get_Embedded().getAttachments().isEmpty()) {
+        if (!releaseWithPrecedenceAttachments.isEmpty()) {
+            if (get_Embedded().getAttachments().isEmpty()) {
                 get_Embedded().setAttachments(releaseWithPrecedenceAttachments);
             } else {
                 get_Embedded().setAttachments(mergeAttachments(get_Embedded().getAttachments(), releaseWithPrecedenceAttachments));

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360Release.java
@@ -26,7 +26,6 @@ import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360SparseLicense
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW360ReleaseEmbedded> {
 
@@ -340,7 +339,7 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
         if (componentIdWithPrecedence != null && !componentIdWithPrecedence.getHref().isEmpty()) {
             get_Links().setSelfComponent(componentIdWithPrecedence);
         }
-        final List<SW360SparseAttachment> releaseWithPrecedenceAttachments = releaseWithPrecedence.get_Embedded().getAttachments();
+        final Set<SW360SparseAttachment> releaseWithPrecedenceAttachments = releaseWithPrecedence.get_Embedded().getAttachments();
         if (!releaseWithPrecedenceAttachments.isEmpty()) {
             if (get_Embedded().getAttachments().isEmpty()) {
                 get_Embedded().setAttachments(releaseWithPrecedenceAttachments);
@@ -354,10 +353,9 @@ public class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects, SW36
         return this;
     }
 
-    private List<SW360SparseAttachment> mergeAttachments(List<SW360SparseAttachment> attachments, List<SW360SparseAttachment> releaseWithPrecedenceAttachments) {
-        return Stream.concat(attachments.stream(), releaseWithPrecedenceAttachments.stream())
-                .distinct()
-                .collect(Collectors.toList());
+    private Set<SW360SparseAttachment> mergeAttachments(Set<SW360SparseAttachment> attachments, Set<SW360SparseAttachment> releaseWithPrecedenceAttachments) {
+        attachments.addAll(releaseWithPrecedenceAttachments);
+        return attachments;
     }
 
     private <T> T getDominantGetterFromVariableMergeOrNull(SW360Release release, Function<SW360Release, T> getter) {

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseEmbedded.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseEmbedded.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,30 +14,27 @@ package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentListEmbedded;
+import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentSetEmbedded;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.rest.resource.licenses.SW360LicenseListEmbedded;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 @JsonDeserialize(as = SW360ReleaseEmbedded.class)
 public class SW360ReleaseEmbedded extends SW360LicenseListEmbedded {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("sw360:attachments")
-    private List<SW360SparseAttachment> attachments;
+    private Set<SW360SparseAttachment> attachments;
 
-    public List<SW360SparseAttachment> getAttachments() {
+    public Set<SW360SparseAttachment> getAttachments() {
         return Optional.ofNullable(attachments)
-                .map(ArrayList::new)
-                .orElse(new ArrayList<>());
+                .map(HashSet::new)
+                .orElse(new HashSet<>());
     }
 
-    public SW360AttachmentListEmbedded setAttachments(List<SW360SparseAttachment> attachments) {
+    public SW360AttachmentSetEmbedded setAttachments(Set<SW360SparseAttachment> attachments) {
         this.attachments = attachments;
-        return new SW360AttachmentListEmbedded().setAttachments(attachments);
+        return new SW360AttachmentSetEmbedded().setAttachments(attachments);
     }
 
     @Override

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapterTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/adapter/SW360ReleaseClientAdapterTest.java
@@ -35,11 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class SW360ReleaseClientAdapterTest {
     private static final String RELEASE_DOWNLOAD_URL = "https://organisation-test.org/";
@@ -123,7 +119,7 @@ public class SW360ReleaseClientAdapterTest {
     @Test
     public void testUploadAttachments() {
         SW360ReleaseEmbedded sw360ReleaseEmbedded = new SW360ReleaseEmbedded();
-        sw360ReleaseEmbedded.setAttachments(Collections.emptyList());
+        sw360ReleaseEmbedded.setAttachments(Collections.emptySet());
         release.set_Embedded(sw360ReleaseEmbedded);
 
         SW360AttachmentType attachmentType = SW360AttachmentType.SOURCE;

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360AttachmentSetEmbeddedTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/attachments/SW360AttachmentSetEmbeddedTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.rest.resource.attachments;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SW360AttachmentSetEmbeddedTest {
+
+
+    private SW360SparseAttachment sparseAttachment;
+
+    @Before
+    public void setUp() {
+        sparseAttachment = new SW360SparseAttachment()
+                .setFilename("test")
+                .setAttachmentType(SW360AttachmentType.SOURCE);
+    }
+
+    @Test
+    public void testGetAttachmentsWithNoAttachments() {
+        SW360AttachmentSetEmbedded sw360AttachmentSetEmbedded = new SW360AttachmentSetEmbedded();
+
+        final Set<SW360SparseAttachment> attachments = sw360AttachmentSetEmbedded.getAttachments();
+        assertThat(attachments).isNotNull();
+        assertThat(attachments).isEmpty();
+    }
+
+    @Test
+    public void testGetAttchmentsWithAttachments() {
+        SW360AttachmentSetEmbedded sw360AttachmentSetEmbedded = new SW360AttachmentSetEmbedded()
+                .setAttachments(Collections.singleton(sparseAttachment));
+
+        final Set<SW360SparseAttachment> attachments = sw360AttachmentSetEmbedded.getAttachments();
+        assertThat(attachments).containsExactly(sparseAttachment);
+    }
+
+    @Test
+    public void testEqualsWithIdentical() {
+        SW360AttachmentSetEmbedded first = new SW360AttachmentSetEmbedded();
+        first.setAttachments(Collections.singleton(sparseAttachment));
+
+        SW360AttachmentSetEmbedded second = new SW360AttachmentSetEmbedded();
+        second.setAttachments(Collections.singleton(sparseAttachment));
+
+        assertThat(second.equals(first)).isTrue();
+    }
+
+    @Test
+    public void testEqualsWithNonIdentical() {
+        SW360AttachmentSetEmbedded first = new SW360AttachmentSetEmbedded();
+        first.setAttachments(Collections.singleton(sparseAttachment));
+
+        SW360AttachmentSetEmbedded second = new SW360AttachmentSetEmbedded();
+
+        assertThat(second.equals(first)).isFalse();
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,6 +11,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.rest.resource.releases;
 
+import org.eclipse.sw360.antenna.sw360.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.rest.resource.SW360ResourcesTestUtils;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     @Override
@@ -54,6 +57,12 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     @Override
     public Class<SW360Release> getHandledClassType() {
         return SW360Release.class;
+    }
+
+    private static SW360SparseAttachment makeSparseAttachment(String test) {
+        return new SW360SparseAttachment()
+                .setAttachmentType(SW360AttachmentType.SOURCE)
+                .setFilename(test);
     }
 
     @Test
@@ -92,5 +101,119 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         sw360Release1.mergeWith(sw360Release2);
 
         assertThat(sw360Release1.getCpeId()).isNotEqualTo(sw360Release2.getCpeId());
+    }
+
+    @Test
+    public void testReleaseMergeWithPrecedenceHasAttachment() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.createEmptyEmbedded();
+        sw360Release2.createEmptyEmbedded();
+
+        final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
+
+        sw360Release2.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.get_Embedded().getAttachments()).containsExactly(sw360SparseAttachment);
+    }
+
+    @Test
+    public void testReleaseMergeWithPrecedenceHasNoAttachment() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.createEmptyEmbedded();
+        sw360Release2.createEmptyEmbedded();
+
+        final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
+
+        sw360Release1.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.get_Embedded().getAttachments()).containsExactly(sw360SparseAttachment);
+
+    }
+
+    @Test
+    public void testReleaseMergeWithBothHaveSameAttachment() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.createEmptyEmbedded();
+        sw360Release2.createEmptyEmbedded();
+
+        SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
+
+        sw360Release1.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360Release2.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.get_Embedded().getAttachments()).containsExactly(sw360SparseAttachment);
+    }
+
+    @Test
+    public void testReleaseMergeWithBothHaveSameAttachmentButOneHasHref() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.createEmptyEmbedded();
+        sw360Release2.createEmptyEmbedded();
+
+        SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
+
+        sw360Release1.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360SparseAttachment.set_Links(mock(LinkObjects.class));
+
+        sw360Release2.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment));
+
+        sw360SparseAttachment.set_Links(null);
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.get_Embedded().getAttachments()).containsExactly(sw360SparseAttachment);
+    }
+
+    @Test
+    public void testReleaseMergeWithBothHaveDifferentAttachment() {
+        SW360Release sw360Release1 = new SW360Release();
+        SW360Release sw360Release2 = new SW360Release();
+
+        sw360Release1.createEmptyEmbedded();
+        sw360Release2.createEmptyEmbedded();
+
+        final SW360SparseAttachment sw360SparseAttachment1 = makeSparseAttachment("test_1");
+
+        sw360Release1.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment1));
+
+        final SW360SparseAttachment sw360SparseAttachment2 = makeSparseAttachment("test_2");
+
+        sw360Release2.get_Embedded().setAttachments(
+                Collections.singletonList(
+                        sw360SparseAttachment2));
+
+        sw360Release1.mergeWith(sw360Release2);
+
+        assertThat(sw360Release1.get_Embedded().getAttachments()).hasSize(2);
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
@@ -108,9 +108,6 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         SW360Release sw360Release1 = new SW360Release();
         SW360Release sw360Release2 = new SW360Release();
 
-        sw360Release1.createEmptyEmbedded();
-        sw360Release2.createEmptyEmbedded();
-
         final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
         sw360Release2.get_Embedded().setAttachments(
@@ -126,9 +123,6 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     public void testReleaseMergeWithPrecedenceHasNoAttachment() {
         SW360Release sw360Release1 = new SW360Release();
         SW360Release sw360Release2 = new SW360Release();
-
-        sw360Release1.createEmptyEmbedded();
-        sw360Release2.createEmptyEmbedded();
 
         final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
@@ -146,9 +140,6 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     public void testReleaseMergeWithBothHaveSameAttachment() {
         SW360Release sw360Release1 = new SW360Release();
         SW360Release sw360Release2 = new SW360Release();
-
-        sw360Release1.createEmptyEmbedded();
-        sw360Release2.createEmptyEmbedded();
 
         SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
@@ -169,9 +160,6 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     public void testReleaseMergeWithBothHaveSameAttachmentButOneHasHref() {
         SW360Release sw360Release1 = new SW360Release();
         SW360Release sw360Release2 = new SW360Release();
-
-        sw360Release1.createEmptyEmbedded();
-        sw360Release2.createEmptyEmbedded();
 
         SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
@@ -196,9 +184,6 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
     public void testReleaseMergeWithBothHaveDifferentAttachment() {
         SW360Release sw360Release1 = new SW360Release();
         SW360Release sw360Release2 = new SW360Release();
-
-        sw360Release1.createEmptyEmbedded();
-        sw360Release2.createEmptyEmbedded();
 
         final SW360SparseAttachment sw360SparseAttachment1 = makeSparseAttachment("test_1");
 

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/rest/resource/releases/SW360ReleaseTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,9 +39,9 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         release.setReleaseId("RELEASE_ID");
         release.setComponentId("COMPONENT_ID");
         release.setMainLicenseIds(Stream.of("MIT","BSD-3-Clause").collect(Collectors.toSet()));
-        ArrayList<SW360SparseAttachment> sparseAttachmentList = new ArrayList<>();
-        sparseAttachmentList.add(new SW360SparseAttachment().setFilename("").setAttachmentType(SW360AttachmentType.SOURCE));
-        release.get_Embedded().setAttachments(sparseAttachmentList);
+        Set<SW360SparseAttachment> sparseAttachmentSet = new HashSet<>();
+        sparseAttachmentSet.add(new SW360SparseAttachment().setFilename("").setAttachmentType(SW360AttachmentType.SOURCE));
+        release.get_Embedded().setAttachments(sparseAttachmentSet);
         release.setSw360ClearingState(SW360ClearingState.NEW_CLEARING);
         release.setClearingState("INITIAL");
         return release;
@@ -111,7 +113,7 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
         sw360Release2.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360Release1.mergeWith(sw360Release2);
@@ -127,7 +129,7 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         final SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
         sw360Release1.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360Release1.mergeWith(sw360Release2);
@@ -144,11 +146,11 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
         sw360Release1.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360Release2.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360Release1.mergeWith(sw360Release2);
@@ -164,13 +166,13 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         SW360SparseAttachment sw360SparseAttachment = makeSparseAttachment("test");
 
         sw360Release1.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360SparseAttachment.set_Links(mock(LinkObjects.class));
 
         sw360Release2.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment));
 
         sw360SparseAttachment.set_Links(null);
@@ -188,13 +190,13 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         final SW360SparseAttachment sw360SparseAttachment1 = makeSparseAttachment("test_1");
 
         sw360Release1.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment1));
 
         final SW360SparseAttachment sw360SparseAttachment2 = makeSparseAttachment("test_2");
 
         sw360Release2.get_Embedded().setAttachments(
-                Collections.singletonList(
+                Collections.singleton(
                         sw360SparseAttachment2));
 
         sw360Release1.mergeWith(sw360Release2);

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherImpl.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherImpl.java
@@ -30,10 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class SW360EnricherImpl {
@@ -74,7 +71,7 @@ public class SW360EnricherImpl {
     }
 
     private void downloadAttachments(SW360Release sw360Release, Artifact artifact) {
-        List<SW360SparseAttachment> attachments = sw360Release.get_Embedded().getAttachments();
+        Set<SW360SparseAttachment> attachments = sw360Release.get_Embedded().getAttachments();
 
         attachments.stream()
                 .filter(attachment -> attachment.getAttachmentType() == SW360AttachmentType.SOURCE)

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImplTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImplTest.java
@@ -68,11 +68,11 @@ public class SW360UpdaterImplTest {
 
         Map<Path, SW360AttachmentType> attachmentsFromArtifact = ArtifactToAttachmentUtils.getAttachmentsFromArtifact(artifact);
 
-        List<SW360SparseAttachment> sparseAttachments = attachmentsFromArtifact.entrySet().stream()
+        Set<SW360SparseAttachment> sparseAttachments = attachmentsFromArtifact.entrySet().stream()
                 .map(entry -> new SW360SparseAttachment()
                         .setAttachmentType(entry.getValue())
                         .setFilename(entry.getKey().toString()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
 
         SW360ReleaseEmbedded sw360ReleaseEmbedded = new SW360ReleaseEmbedded();
         sw360ReleaseEmbedded.setAttachments(sparseAttachments);

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/workflow/processors/SW360EnricherTest.java
@@ -154,7 +154,7 @@ public class SW360EnricherTest extends AntennaTestWithMockedContext {
                 .setAttachmentType(SW360AttachmentType.SOURCE)
                 .setFilename(downloadFilename);
         SW360ReleaseEmbedded releaseEmbedded = new SW360ReleaseEmbedded();
-        releaseEmbedded.setAttachments(Collections.singletonList(sparseAttachment));
+        releaseEmbedded.setAttachments(Collections.singleton(sparseAttachment));
         SW360Release release0 = new SW360Release();
         release0.set_Embedded(releaseEmbedded);
 


### PR DESCRIPTION
Issue: #494

Since attachments are part of a release they should be
merged along with everything else in the mergeWith method.

Now when checking the merged release in the
hasDuplicateAttachments method, attachments won't be empty
if there were any in the fetched release.

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Unit tests were added
Additionally this should be tested with the entry update_releases set to false in the SW360UpdaterImpl. The example project should be run twice, since the error is one that occurs when trying to upload a duplicate attachment. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
