### PR TITLE
Enable github actions build on master pushes as well

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -1,4 +1,5 @@
-# Copyright (c) Bosch Software Innovations GmbH 2018.
+# Copyright (c) Bosch Software Innovations GmbH 2018
+# Copyright (c) Bosch.IO GmbH 2020
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -7,7 +8,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 name: Antenna Pull Request Build
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch.io>

Configure github actions build to run also on pushes to master

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change

*Type of change*:  improvements

### How Has This Been Tested?
Can only be tested completely after merge

### Checklist
Must:
- [X] All related issues are referenced in commit messages
