### PR TITLE
Fix wrong documentation link for Antenna CLI

### DIFF
--- a/antenna-documentation/src/site/site.xml
+++ b/antenna-documentation/src/site/site.xml
@@ -46,7 +46,7 @@
                 </item>
             </item>
             <item name="Development Guide" href="dev-guide.html"/>
-            <item name="HTTP Support Library" href="http-support/index.html"/>
+            <item name="HTTP Support Library" href="http-support/index_http.html"/>
         </menu>
     </body>
 </project>

--- a/http-support/src/site/markdown/index_http.md.vm
+++ b/http-support/src/site/markdown/index_http.md.vm
@@ -101,6 +101,7 @@ a very lean interface with only a single _execute()_ method:
 ```
 
 The method references the following components:
+
 * A _Consumer_ of the interface _RequestBuilder_ is passed in as the first
   parameter. This object defines the request to be executed. We will see a bit
   later how a request definition looks like with this approach.


### PR DESCRIPTION
Issue: eclipse#506.

Clicking on the link for the Antenna CLI in the documentation site opened the page for the HTTP support library.

When building the jar with dependencies for the Antenna CLI the file index..md.vm from the HTTP support library module, due to the name clash, was overriding the documentation for the CLI. Therefore, the file has been renamed.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
documentation update

### How Has This Been Tested?
Rebuilt the documentation and verified that now the correct information is displayed.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

