### PR TITLE
Get rid of incompatible xml property

### DIFF
--- a/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/CycloneDXGenerator.java
+++ b/modules/cyclone-dx/src/main/java/com/eclipse/sw360/antenna/cyclonedx/CycloneDXGenerator.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -71,8 +70,6 @@ public class CycloneDXGenerator extends AbstractGenerator {
         try {
             Document document = gen.generate();
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             DOMSource source = new DOMSource(document);
             try (Writer writer = new OutputStreamWriter(new FileOutputStream(targetFile), UTF_8)) {
                 StreamResult result = new StreamResult(writer);


### PR DESCRIPTION
There is a mismatch on this properties. They are not known to the xml components we are using, although, e.g., SonarCloud marks the missing code as vulnerability. The vulnerability is not an issue in our tooling, so I think removing is ok.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch.io>

### Request Reviewer
@bs-ondem 

### Type of Change
*Type of change*:  bug fix

### How Has This Been Tested?
Regression Test and example project test in Tina later

### Checklist
Must:
- [X] All related issues are referenced in commit messages
