### PR TITLE
Get rid of critical sca warnings

### DIFF
--- a/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ProcessingState.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/api/workflow/ProcessingState.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -64,7 +65,7 @@ public class ProcessingState {
         attachableMap.putAll(workflowStepResult.getAttachables());
         additionalReportComments.addAll(workflowStepResult.getAdditionalReportComments());
         Optional.ofNullable(workflowStepResult.getFailCausingResults())
-                .map(failCausingResult ->
+                .ifPresent(failCausingResult ->
                         failCausingResults.put(failCausingResult.getKey(), failCausingResult.getValue()));
     }
 

--- a/core/model/src/main/java/org/eclipse/sw360/antenna/model/coordinates/Coordinate.java
+++ b/core/model/src/main/java/org/eclipse/sw360/antenna/model/coordinates/Coordinate.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -12,6 +13,7 @@ package org.eclipse.sw360.antenna.model.coordinates;
 
 import com.github.packageurl.PackageURL;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -67,11 +69,11 @@ public final class Coordinate extends PackageURLFacade {
     public static class Types extends PackageURL.StandardTypes {
         public static final String P2 = "p2";
 
-        public static final Set<String> all = Stream.of(
+        public static final Set<String> all = Collections.unmodifiableSet(Stream.of(
                 // Standard Types:
                 BITBUCKET, COMPOSER, DEBIAN, DOCKER, GEM, GENERIC, GITHUB, GOLANG, MAVEN, NPM, NUGET, PYPI, RPM,
                 // Custom Types:
                 P2)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toSet()));
     }
 }

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/AttributionDocumentGeneratorImpl.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/AttributionDocumentGeneratorImpl.java
@@ -308,19 +308,17 @@ public class AttributionDocumentGeneratorImpl {
     }
 
     private File doOverlay(File file, PDDocument template, String newFileName) {
-        try (PDDocument content = PDDocument.load(file))  {
-            Overlay overlay = new Overlay();
+        File overlayed = new File(workingDir, newFileName);
+        try (PDDocument content = PDDocument.load(file);
+             Overlay overlay = new Overlay();
+             FileOutputStream fos = new FileOutputStream(overlayed))  {
             overlay.setInputPDF(content);
             overlay.setAllPagesOverlayPDF(template);
             overlay.setOverlayPosition(Overlay.Position.BACKGROUND);
             overlay.overlay(Collections.emptyMap());
 
-            File overlayed = new File(workingDir, newFileName);
-            try (FileOutputStream fos = new FileOutputStream(overlayed)) {
-                content.save(fos);
-                content.close();
-                return overlayed;
-            }
+            content.save(fos);
+            return overlayed;
         } catch (IOException e) {
             throw new ExecutionException("PDF overlay failed", e);
         }


### PR DESCRIPTION
Each commit is looking into warnings from one file raised during the SonarCloud analysis

### Request Reviewer
@bs-ondem @neubs-bsi @oheger-bosch 

### Type of Change

*Type of change*:  improvement

### How Has This Been Tested?
Standard regression tests

### Checklist
Must:
- [X] All related issues are referenced in commit messages

