### PR TITLE
Fixed a NPE in SW360Updater; changed creation of helper objects.

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/main/AntennaComplianceTool.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/main/AntennaComplianceTool.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.main;
 
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.exporter.SW360Exporter;
+import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater.ClearingReportGenerator;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater.SW360Updater;
 import org.eclipse.sw360.antenna.sw360.SW360MetaDataUpdater;
 import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
@@ -42,10 +43,10 @@ public class AntennaComplianceTool {
     private int execute(String mode, Path propertiesFile) {
         switch (mode) {
             case "exporter":
-                init(new SW360Exporter(), propertiesFile).execute();
+                createExporter(propertiesFile).execute();
                 return 0;
             case "updater":
-                init(new SW360Updater(), propertiesFile).execute();
+                createUpdater(propertiesFile).execute();
                 return 0;
             default:
                 LOGGER.error("You did not supply any compliance task.");
@@ -53,25 +54,23 @@ public class AntennaComplianceTool {
         }
     }
 
-    private SW360Exporter init(SW360Exporter executor, Path propertiesFile) {
+    private SW360Exporter createExporter(Path propertiesFile) {
         SW360Configuration configuration = new SW360Configuration(propertiesFile.toFile());
-        executor.setConfiguration(configuration);
-        return executor;
+        return new SW360Exporter(configuration);
     }
 
-    private SW360Updater init(SW360Updater executor, Path propertiesFile) {
+    private SW360Updater createUpdater(Path propertiesFile) {
         SW360Configuration configuration = new SW360Configuration(propertiesFile.toFile());
-        executor.setConfiguration(configuration);
 
-        executor.setUpdater(new SW360UpdaterImpl(new SW360MetaDataUpdater(
+        SW360UpdaterImpl updaterImpl = new SW360UpdaterImpl(new SW360MetaDataUpdater(
                 configuration.getConnection(),
                 configuration.getBooleanConfigValue("sw360updateReleases"),
                 configuration.getBooleanConfigValue("sw360uploadSources")),
                 "redundant project name",
-                "redundant project version"));
+                "redundant project version");
         // since we only use the updaters functionality to handle individual releases,
         // we do not need to give a project name or version.
 
-        return executor;
+        return new SW360Updater(updaterImpl, configuration, new ClearingReportGenerator());
     }
 }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -40,11 +40,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class SW360Exporter {
-    private SW360Configuration configuration;
+    private final SW360Configuration configuration;
     private SW360Connection connection;
 
-    public void setConfiguration(SW360Configuration configuration) {
-        this.configuration = configuration;
+    public SW360Exporter(SW360Configuration configuration) {
+        this.configuration = Objects.requireNonNull(configuration, "Configuration must not be null");
     }
 
     public void execute() {

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-class ClearingReportGenerator {
+public class ClearingReportGenerator {
     private static final String CLEARING_DOC_SUFFIX = "_clearing.json";
 
     Path createClearingDocument(SW360Release release, Path targetDir) {

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -23,24 +23,20 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils.getArtifactsFromCsvFile;
 
 public class SW360Updater {
-    private SW360UpdaterImpl updater;
-    private SW360Configuration configuration;
-    private ClearingReportGenerator generator;
+    private final SW360UpdaterImpl updater;
+    private final SW360Configuration configuration;
+    private final ClearingReportGenerator generator;
 
-    public void setUpdater(SW360UpdaterImpl updater) {
-        this.updater = updater;
-    }
-
-    public void setConfiguration(SW360Configuration configuration) {
-        this.configuration = configuration;
-    }
-
-    public void setClearingReportGenerator(ClearingReportGenerator generator) {
-        this.generator = generator;
+    public SW360Updater(SW360UpdaterImpl updater, SW360Configuration configuration,
+                        ClearingReportGenerator generator) {
+        this.updater = Objects.requireNonNull(updater, "UpdaterImpl must not be null");
+        this.configuration = Objects.requireNonNull(configuration, "Configuration must not be null");
+        this.generator = Objects.requireNonNull(generator, "Clearing report generator must not be null");
     }
 
     public void execute() {

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
@@ -158,10 +158,14 @@ public class SW360ExporterTest {
                 thenReturn(propertiesMap);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testConfigurationMustNotBeNull() {
+        new SW360Exporter(null);
+    }
+
     @Test
     public void testExporter() throws IOException {
-        SW360Exporter sw360Exporter = new SW360Exporter();
-        sw360Exporter.setConfiguration(configurationMock);
+        SW360Exporter sw360Exporter = new SW360Exporter(configurationMock);
         sw360Exporter.execute();
 
         assertThat(csvFile).exists();

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -111,6 +111,21 @@ public class SW360UpdaterTest {
         return folder.getRoot().toPath();
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testUpdaterImplMustNotBeNull() {
+        new SW360Updater(null, configurationMock, mock(ClearingReportGenerator.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConfigurationMustNotBeNull() {
+        new SW360Updater(mock(SW360UpdaterImpl.class), null, mock(ClearingReportGenerator.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testClearingReportGeneratorMustNotBeNull() {
+        new SW360Updater(mock(SW360UpdaterImpl.class), configurationMock, null);
+    }
+
     @Test
     public void testExecute() throws IOException {
         initBasicConfiguration();
@@ -129,10 +144,7 @@ public class SW360UpdaterTest {
         when(generator.createClearingDocument(any(), any()))
                 .thenReturn(getTargetDir().resolve(CLEARING_DOC));
 
-        SW360Updater sw360Updater = new SW360Updater();
-        sw360Updater.setUpdater(updater);
-        sw360Updater.setConfiguration(configurationMock);
-        sw360Updater.setClearingReportGenerator(generator);
+        SW360Updater sw360Updater = new SW360Updater(updater, configurationMock, generator);
 
         sw360Updater.execute();
 


### PR DESCRIPTION
Issue: eclipse#497.

The generator for clearing reports was not set, which caused the
exception when a report needed to be generated.

To prevent that incomplete objects are created, all dependencies are
now passed to constructors and are checked for null. Tests have been
updated accordingly.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
bug fix

### How Has This Been Tested?
Tests have been added to verify that the helper object is available. A manual test run with the compliance tool was done as well.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
