### PR TITLE
Oheger bosch/sw360/#426 tweak SW360 release client API

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuratio
 import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactClearingDocument;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactClearingState;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadRequest;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -24,8 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils.getArtifactsFromCsvFile;
@@ -71,10 +70,11 @@ public class SW360Updater {
             if (release.getClearingState() != null &&
                     !release.getClearingState().isEmpty() &&
                     ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITIAL) {
-                Map<Path, SW360AttachmentType> attachmentPathMap =
-                        Collections.singletonMap(getOrGenerateClearingDocument(release, artifact),
-                                SW360AttachmentType.CLEARING_REPORT);
-                releaseClientAdapter.uploadAttachments(release, attachmentPathMap);
+                AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+                        .addAttachment(getOrGenerateClearingDocument(release, artifact),
+                                SW360AttachmentType.CLEARING_REPORT)
+                        .build();
+                releaseClientAdapter.uploadAttachments(uploadRequest);
             }
         } catch (SW360ClientException e) {
             LOGGER.error("Failed to process artifact {}.", artifact, e);

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -162,14 +162,15 @@ public class SW360UpdaterTest {
             verify(generator).createClearingDocument(release, getTargetDir());
         }
         verify(updater, times(2)).artifactToReleaseInSW360(any());
-        ArgumentCaptor<AttachmentUploadRequest> captor = ArgumentCaptor.forClass(AttachmentUploadRequest.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<AttachmentUploadRequest<SW360Release>> captor = ArgumentCaptor.forClass(AttachmentUploadRequest.class);
         verify(releaseClientAdapter, times(expectUpload ? 1 : 0)).uploadAttachments(captor.capture());
         if (expectUpload) {
-            AttachmentUploadRequest uploadRequest = captor.getValue();
+            AttachmentUploadRequest<SW360Release> uploadRequest = captor.getValue();
             List<AttachmentUploadRequest.Item> expItems = testAttachmentMap.entrySet().stream()
                     .map(entry -> new AttachmentUploadRequest.Item(entry.getKey(), entry.getValue()))
                     .collect(Collectors.toList());
-            assertThat(uploadRequest.items()).containsAll(expItems);
+            assertThat(uploadRequest.getItems()).containsAll(expItems);
         }
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequest.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequest.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,12 +30,13 @@ import java.util.Objects;
  * is created using a builder that offers methods to add the items to be
  * uploaded.
  * </p>
+ * @param <T> the type of the entity to upload attachments to
  */
-public final class AttachmentUploadRequest {
+public final class AttachmentUploadRequest<T extends SW360HalResource<?, ?>> {
     /**
-     * The release that is the target for uploads.
+     * The entity that is the target for uploads.
      */
-    private final SW360Release target;
+    private final T target;
 
     /**
      * Stores the items to be uploaded.
@@ -49,20 +50,20 @@ public final class AttachmentUploadRequest {
      * @param target the target entity of the uploads
      * @param items  a list with the items to be uploaded
      */
-    private AttachmentUploadRequest(SW360Release target, List<Item> items) {
+    private AttachmentUploadRequest(T target, List<Item> items) {
         this.target = target;
         this.items = Collections.unmodifiableList(new ArrayList<>(items));
     }
 
     /**
      * Returns a new {@code Builder} to define a request to upload attachments
-     * to the given release.
+     * to the given entity.
      *
      * @param target the target of the upload operation
      * @return the builder to define the upload request
      */
-    public static Builder builder(SW360Release target) {
-        return new Builder(target);
+    public static <T extends SW360HalResource<?, ?>> Builder<T> builder(T target) {
+        return new Builder<>(target);
     }
 
     /**
@@ -70,7 +71,7 @@ public final class AttachmentUploadRequest {
      *
      * @return the target entity for attachment uploads
      */
-    public SW360Release getTarget() {
+    public T getTarget() {
         return target;
     }
 
@@ -79,7 +80,7 @@ public final class AttachmentUploadRequest {
      *
      * @return a list with the items to be uploaded
      */
-    public List<Item> items() {
+    public List<Item> getItems() {
         return items;
     }
 
@@ -87,7 +88,7 @@ public final class AttachmentUploadRequest {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        AttachmentUploadRequest request = (AttachmentUploadRequest) o;
+        AttachmentUploadRequest<?> request = (AttachmentUploadRequest<?>) o;
         return Objects.equals(getTarget(), request.getTarget()) &&
                 items.equals(request.items);
     }
@@ -175,18 +176,18 @@ public final class AttachmentUploadRequest {
     /**
      * A builder class for creating {@link AttachmentUploadRequest} instances.
      */
-    public static class Builder {
+    public static class Builder<T extends SW360HalResource<?, ?>> {
         /**
          * The entity to upload attachments to.
          */
-        private final SW360Release target;
+        private final T target;
 
         /**
          * Stores the items to be uploaded.
          */
         private final List<Item> items;
 
-        private Builder(SW360Release target) {
+        private Builder(T target) {
             this.target = target;
             items = new LinkedList<>();
         }
@@ -198,7 +199,7 @@ public final class AttachmentUploadRequest {
          * @param attachmentType the type of the resulting attachment
          * @return this builder
          */
-        public Builder addAttachment(Path attachmentPath, SW360AttachmentType attachmentType) {
+        public Builder<T> addAttachment(Path attachmentPath, SW360AttachmentType attachmentType) {
             items.add(new Item(attachmentPath, attachmentType));
             return this;
         }
@@ -209,8 +210,8 @@ public final class AttachmentUploadRequest {
          *
          * @return the newly created {@code AttachmentUploadRequest}
          */
-        public AttachmentUploadRequest build() {
-            return new AttachmentUploadRequest(target, items);
+        public AttachmentUploadRequest<T> build() {
+            return new AttachmentUploadRequest<>(target, items);
         }
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequest.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * <p>
+ * A data class that represents a request to upload multiple attachments for an
+ * entity.
+ * </p>
+ * <p>
+ * It is possible to upload multiple attachments in a single request. A request
+ * is created using a builder that offers methods to add the items to be
+ * uploaded.
+ * </p>
+ */
+public final class AttachmentUploadRequest {
+    /**
+     * The release that is the target for uploads.
+     */
+    private final SW360Release target;
+
+    /**
+     * Stores the items to be uploaded.
+     */
+    private final List<Item> items;
+
+    /**
+     * Creates a new instance of {@code AttachmentUploadRequest} with the items
+     * to be uploaded.
+     *
+     * @param target the target entity of the uploads
+     * @param items  a list with the items to be uploaded
+     */
+    private AttachmentUploadRequest(SW360Release target, List<Item> items) {
+        this.target = target;
+        this.items = Collections.unmodifiableList(new ArrayList<>(items));
+    }
+
+    /**
+     * Returns a new {@code Builder} to define a request to upload attachments
+     * to the given release.
+     *
+     * @param target the target of the upload operation
+     * @return the builder to define the upload request
+     */
+    public static Builder builder(SW360Release target) {
+        return new Builder(target);
+    }
+
+    /**
+     * Returns the target entity to which attachments are to be uploaded.
+     *
+     * @return the target entity for attachment uploads
+     */
+    public SW360Release getTarget() {
+        return target;
+    }
+
+    /**
+     * Returns a list with the items that are to be uploaded.
+     *
+     * @return a list with the items to be uploaded
+     */
+    public List<Item> items() {
+        return items;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AttachmentUploadRequest request = (AttachmentUploadRequest) o;
+        return Objects.equals(getTarget(), request.getTarget()) &&
+                items.equals(request.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTarget(), items);
+    }
+
+    @Override
+    public String toString() {
+        return "AttachmentUploadRequest{" +
+                "target=" + target +
+                ", items=" + items +
+                '}';
+    }
+
+    /**
+     * A simple data class representing a single attachment item to be
+     * uploaded.
+     */
+    public static final class Item {
+        /**
+         * The path of the file to be uploaded.
+         */
+        private final Path path;
+
+        /**
+         * The type of the attachment.
+         */
+        private final SW360AttachmentType attachmentType;
+
+        /**
+         * Creates a new instance of {@code Item} with the given properties.
+         *
+         * @param path           the path of the file to be uploaded
+         * @param attachmentType the attachment type
+         */
+        public Item(Path path, SW360AttachmentType attachmentType) {
+            this.path = path;
+            this.attachmentType = attachmentType;
+        }
+
+        /**
+         * Returns the path to the document that is to be uploaded.
+         *
+         * @return the path to be uploaded
+         */
+        public Path getPath() {
+            return path;
+        }
+
+        /**
+         * Returns the type of the new attachment.
+         *
+         * @return the attachment type
+         */
+        public SW360AttachmentType getAttachmentType() {
+            return attachmentType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Item item = (Item) o;
+            return Objects.equals(getPath(), item.getPath()) &&
+                    getAttachmentType() == item.getAttachmentType();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getPath(), getAttachmentType());
+        }
+
+        @Override
+        public String toString() {
+            return "Item{" +
+                    "path=" + path +
+                    ", attachmentType=" + attachmentType +
+                    '}';
+        }
+    }
+
+    /**
+     * A builder class for creating {@link AttachmentUploadRequest} instances.
+     */
+    public static class Builder {
+        /**
+         * The entity to upload attachments to.
+         */
+        private final SW360Release target;
+
+        /**
+         * Stores the items to be uploaded.
+         */
+        private final List<Item> items;
+
+        private Builder(SW360Release target) {
+            this.target = target;
+            items = new LinkedList<>();
+        }
+
+        /**
+         * Adds an attachment to be uploaded to the request to be created.
+         *
+         * @param attachmentPath the path to the document to be uploaded
+         * @param attachmentType the type of the resulting attachment
+         * @return this builder
+         */
+        public Builder addAttachment(Path attachmentPath, SW360AttachmentType attachmentType) {
+            items.add(new Item(attachmentPath, attachmentType));
+            return this;
+        }
+
+        /**
+         * Creates the request to upload attachments based on the data added to
+         * this builder so far.
+         *
+         * @return the newly created {@code AttachmentUploadRequest}
+         */
+        public AttachmentUploadRequest build() {
+            return new AttachmentUploadRequest(target, items);
+        }
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResult.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResult.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * <p>
+ * A data class holding the result of a (multi) attachment upload request.
+ * </p>
+ * <p>
+ * When uploading multiple attachments using a single request, every single
+ * upload might fail. With this class it is possible to get detailed
+ * information about all the uploads that were made and which of them were
+ * successful. The updated {@link SW360Release} object is also available.
+ * </p>
+ */
+public final class AttachmentUploadResult {
+    /**
+     * Stores the target entity of the upload operation.
+     */
+    private final SW360Release target;
+
+    /**
+     * Stores information about the attachments that could be uploaded.
+     */
+    private final Set<AttachmentUploadRequest.Item> successfulUploads;
+
+    /**
+     * A map with information about attachments that could not be uploaded and
+     * the reasons for the failed uploads.
+     */
+    private final Map<AttachmentUploadRequest.Item, Throwable> failedUploads;
+
+    /**
+     * Creates a new instance of {@code AttachmentUploadResult} that references
+     * the given release.
+     *
+     * @param target the {@code SW360Release} that was the target for uploads
+     */
+    public AttachmentUploadResult(SW360Release target) {
+        this(target, Collections.emptySet(), Collections.emptyMap());
+    }
+
+    /**
+     * Internal constructor to create an instance of
+     * {@code AttachmentUploadResult} with all information.
+     *
+     * @param target            the {@code SW360Release} that was the target for uploads
+     * @param successfulUploads a set with successful uploads
+     * @param failedUploads     a map with failed uploads
+     */
+    private AttachmentUploadResult(SW360Release target,
+                                   Set<AttachmentUploadRequest.Item> successfulUploads,
+                                   Map<AttachmentUploadRequest.Item, Throwable> failedUploads) {
+        this.target = target;
+        this.successfulUploads = successfulUploads;
+        this.failedUploads = failedUploads;
+    }
+
+    /**
+     * Returns the release that is the target of the upload operation.
+     *
+     * @return the updated release to which attachments have been uploaded
+     */
+    public SW360Release getTarget() {
+        return target;
+    }
+
+    /**
+     * Returns a flag whether the whole upload operation was successful. If
+     * this method returns <strong>true</strong>, all the single attachment
+     * uploads have been successful; otherwise, there was at least one failure.
+     * More information about successful and failed uploads is then available
+     * through the other methods of this class.
+     *
+     * @return a flag whether all attachments could be uploaded successfully
+     */
+    public boolean isSuccess() {
+        return failedUploads.isEmpty();
+    }
+
+    /**
+     * Returns a set with information about all the attachment items that could
+     * be uploaded successfully.
+     *
+     * @return a set with successfully uploaded attachment items
+     */
+    public Set<AttachmentUploadRequest.Item> successfulUploads() {
+        return successfulUploads;
+    }
+
+    /**
+     * Returns a map with information about all the attachment items that could
+     * not be uploaded successfully. For each item whose upload caused a
+     * failure, the corresponding exception can be queried.
+     *
+     * @return a map with the failed attachment items and the corresponding
+     * exceptions
+     */
+    public Map<AttachmentUploadRequest.Item, Throwable> failedUploads() {
+        return failedUploads;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AttachmentUploadResult result = (AttachmentUploadResult) o;
+        return Objects.equals(getTarget(), result.getTarget()) &&
+                successfulUploads.equals(result.successfulUploads) &&
+                failedUploads.equals(result.failedUploads);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTarget(), successfulUploads, failedUploads);
+    }
+
+    @Override
+    public String toString() {
+        return "AttachmentUploadResult{" +
+                "target=" + target +
+                ", successfulUploads=" + successfulUploads +
+                ", failedUploads=" + failedUploads +
+                '}';
+    }
+
+    /**
+     * Returns a copy of this object that contains the given attachment item as
+     * a successful upload.
+     *
+     * @param updatedRelease the updated release entity
+     * @param item           the item that was uploaded successfully
+     * @return the modified copy of this object
+     */
+    AttachmentUploadResult addSuccessfulUpload(SW360Release updatedRelease, AttachmentUploadRequest.Item item) {
+        Set<AttachmentUploadRequest.Item> updatedSet = new HashSet<>(successfulUploads);
+        updatedSet.add(item);
+        return new AttachmentUploadResult(updatedRelease, Collections.unmodifiableSet(updatedSet), failedUploads);
+    }
+
+    /**
+     * Returns a copy of this object that contains the given attachment item as
+     * a failed upload, together with the corresponding exception.
+     *
+     * @param item      the item that could not be uploaded
+     * @param exception the exception causing the upload to fail
+     * @return the modified copy of this object
+     */
+    AttachmentUploadResult addFailedUpload(AttachmentUploadRequest.Item item, Throwable exception) {
+        Map<AttachmentUploadRequest.Item, Throwable> updatedMap = new HashMap<>(failedUploads);
+        updatedMap.put(item, exception);
+        return new AttachmentUploadResult(getTarget(), successfulUploads, Collections.unmodifiableMap(updatedMap));
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResult.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResult.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 
 import java.util.Collections;
@@ -29,12 +30,14 @@ import java.util.Set;
  * information about all the uploads that were made and which of them were
  * successful. The updated {@link SW360Release} object is also available.
  * </p>
+ *
+ * @param <T> the type of the entity for which attachments were uploaded
  */
-public final class AttachmentUploadResult {
+public final class AttachmentUploadResult<T extends SW360HalResource<?, ?>> {
     /**
      * Stores the target entity of the upload operation.
      */
-    private final SW360Release target;
+    private final T target;
 
     /**
      * Stores information about the attachments that could be uploaded.
@@ -49,11 +52,11 @@ public final class AttachmentUploadResult {
 
     /**
      * Creates a new instance of {@code AttachmentUploadResult} that references
-     * the given release.
+     * the given target entity.
      *
-     * @param target the {@code SW360Release} that was the target for uploads
+     * @param target the entity that was the target for uploads
      */
-    public AttachmentUploadResult(SW360Release target) {
+    public AttachmentUploadResult(T target) {
         this(target, Collections.emptySet(), Collections.emptyMap());
     }
 
@@ -61,11 +64,11 @@ public final class AttachmentUploadResult {
      * Internal constructor to create an instance of
      * {@code AttachmentUploadResult} with all information.
      *
-     * @param target            the {@code SW360Release} that was the target for uploads
+     * @param target            the entity that was the target for uploads
      * @param successfulUploads a set with successful uploads
      * @param failedUploads     a map with failed uploads
      */
-    private AttachmentUploadResult(SW360Release target,
+    private AttachmentUploadResult(T target,
                                    Set<AttachmentUploadRequest.Item> successfulUploads,
                                    Map<AttachmentUploadRequest.Item, Throwable> failedUploads) {
         this.target = target;
@@ -74,11 +77,11 @@ public final class AttachmentUploadResult {
     }
 
     /**
-     * Returns the release that is the target of the upload operation.
+     * Returns the entity that is the target of the upload operation.
      *
-     * @return the updated release to which attachments have been uploaded
+     * @return the updated entity to which attachments have been uploaded
      */
-    public SW360Release getTarget() {
+    public T getTarget() {
         return target;
     }
 
@@ -121,7 +124,7 @@ public final class AttachmentUploadResult {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        AttachmentUploadResult result = (AttachmentUploadResult) o;
+        AttachmentUploadResult<?> result = (AttachmentUploadResult<?>) o;
         return Objects.equals(getTarget(), result.getTarget()) &&
                 successfulUploads.equals(result.successfulUploads) &&
                 failedUploads.equals(result.failedUploads);
@@ -145,14 +148,14 @@ public final class AttachmentUploadResult {
      * Returns a copy of this object that contains the given attachment item as
      * a successful upload.
      *
-     * @param updatedRelease the updated release entity
+     * @param updatedTarget the updated target entity
      * @param item           the item that was uploaded successfully
      * @return the modified copy of this object
      */
-    AttachmentUploadResult addSuccessfulUpload(SW360Release updatedRelease, AttachmentUploadRequest.Item item) {
+    AttachmentUploadResult<T> addSuccessfulUpload(T updatedTarget, AttachmentUploadRequest.Item item) {
         Set<AttachmentUploadRequest.Item> updatedSet = new HashSet<>(successfulUploads);
         updatedSet.add(item);
-        return new AttachmentUploadResult(updatedRelease, Collections.unmodifiableSet(updatedSet), failedUploads);
+        return new AttachmentUploadResult<>(updatedTarget, Collections.unmodifiableSet(updatedSet), failedUploads);
     }
 
     /**
@@ -163,9 +166,9 @@ public final class AttachmentUploadResult {
      * @param exception the exception causing the upload to fail
      * @return the modified copy of this object
      */
-    AttachmentUploadResult addFailedUpload(AttachmentUploadRequest.Item item, Throwable exception) {
+    AttachmentUploadResult<T> addFailedUpload(AttachmentUploadRequest.Item item, Throwable exception) {
         Map<AttachmentUploadRequest.Item, Throwable> updatedMap = new HashMap<>(failedUploads);
         updatedMap.put(item, exception);
-        return new AttachmentUploadResult(getTarget(), successfulUploads, Collections.unmodifiableMap(updatedMap));
+        return new AttachmentUploadResult<>(getTarget(), successfulUploads, Collections.unmodifiableMap(updatedMap));
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360AttachmentUtils.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360AttachmentUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import org.eclipse.sw360.antenna.sw360.client.rest.SW360AttachmentAwareClient;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils.optionalFuture;
+
+/**
+ * <p>
+ * A helper class providing utility methods related to the handling of
+ * attachments.
+ * </p>
+ * <p>
+ * Attachments are supported by multiple entity types. Therefore, it makes
+ * sense to extract the functionality into a separate utility class.
+ * </p>
+ */
+class SW360AttachmentUtils {
+    private SW360AttachmentUtils() {
+    }
+
+    /**
+     * Processes a request to upload multiple attachments. All attachment files
+     * referenced by the passed in request are uploaded to the target entity. A
+     * result object is returned with information about the single upload
+     * operations.
+     *
+     * @param client             the client that handles a single upload operation
+     * @param uploadRequest      the request to upload attachments
+     * @param getAttachmentsFunc a function to access the existing attachments;
+     *                           this is used to check for duplicates
+     * @param <T>                the type of the target entity for the upload
+     * @return a result object for the multi-upload operation
+     */
+    public static <T extends SW360HalResource<?, ?>> CompletableFuture<AttachmentUploadResult<T>>
+    uploadAttachments(SW360AttachmentAwareClient<T> client, AttachmentUploadRequest<T> uploadRequest,
+                      Function<? super T, Set<SW360SparseAttachment>> getAttachmentsFunc) {
+        CompletableFuture<AttachmentUploadResult<T>> futResult =
+                CompletableFuture.completedFuture(new AttachmentUploadResult<>(uploadRequest.getTarget()));
+
+        for (AttachmentUploadRequest.Item item : uploadRequest.getItems()) {
+            futResult = futResult.thenCompose(result -> {
+                if (attachmentIsPotentialDuplicate(item.getPath(), getAttachmentsFunc.apply(result.getTarget()))) {
+                    return CompletableFuture.completedFuture(result.addFailedUpload(item,
+                            new SW360ClientException("Duplicate attachment file name: " +
+                                    item.getPath().getFileName())));
+                }
+
+                return client
+                        .uploadAndAttachAttachment(result.getTarget(), item.getPath(), item.getAttachmentType())
+                        .handle((updatedEntity, ex) -> (updatedEntity != null) ?
+                                result.addSuccessfulUpload(updatedEntity, item) :
+                                result.addFailedUpload(item, ex));
+            });
+        }
+
+        return futResult;
+    }
+
+    /**
+     * Downloads a specific attachment file assigned to an entity to a local
+     * folder on the hard disk. The directory is created if it does not exist
+     * yet (but not any non-existing parent components). Result is an
+     * {@code Optional} with the path to the file that has been downloaded. If
+     * the requested attachment cannot be resolved, the {@code Optional} is
+     * empty.
+     *
+     * @param client       the client that handles the download operation
+     * @param entity       the entity to which the attachment belongs
+     * @param attachment   the attachment that is to be downloaded
+     * @param downloadPath the path where to store the downloaded file
+     * @param <T>          the type of the entity that owns the attachment
+     * @return a future with the {@code Optional} containing the path to the
+     * file that was downloaded
+     */
+    public static <T extends SW360HalResource<?, ?>> CompletableFuture<Optional<Path>>
+    downloadAttachment(SW360AttachmentAwareClient<? extends T> client, T entity, SW360SparseAttachment attachment,
+                       Path downloadPath) {
+        return Optional.ofNullable(entity.getSelfLink())
+                .map(self ->
+                        optionalFuture(client.downloadAttachment(self.getHref(), attachment, downloadPath)))
+                .orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()));
+    }
+
+    /**
+     * Checks whether an attachment with a specific name already exists for the
+     * target entity.
+     *
+     * @param attachment  the path to the local attachment file
+     * @param attachments the attachments assigned to the target entity
+     * @return a flag whether the attachment is duplicate
+     */
+    private static boolean attachmentIsPotentialDuplicate(Path attachment, Set<SW360SparseAttachment> attachments) {
+        return attachments.stream()
+                .anyMatch(attachment1 -> attachment1.getFilename().equals(attachment.getFileName().toString()));
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -28,28 +28,109 @@ import java.util.Optional;
  * </p>
  */
 public interface SW360ReleaseClientAdapter {
+    /**
+     * Returns the {@code SW360ReleaseClient} used by this adapter. The client
+     * can be used for low-level operations against the SW360 releases
+     * endpoint.
+     *
+     * @return the {@code SW360ReleaseClient}
+     */
     SW360ReleaseClient getReleaseClient();
 
-    SW360Release getOrCreateRelease(SW360Release sw360ReleaseFromArtifact, boolean updateReleases);
+    /**
+     * Creates a new release in SW360 based on the passed in entity. The given
+     * entity must have all mandatory properties defined. It is assigned to the
+     * component it references; the component instance is created if necessary.
+     *
+     * @param release the entity describing the release to be created
+     * @return the newly created release entity
+     */
+    SW360Release createRelease(SW360Release release);
 
-    SW360Release createRelease(SW360Release releaseFromArtifact);
 
-    SW360Release uploadAttachments(SW360Release sw360item, Map<Path, SW360AttachmentType> attachments);
-
+    /**
+     * Tries to find the release with the given ID. Result is an
+     * {@code Optional}; if the release ID cannot be resolved, the
+     * {@code Optional} is empty.
+     *
+     * @param releaseId the ID of the release in question
+     * @return an {@code Optional} with the release found
+     */
     Optional<SW360Release> getReleaseById(String releaseId);
 
+
+    /**
+     * Tries to transform a sparse release into a full one. This method looks
+     * up the release the given object points to and returns a data object with
+     * all its properties. If the release cannot be resolved, result is an
+     * empty {@code Optional}.
+     *
+     * @param sparseRelease the sparse release object
+     * @return an {@code Optional} with the release found
+     */
     Optional<SW360Release> enrichSparseRelease(SW360SparseRelease sparseRelease);
 
-    Optional<SW360SparseRelease> getSparseRelease(SW360Release sw360ReleaseFromArtifact);
+    /**
+     * Searches for a release based on the given external IDs. This method
+     * performs a search on the releases using the external IDs as criterion.
+     * If no match is found, result is an empty {@code Optional}. If the search
+     * yields multiple results, an exception is thrown. Result is a sparse
+     * release, which can be converted to a full {@link SW360Release} object
+     * by using the {@link #enrichSparseRelease(SW360SparseRelease)} method.
+     *
+     * @param externalIds a map with the external IDs to search for
+     * @return an {@code Optional} with the release that was found
+     */
+    Optional<SW360SparseRelease> getSparseReleaseByExternalIds(Map<String, ?> externalIds);
 
-    Optional<SW360Release> getRelease(SW360Release sw360ReleaseFromArtifact);
+    /**
+     * Searches for a release based on the component name and the release
+     * version. This method obtains the component associated with this release
+     * and filters its releases for the correct version. Result is an empty
+     * {@code Optional} if no matching version is found. Otherwise, a sparse
+     * release is returned, which can be converted to a full
+     * {@link SW360Release} by using the
+     * {@link #enrichSparseRelease(SW360SparseRelease)} method.
+     *
+     * @param componentName the name of the component affected
+     * @param version the version of the desired release
+     * @return an {@code Optional} with the release that was found
+     */
+    Optional<SW360SparseRelease> getSparseReleaseByNameAndVersion(String componentName, String version);
 
-    Optional<SW360SparseRelease> getReleaseByExternalIds(Map<String, ?> externalIds);
-
-    Optional<SW360SparseRelease> getReleaseByNameAndVersion(SW360Release sw360ReleaseFromArtifact);
-
+    /**
+     * Tries to retrieve the release with the given version from the passed in
+     * {@code SW360Component} entity. If the component has a release with the
+     * version specified, all its properties are loaded and returned in an
+     * entity object; otherwise, result is an empty {@code Optional}.
+     *
+     * @param component      the {@code SW360Component} entity
+     * @param releaseVersion the version of the release in question
+     * @return a future with an {@code Optional} with the release found
+     */
     Optional<SW360Release> getReleaseByVersion(SW360Component component, String releaseVersion);
 
+    /**
+     * Uploads an arbitrary number of attachments for a release.
+     *
+     * @param sw360item   the release to upload attachments to
+     * @param attachments a map defining the attachments to be uploaded
+     * @return the updated release entity
+     */
+    SW360Release uploadAttachments(SW360Release sw360item, Map<Path, SW360AttachmentType> attachments);
+
+    /**
+     * Tries to download an attachment from a release. If it can be resolved,
+     * the attachment file is written into the download path provided. This
+     * directory is created if it does not exist (but not any parent
+     * directories).
+     *
+     * @param release      the release entity
+     * @param attachment   the attachment to be downloaded
+     * @param downloadPath the path where to store the downloaded file
+     * @return an {@code Optional} with the path to the file that has been
+     * written
+     */
     Optional<Path> downloadAttachment(SW360Release release, SW360SparseAttachment attachment, Path downloadPath);
 
     /**

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -113,11 +112,10 @@ public interface SW360ReleaseClientAdapter {
     /**
      * Uploads an arbitrary number of attachments for a release.
      *
-     * @param sw360item   the release to upload attachments to
-     * @param attachments a map defining the attachments to be uploaded
-     * @return the updated release entity
+     * @param uploadRequest the request with the attachments to be uploaded
+     * @return the result of the upload operation
      */
-    SW360Release uploadAttachments(SW360Release sw360item, Map<Path, SW360AttachmentType> attachments);
+    AttachmentUploadResult uploadAttachments(AttachmentUploadRequest uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -115,7 +115,7 @@ public interface SW360ReleaseClientAdapter {
      * @param uploadRequest the request with the attachments to be uploaded
      * @return the result of the upload operation
      */
-    AttachmentUploadResult uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
+    AttachmentUploadResult<SW360Release> uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -115,7 +115,7 @@ public interface SW360ReleaseClientAdapter {
      * @param uploadRequest the request with the attachments to be uploaded
      * @return the result of the upload operation
      */
-    AttachmentUploadResult uploadAttachments(AttachmentUploadRequest uploadRequest);
+    AttachmentUploadResult uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -51,4 +51,13 @@ public interface SW360ReleaseClientAdapter {
     Optional<SW360Release> getReleaseByVersion(SW360Component component, String releaseVersion);
 
     Optional<Path> downloadAttachment(SW360Release release, SW360SparseAttachment attachment, Path downloadPath);
+
+    /**
+     * Updates a release. The release is updated in the database based on the
+     * properties of the passed in entity.
+     *
+     * @param release the release to be updated
+     * @return the updated release
+     */
+    SW360Release updateRelease(SW360Release release);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -118,7 +118,7 @@ public interface SW360ReleaseClientAdapterAsync {
      * @param uploadRequest the request with the attachments to be uploaded
      * @return a future with the result of the upload operation
      */
-    CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest uploadRequest);
+    CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -54,4 +54,13 @@ public interface SW360ReleaseClientAdapterAsync {
 
     CompletableFuture<Optional<Path>> downloadAttachment(SW360Release release, SW360SparseAttachment attachment,
                                                          Path downloadPath);
+
+    /**
+     * Updates a release. The release is updated in the database based on the
+     * properties of the passed in entity.
+     *
+     * @param release the release to be updated
+     * @return a future with the updated release
+     */
+    CompletableFuture<SW360Release> updateRelease(SW360Release release);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -29,29 +29,112 @@ import java.util.concurrent.CompletableFuture;
  * </p>
  */
 public interface SW360ReleaseClientAdapterAsync {
+    /**
+     * Returns the {@code SW360ReleaseClient} used by this adapter. The client
+     * can be used for low-level operations against the SW360 releases
+     * endpoint.
+     *
+     * @return the {@code SW360ReleaseClient}
+     */
     SW360ReleaseClient getReleaseClient();
 
-    CompletableFuture<SW360Release> getOrCreateRelease(SW360Release sw360ReleaseFromArtifact, boolean updateReleases);
+    /**
+     * Creates a new release in SW360 based on the passed in entity. The given
+     * entity must have all mandatory properties defined. It is assigned to the
+     * component it references; the component instance is created if necessary.
+     *
+     * @param release the entity describing the release to be created
+     * @return a future with the newly created release entity
+     */
+    CompletableFuture<SW360Release> createRelease(SW360Release release);
 
-    CompletableFuture<SW360Release> createRelease(SW360Release releaseFromArtifact);
-
-    CompletableFuture<SW360Release> uploadAttachments(SW360Release sw360item, Map<Path,
-            SW360AttachmentType> attachments);
-
+    /**
+     * Tries to find the release with the given ID. Result is an
+     * {@code Optional}; if the release ID cannot be resolved, the
+     * {@code Optional} is empty.
+     *
+     * @param releaseId the ID of the release in question
+     * @return a future with an {@code Optional} with the release found
+     */
     CompletableFuture<Optional<SW360Release>> getReleaseById(String releaseId);
 
+    /**
+     * Tries to transform a sparse release into a full one. This method looks
+     * up the release the given object points to and returns a data object with
+     * all its properties. If the release cannot be resolved, result is an
+     * empty {@code Optional}.
+     *
+     * @param sparseRelease the sparse release object
+     * @return a future with an {@code Optional} with the release found
+     */
     CompletableFuture<Optional<SW360Release>> enrichSparseRelease(SW360SparseRelease sparseRelease);
 
-    CompletableFuture<Optional<SW360SparseRelease>> getSparseRelease(SW360Release sw360ReleaseFromArtifact);
+    /**
+     * Searches for a release based on the given external IDs. This method
+     * performs a search on the releases using the external IDs as criterion.
+     * If no match is found, result is an empty {@code Optional}. If the search
+     * yields multiple results, the resulting future fails with an exception.
+     * Result is a sparse release, which can be converted to a full
+     * {@link SW360Release} object by using the
+     * {@link #enrichSparseRelease(SW360SparseRelease)} method.
+     *
+     * @param externalIds a map with the external IDs to search for
+     * @return a future with an {@code Optional} with the release that was
+     * found
+     */
+    CompletableFuture<Optional<SW360SparseRelease>> getSparseReleaseByExternalIds(Map<String, ?> externalIds);
 
-    CompletableFuture<Optional<SW360Release>> getRelease(SW360Release sw360ReleaseFromArtifact);
+    /**
+     * Searches for a release based on the component name and the release
+     * version. This method obtains the component associated with this release
+     * and filters its releases for the correct version. Result is an empty
+     * {@code Optional} if no matching version is found. Otherwise, a sparse
+     * release is returned, which can be converted to a full
+     * {@link SW360Release} by using the
+     * {@link #enrichSparseRelease(SW360SparseRelease)} method.
+     *
+     * @param componentName the name of the component affected
+     * @param version the version of the desired release
+     * @return a future with an {@code Optional} with the release that was
+     * found
+     */
+    CompletableFuture<Optional<SW360SparseRelease>> getSparseReleaseByNameAndVersion(String componentName,
+                                                                                     String version);
 
-    CompletableFuture<Optional<SW360SparseRelease>> getReleaseByExternalIds(Map<String, ?> externalIds);
-
-    CompletableFuture<Optional<SW360SparseRelease>> getReleaseByNameAndVersion(SW360Release sw360ReleaseFromArtifact);
-
+    /**
+     * Tries to retrieve the release with the given version from the passed in
+     * {@code SW360Component} entity. If the component has a release with the
+     * version specified, all its properties are loaded and returned in an
+     * entity object; otherwise, result is an empty {@code Optional}.
+     *
+     * @param component      the {@code SW360Component} entity
+     * @param releaseVersion the version of the release in question
+     * @return a future with an {@code Optional} with the release found
+     */
     CompletableFuture<Optional<SW360Release>> getReleaseByVersion(SW360Component component, String releaseVersion);
 
+    /**
+     * Uploads an arbitrary number of attachments for a release.
+     *
+     * @param sw360item   the release to upload attachments to
+     * @param attachments a map defining the attachments to be uploaded
+     * @return a future with the updated release entity
+     */
+    CompletableFuture<SW360Release> uploadAttachments(SW360Release sw360item,
+                                                      Map<Path, SW360AttachmentType> attachments);
+
+    /**
+     * Tries to download an attachment from a release. If it can be resolved,
+     * the attachment file is written into the download path provided. This
+     * directory is created if it does not exist (but not any parent
+     * directories).
+     *
+     * @param release      the release entity
+     * @param attachment   the attachment to be downloaded
+     * @param downloadPath the path where to store the downloaded file
+     * @return a future with an {@code Optional} with the path to the file that
+     * has been written
+     */
     CompletableFuture<Optional<Path>> downloadAttachment(SW360Release release, SW360SparseAttachment attachment,
                                                          Path downloadPath);
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -116,12 +115,10 @@ public interface SW360ReleaseClientAdapterAsync {
     /**
      * Uploads an arbitrary number of attachments for a release.
      *
-     * @param sw360item   the release to upload attachments to
-     * @param attachments a map defining the attachments to be uploaded
-     * @return a future with the updated release entity
+     * @param uploadRequest the request with the attachments to be uploaded
+     * @return a future with the result of the upload operation
      */
-    CompletableFuture<SW360Release> uploadAttachments(SW360Release sw360item,
-                                                      Map<Path, SW360AttachmentType> attachments);
+    CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -118,7 +118,8 @@ public interface SW360ReleaseClientAdapterAsync {
      * @param uploadRequest the request with the attachments to be uploaded
      * @return a future with the result of the upload operation
      */
-    CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
+    CompletableFuture<AttachmentUploadResult<SW360Release>>
+    uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest);
 
     /**
      * Tries to download an attachment from a release. If it can be resolved,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
@@ -91,11 +91,11 @@ class SW360ReleaseClientAdapterAsyncImpl implements SW360ReleaseClientAdapterAsy
     }
 
     @Override
-    public CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest uploadRequest) {
+    public CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest) {
         CompletableFuture<AttachmentUploadResult> futResult =
                 CompletableFuture.completedFuture(new AttachmentUploadResult(uploadRequest.getTarget()));
 
-        for (AttachmentUploadRequest.Item item : uploadRequest.items()) {
+        for (AttachmentUploadRequest.Item item : uploadRequest.getItems()) {
             futResult = futResult.thenCompose(result -> {
                 if (attachmentIsPotentialDuplicate(item.getPath(), result.getTarget().getEmbedded().getAttachments())) {
                     return CompletableFuture.completedFuture(result.addFailedUpload(item,

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
@@ -91,9 +91,10 @@ class SW360ReleaseClientAdapterAsyncImpl implements SW360ReleaseClientAdapterAsy
     }
 
     @Override
-    public CompletableFuture<AttachmentUploadResult> uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest) {
-        CompletableFuture<AttachmentUploadResult> futResult =
-                CompletableFuture.completedFuture(new AttachmentUploadResult(uploadRequest.getTarget()));
+    public CompletableFuture<AttachmentUploadResult<SW360Release>>
+    uploadAttachments(AttachmentUploadRequest<SW360Release> uploadRequest) {
+        CompletableFuture<AttachmentUploadResult<SW360Release>> futResult =
+                CompletableFuture.completedFuture(new AttachmentUploadResult<>(uploadRequest.getTarget()));
 
         for (AttachmentUploadRequest.Item item : uploadRequest.getItems()) {
             futResult = futResult.thenCompose(result -> {

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequestTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequestTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttachmentUploadRequestTest {
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(AttachmentUploadRequest.class)
+                .withNonnullFields("items")
+                .verify();
+    }
+
+    @Test
+    public void testToString() {
+        SW360Release release = new SW360Release();
+        release.setName("Test release");
+        Path path1 = Paths.get("testAttachment.doc");
+        Path path2 = Paths.get("anotherAttachment.json");
+        AttachmentUploadRequest request = AttachmentUploadRequest.builder(release)
+                .addAttachment(path1, SW360AttachmentType.LICENSE_AGREEMENT)
+                .addAttachment(path2, SW360AttachmentType.REQUIREMENT)
+                .build();
+
+        String s = request.toString();
+        assertThat(s).contains(path1.toString(), path2.toString(), release.toString());
+    }
+
+    @Test
+    public void testItemsListIsCopiedOnCreation() {
+        Path path = Paths.get("foo");
+        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(new SW360Release())
+                .addAttachment(path, SW360AttachmentType.DECISION_REPORT);
+
+        AttachmentUploadRequest request = builder.build();
+        builder.addAttachment(Paths.get("bar"), SW360AttachmentType.COMPONENT_LICENSE_INFO_COMBINED);
+        assertThat(request.items())
+                .containsOnly(new AttachmentUploadRequest.Item(path, SW360AttachmentType.DECISION_REPORT));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testItemsNonModifiable() {
+        Path path = Paths.get("first");
+        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(new SW360Release())
+                .addAttachment(path, SW360AttachmentType.DECISION_REPORT);
+        AttachmentUploadRequest request = builder.build();
+
+        request.items()
+                .add(new AttachmentUploadRequest.Item(Paths.get("more"), SW360AttachmentType.SCAN_RESULT_REPORT));
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequestTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadRequestTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 import org.junit.Test;
@@ -23,7 +24,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AttachmentUploadRequestTest {
     @Test
     public void testEquals() {
+        SW360Release release1 = new SW360Release();
+        release1.setName("release1");
+        SW360Release release2 = new SW360Release();
+        release2.setName("release2");
         EqualsVerifier.forClass(AttachmentUploadRequest.class)
+                .withPrefabValues(SW360HalResource.class, release1, release2)
                 .withNonnullFields("items")
                 .verify();
     }
@@ -34,7 +40,7 @@ public class AttachmentUploadRequestTest {
         release.setName("Test release");
         Path path1 = Paths.get("testAttachment.doc");
         Path path2 = Paths.get("anotherAttachment.json");
-        AttachmentUploadRequest request = AttachmentUploadRequest.builder(release)
+        AttachmentUploadRequest<SW360Release> request = AttachmentUploadRequest.builder(release)
                 .addAttachment(path1, SW360AttachmentType.LICENSE_AGREEMENT)
                 .addAttachment(path2, SW360AttachmentType.REQUIREMENT)
                 .build();
@@ -46,23 +52,25 @@ public class AttachmentUploadRequestTest {
     @Test
     public void testItemsListIsCopiedOnCreation() {
         Path path = Paths.get("foo");
-        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(new SW360Release())
+        AttachmentUploadRequest.Builder<SW360Release> builder =
+                AttachmentUploadRequest.builder(new SW360Release())
                 .addAttachment(path, SW360AttachmentType.DECISION_REPORT);
 
-        AttachmentUploadRequest request = builder.build();
+        AttachmentUploadRequest<SW360Release> request = builder.build();
         builder.addAttachment(Paths.get("bar"), SW360AttachmentType.COMPONENT_LICENSE_INFO_COMBINED);
-        assertThat(request.items())
+        assertThat(request.getItems())
                 .containsOnly(new AttachmentUploadRequest.Item(path, SW360AttachmentType.DECISION_REPORT));
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testItemsNonModifiable() {
         Path path = Paths.get("first");
-        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(new SW360Release())
+        AttachmentUploadRequest.Builder<SW360Release> builder =
+                AttachmentUploadRequest.builder(new SW360Release())
                 .addAttachment(path, SW360AttachmentType.DECISION_REPORT);
-        AttachmentUploadRequest request = builder.build();
+        AttachmentUploadRequest<SW360Release> request = builder.build();
 
-        request.items()
+        request.getItems()
                 .add(new AttachmentUploadRequest.Item(Paths.get("more"), SW360AttachmentType.SCAN_RESULT_REPORT));
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResultTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResultTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class AttachmentUploadResultTest {
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(AttachmentUploadResult.class)
+                .withNonnullFields("successfulUploads", "failedUploads")
+                .verify();
+    }
+
+    @Test
+    public void testToString() {
+        Path successPath = Paths.get("success.txt");
+        Path failurePath = Paths.get("error.doc");
+        Throwable exception = new IOException("Failed upload");
+        SW360Release release = new SW360Release();
+        release.setName("uploadTargetRelease");
+        AttachmentUploadResult result = new AttachmentUploadResult(release)
+                .addSuccessfulUpload(release,
+                        new AttachmentUploadRequest.Item(successPath, SW360AttachmentType.SCREENSHOT))
+                .addFailedUpload(new AttachmentUploadRequest.Item(failurePath,
+                        SW360AttachmentType.SOURCE_SELF), exception);
+        String s = result.toString();
+
+        assertThat(s)
+                .contains(successPath.toString(), failurePath.toString(), exception.getMessage(), release.toString());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSuccessUploadsNotModifiableInitial() {
+        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release());
+
+        result.successfulUploads()
+                .add(new AttachmentUploadRequest.Item(Paths.get("p"), SW360AttachmentType.SOURCE));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSuccessUploadsNotModifiableWhenFilled() {
+        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release())
+                .addSuccessfulUpload(new SW360Release(),
+                        new AttachmentUploadRequest.Item(Paths.get("p1"), SW360AttachmentType.SCREENSHOT));
+
+        result.successfulUploads()
+                .add(new AttachmentUploadRequest.Item(Paths.get("p2"), SW360AttachmentType.SOURCE));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFailedUploadsNotModifiableInitial() {
+        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release());
+
+        result.failedUploads()
+                .put(new AttachmentUploadRequest.Item(Paths.get("p"), SW360AttachmentType.SOURCE_SELF),
+                        new Exception());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFailedUploadsNotModifiableWhenFilled() {
+        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release())
+                .addFailedUpload(new AttachmentUploadRequest.Item(Paths.get("p1"),
+                        SW360AttachmentType.SOURCE_SELF), new Exception("e1"));
+
+        result.failedUploads()
+                .put(new AttachmentUploadRequest.Item(Paths.get("p2"), SW360AttachmentType.SOURCE_SELF),
+                        new Exception("e2"));
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResultTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/AttachmentUploadResultTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 import org.junit.Test;
@@ -24,8 +25,13 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public class AttachmentUploadResultTest {
     @Test
     public void testEquals() {
+        SW360Release release1 = new SW360Release();
+        release1.setName("release1");
+        SW360Release release2 = new SW360Release();
+        release2.setName("release2");
         EqualsVerifier.forClass(AttachmentUploadResult.class)
                 .withNonnullFields("successfulUploads", "failedUploads")
+                .withPrefabValues(SW360HalResource.class, release1, release2)
                 .verify();
     }
 
@@ -36,7 +42,7 @@ public class AttachmentUploadResultTest {
         Throwable exception = new IOException("Failed upload");
         SW360Release release = new SW360Release();
         release.setName("uploadTargetRelease");
-        AttachmentUploadResult result = new AttachmentUploadResult(release)
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(release)
                 .addSuccessfulUpload(release,
                         new AttachmentUploadRequest.Item(successPath, SW360AttachmentType.SCREENSHOT))
                 .addFailedUpload(new AttachmentUploadRequest.Item(failurePath,
@@ -49,7 +55,7 @@ public class AttachmentUploadResultTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSuccessUploadsNotModifiableInitial() {
-        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release());
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(new SW360Release());
 
         result.successfulUploads()
                 .add(new AttachmentUploadRequest.Item(Paths.get("p"), SW360AttachmentType.SOURCE));
@@ -57,7 +63,7 @@ public class AttachmentUploadResultTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSuccessUploadsNotModifiableWhenFilled() {
-        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release())
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(new SW360Release())
                 .addSuccessfulUpload(new SW360Release(),
                         new AttachmentUploadRequest.Item(Paths.get("p1"), SW360AttachmentType.SCREENSHOT));
 
@@ -67,7 +73,7 @@ public class AttachmentUploadResultTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testFailedUploadsNotModifiableInitial() {
-        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release());
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(new SW360Release());
 
         result.failedUploads()
                 .put(new AttachmentUploadRequest.Item(Paths.get("p"), SW360AttachmentType.SOURCE_SELF),
@@ -76,7 +82,7 @@ public class AttachmentUploadResultTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testFailedUploadsNotModifiableWhenFilled() {
-        AttachmentUploadResult result = new AttachmentUploadResult(new SW360Release())
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(new SW360Release())
                 .addFailedUpload(new AttachmentUploadRequest.Item(Paths.get("p1"),
                         SW360AttachmentType.SOURCE_SELF), new Exception("e1"));
 

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -307,7 +307,15 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         assertThat(downloadPath).hasValue(path);
     }
 
-    public static SW360Release mkSW360Release(String name) throws MalformedPackageURLException {
+    @Test
+    public void testUpdateRelease() throws MalformedPackageURLException {
+        SW360Release updatedRelease = mkSW360Release("updatedRelease");
+        when(releaseClient.patchRelease(release)).thenReturn(CompletableFuture.completedFuture(updatedRelease));
+
+        assertThat(block(releaseClientAdapter.updateRelease(release))).isEqualTo(updatedRelease);
+    }
+
+    private static SW360Release mkSW360Release(String name) throws MalformedPackageURLException {
         SW360Release sw360Release = new SW360Release();
 
         sw360Release.setVersion(RELEASE_VERSION1);

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -176,7 +176,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         SW360Release updatedRelease1 = createReleaseWithAttachments("attach1");
         SW360Release updatedRelease2 = createReleaseWithAttachments("attach1", "attach2");
 
-        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+        AttachmentUploadRequest<SW360Release> uploadRequest = AttachmentUploadRequest.builder(release)
                 .addAttachment(uploadPath1, attachmentType1)
                 .addAttachment(uploadPath2, attachmentType2)
                 .build();
@@ -207,7 +207,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         release.setEmbedded(createEmbeddedReleaseWithAttachments());
         SW360Release updatedRelease = createReleaseWithAttachments("attach1");
 
-        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+        AttachmentUploadRequest<SW360Release> uploadRequest = AttachmentUploadRequest.builder(release)
                 .addAttachment(uploadPath1, attachmentType1)
                 .addAttachment(uploadPath2, attachmentType2)
                 .addAttachment(uploadPath3, attachmentType3)
@@ -237,7 +237,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         Path uploadPath = Paths.get(fileName);
         SW360AttachmentType attachmentType = SW360AttachmentType.LEGAL_EVALUATION;
         release.setEmbedded(createEmbeddedReleaseWithAttachments(fileName));
-        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+        AttachmentUploadRequest<SW360Release> uploadRequest = AttachmentUploadRequest.builder(release)
                 .addAttachment(uploadPath, attachmentType)
                 .build();
 

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -73,35 +73,6 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
     }
 
     @Test
-    public void testGetOrCreateReleaseWithPatchRelease() {
-        SW360ReleaseLinkObjects links = getSw360ReleaseLinkObjects();
-        SW360SparseRelease sparseRelease = new SW360SparseRelease();
-        sparseRelease.setLinks(links);
-
-        when(releaseClient.getReleasesByExternalIds(release.getExternalIds()))
-                .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseRelease)));
-        when(releaseClient.getRelease(sparseRelease.getReleaseId()))
-                .thenReturn(CompletableFuture.completedFuture(release));
-
-        when(releaseClient.patchRelease(release))
-                .thenReturn(CompletableFuture.completedFuture(release));
-
-        SW360Release patchedRelease = block(releaseClientAdapter.getOrCreateRelease(release, true));
-
-        assertThat(patchedRelease).isEqualTo(release);
-        verify(releaseClient).getRelease(ID);
-        verify(releaseClient).patchRelease(release);
-    }
-
-    private static SW360ReleaseLinkObjects getSw360ReleaseLinkObjects() {
-        String releaseHref = "url/" + ID;
-        Self releaseSelf = new Self().setHref(releaseHref);
-        SW360ReleaseLinkObjects links = new SW360ReleaseLinkObjects();
-        links.setSelf(releaseSelf);
-        return links;
-    }
-
-    @Test
     public void testCreateRelease() {
         SW360SparseRelease sparseRelease = new SW360SparseRelease()
                 .setVersion(release.getVersion() + "-noMatch");
@@ -199,7 +170,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
                 .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseRelease)));
 
         Optional<SW360SparseRelease> releaseByExternalIds =
-                block(releaseClientAdapter.getReleaseByExternalIds(externalIds));
+                block(releaseClientAdapter.getSparseReleaseByExternalIds(externalIds));
 
         assertThat(releaseByExternalIds).isPresent();
         assertThat(releaseByExternalIds).hasValue(sparseRelease);
@@ -213,7 +184,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 
         Optional<SW360SparseRelease> releaseByExternalIds =
-                block(releaseClientAdapter.getReleaseByExternalIds(externalIds));
+                block(releaseClientAdapter.getSparseReleaseByExternalIds(externalIds));
         assertThat(releaseByExternalIds).isEmpty();
     }
 
@@ -225,7 +196,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
                         new SW360SparseRelease(), new SW360SparseRelease())));
 
         try {
-            block(releaseClientAdapter.getReleaseByExternalIds(externalIds));
+            block(releaseClientAdapter.getSparseReleaseByExternalIds(externalIds));
             fail("Multiple results not detected");
         } catch (SW360ClientException e) {
             assertThat(e.getMessage()).contains("Multiple releases");
@@ -242,7 +213,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(component)));
 
         Optional<SW360SparseRelease> releaseByNameAndVersion =
-                block(releaseClientAdapter.getReleaseByNameAndVersion(release));
+                block(releaseClientAdapter.getSparseReleaseByNameAndVersion(release.getName(), release.getVersion()));
 
         assertThat(releaseByNameAndVersion).isPresent();
         assertThat(releaseByNameAndVersion).hasValue(sparseRelease);

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -185,7 +185,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         when(releaseClient.uploadAndAttachAttachment(updatedRelease1, uploadPath2, attachmentType2))
                 .thenReturn(CompletableFuture.completedFuture(updatedRelease2));
 
-        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
+        AttachmentUploadResult<SW360Release> result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
 
         assertThat(result.getTarget()).isEqualTo(updatedRelease2);
         assertThat(result.isSuccess()).isTrue();
@@ -219,7 +219,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         when(releaseClient.uploadAndAttachAttachment(release, uploadPath3, attachmentType3))
                 .thenReturn(CompletableFuture.completedFuture(updatedRelease));
 
-        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
+        AttachmentUploadResult<SW360Release> result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
         assertThat(result.getTarget()).isEqualTo(updatedRelease);
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.successfulUploads())
@@ -241,7 +241,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
                 .addAttachment(uploadPath, attachmentType)
                 .build();
 
-        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
+        AttachmentUploadResult<SW360Release> result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
         assertThat(result.getTarget()).isEqualTo(release);
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.failedUploads().get(new AttachmentUploadRequest.Item(uploadPath, attachmentType)))

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
+import org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
@@ -27,6 +28,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Sparse
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -34,7 +36,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -43,6 +47,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class SW360ReleaseClientAdapterAsyncImplTest {
@@ -140,25 +145,108 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         }
     }
 
+    private static SW360SparseAttachment createAttachment(String file) {
+        SW360SparseAttachment attachment = new SW360SparseAttachment();
+        attachment.setFilename(file);
+        return attachment;
+    }
+
+    private static SW360Release createReleaseWithAttachments(String... files) {
+        SW360Release release = new SW360Release();
+        release.setEmbedded(createEmbeddedReleaseWithAttachments(files));
+        return release;
+    }
+
+    private static SW360ReleaseEmbedded createEmbeddedReleaseWithAttachments(String... files) {
+        SW360ReleaseEmbedded releaseEmbedded = new SW360ReleaseEmbedded();
+        Set<SW360SparseAttachment> attachmentSet = Arrays.stream(files)
+                .map(SW360ReleaseClientAdapterAsyncImplTest::createAttachment)
+                .collect(Collectors.toSet());
+        releaseEmbedded.setAttachments(attachmentSet);
+        return releaseEmbedded;
+    }
+
     @Test
-    public void testUploadAttachments() {
-        SW360ReleaseEmbedded sw360ReleaseEmbedded = new SW360ReleaseEmbedded();
-        sw360ReleaseEmbedded.setAttachments(Collections.emptySet());
-        release.setEmbedded(sw360ReleaseEmbedded);
+    public void testUploadAttachmentsSuccess() {
+        Path uploadPath1 = Paths.get("file1.doc");
+        SW360AttachmentType attachmentType1 = SW360AttachmentType.DOCUMENT;
+        Path uploadPath2 = Paths.get("sources.zip");
+        SW360AttachmentType attachmentType2 = SW360AttachmentType.SOURCE;
+        release.setEmbedded(createEmbeddedReleaseWithAttachments());
+        SW360Release updatedRelease1 = createReleaseWithAttachments("attach1");
+        SW360Release updatedRelease2 = createReleaseWithAttachments("attach1", "attach2");
 
-        SW360AttachmentType attachmentType = SW360AttachmentType.SOURCE;
-        Path path = Paths.get("");
+        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+                .addAttachment(uploadPath1, attachmentType1)
+                .addAttachment(uploadPath2, attachmentType2)
+                .build();
+        when(releaseClient.uploadAndAttachAttachment(release, uploadPath1, attachmentType1))
+                .thenReturn(CompletableFuture.completedFuture(updatedRelease1));
+        when(releaseClient.uploadAndAttachAttachment(updatedRelease1, uploadPath2, attachmentType2))
+                .thenReturn(CompletableFuture.completedFuture(updatedRelease2));
 
-        when(releaseClient.uploadAndAttachAttachment(release, path, attachmentType))
-                .thenReturn(CompletableFuture.completedFuture(release));
+        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
 
-        Map<Path, SW360AttachmentType> attachmentMap = new HashMap<>();
-        attachmentMap.put(path, attachmentType);
+        assertThat(result.getTarget()).isEqualTo(updatedRelease2);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.failedUploads()).isEmpty();
+        assertThat(result.successfulUploads()).contains(new AttachmentUploadRequest.Item(uploadPath1, attachmentType1),
+                new AttachmentUploadRequest.Item(uploadPath2, attachmentType2));
+    }
 
-        SW360Release releaseWithAttachment = block(releaseClientAdapter.uploadAttachments(this.release, attachmentMap));
+    @Test
+    public void testUploadAttachmentsWithFailures() {
+        Path uploadPath1 = Paths.get("failedUpload1.err");
+        SW360AttachmentType attachmentType1 = SW360AttachmentType.DESIGN;
+        Throwable failure1 = new IOException("I/O exception during upload");
+        Path uploadPath2 = Paths.get("failedUpload2.exc");
+        SW360AttachmentType attachmentType2 = SW360AttachmentType.BINARY_SELF;
+        Throwable failure2 = new SW360ClientException("Forbidden upload");
+        Path uploadPath3 = Paths.get("success.yes");
+        SW360AttachmentType attachmentType3 = SW360AttachmentType.CLEARING_REPORT;
+        release.setEmbedded(createEmbeddedReleaseWithAttachments());
+        SW360Release updatedRelease = createReleaseWithAttachments("attach1");
 
-        assertThat(releaseWithAttachment).isEqualTo(release);
-        verify(releaseClient).uploadAndAttachAttachment(release, path, attachmentType);
+        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+                .addAttachment(uploadPath1, attachmentType1)
+                .addAttachment(uploadPath2, attachmentType2)
+                .addAttachment(uploadPath3, attachmentType3)
+                .build();
+        when(releaseClient.uploadAndAttachAttachment(release, uploadPath1, attachmentType1))
+                .thenReturn(FutureUtils.failedFuture(failure1));
+        when(releaseClient.uploadAndAttachAttachment(release, uploadPath2, attachmentType2))
+                .thenReturn(FutureUtils.failedFuture(failure2));
+        when(releaseClient.uploadAndAttachAttachment(release, uploadPath3, attachmentType3))
+                .thenReturn(CompletableFuture.completedFuture(updatedRelease));
+
+        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
+        assertThat(result.getTarget()).isEqualTo(updatedRelease);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.successfulUploads())
+                .containsOnly(new AttachmentUploadRequest.Item(uploadPath3, attachmentType3));
+        assertThat(result.failedUploads()).hasSize(2);
+        assertThat(result.failedUploads().get(new AttachmentUploadRequest.Item(uploadPath1, attachmentType1)))
+                .isEqualTo(failure1);
+        assertThat(result.failedUploads().get(new AttachmentUploadRequest.Item(uploadPath2, attachmentType2)))
+                .isEqualTo(failure2);
+    }
+
+    @Test
+    public void testUploadAttachmentsDuplicate() {
+        String fileName = "alreadyExistingAttachment.1st";
+        Path uploadPath = Paths.get(fileName);
+        SW360AttachmentType attachmentType = SW360AttachmentType.LEGAL_EVALUATION;
+        release.setEmbedded(createEmbeddedReleaseWithAttachments(fileName));
+        AttachmentUploadRequest uploadRequest = AttachmentUploadRequest.builder(release)
+                .addAttachment(uploadPath, attachmentType)
+                .build();
+
+        AttachmentUploadResult result = block(releaseClientAdapter.uploadAttachments(uploadRequest));
+        assertThat(result.getTarget()).isEqualTo(release);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.failedUploads().get(new AttachmentUploadRequest.Item(uploadPath, attachmentType)))
+                .isInstanceOf(SW360ClientException.class);
+        verifyZeroInteractions(releaseClient);
     }
 
     @Test

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -74,9 +74,10 @@ public class SW360MetaDataUpdater {
 
     public SW360Release getOrCreateRelease(SW360Release sw360ReleaseFromArtifact) {
         Optional<SW360SparseRelease> optSparseReleaseByIds =
-                releaseClientAdapter.getReleaseByExternalIds(sw360ReleaseFromArtifact.getExternalIds());
+                releaseClientAdapter.getSparseReleaseByExternalIds(sw360ReleaseFromArtifact.getExternalIds());
         Optional<SW360SparseRelease> optSparseRelease = optSparseReleaseByIds.isPresent() ? optSparseReleaseByIds :
-                releaseClientAdapter.getReleaseByNameAndVersion(sw360ReleaseFromArtifact);
+                releaseClientAdapter.getSparseReleaseByNameAndVersion(sw360ReleaseFromArtifact.getName(),
+                        sw360ReleaseFromArtifact.getVersion());
         Optional<SW360Release> optRelease = optSparseRelease.flatMap(releaseClientAdapter::enrichSparseRelease)
                 .map(sw360ReleaseFromArtifact::mergeWith);
 

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -106,7 +106,7 @@ public class SW360MetaDataUpdater {
     }
 
     public SW360Release uploadAttachments(SW360Release sw360Release, Map<Path, SW360AttachmentType> attachments) {
-        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(sw360Release);
+        AttachmentUploadRequest.Builder<SW360Release> builder = AttachmentUploadRequest.builder(sw360Release);
         for (Map.Entry<Path, SW360AttachmentType> e : attachments.entrySet()) {
             builder = builder.addAttachment(e.getKey(), e.getValue());
         }

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -111,7 +111,7 @@ public class SW360MetaDataUpdater {
             builder = builder.addAttachment(e.getKey(), e.getValue());
         }
 
-        AttachmentUploadResult result = releaseClientAdapter.uploadAttachments(builder.build());
+        AttachmentUploadResult<SW360Release> result = releaseClientAdapter.uploadAttachments(builder.build());
         LOGGER.debug("Result of attachment upload operation: {}", result);
         if (!result.isSuccess()) {
             LOGGER.error("Failed to upload attachments: {}", result.failedUploads());

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -13,6 +13,8 @@
 package org.eclipse.sw360.antenna.sw360;
 
 import org.eclipse.sw360.antenna.model.license.License;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadRequest;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadResult;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360LicenseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ProjectClientAdapter;
@@ -104,7 +106,17 @@ public class SW360MetaDataUpdater {
     }
 
     public SW360Release uploadAttachments(SW360Release sw360Release, Map<Path, SW360AttachmentType> attachments) {
-        return releaseClientAdapter.uploadAttachments(sw360Release, attachments);
+        AttachmentUploadRequest.Builder builder = AttachmentUploadRequest.builder(sw360Release);
+        for (Map.Entry<Path, SW360AttachmentType> e : attachments.entrySet()) {
+            builder = builder.addAttachment(e.getKey(), e.getValue());
+        }
+
+        AttachmentUploadResult result = releaseClientAdapter.uploadAttachments(builder.build());
+        LOGGER.debug("Result of attachment upload operation: {}", result);
+        if (!result.isSuccess()) {
+            LOGGER.error("Failed to upload attachments: {}", result.failedUploads());
+        }
+        return result.getTarget();
     }
 
     /**

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -223,7 +223,7 @@ public class SW360MetaDataUpdaterTest {
         AttachmentUploadRequest<SW360Release> expRequest = AttachmentUploadRequest.builder(release)
                 .addAttachment(uploadPath, attachmentType)
                 .build();
-        AttachmentUploadResult result = new AttachmentUploadResult(release);
+        AttachmentUploadResult<SW360Release> result = new AttachmentUploadResult<>(release);
         when(releaseClientAdapter.uploadAttachments(expRequest))
                 .thenReturn(result);
 

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -11,12 +11,15 @@
 package org.eclipse.sw360.antenna.sw360;
 
 import org.eclipse.sw360.antenna.model.license.License;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadRequest;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadResult;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360LicenseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ProjectClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360Visibility;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectType;
@@ -26,6 +29,8 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import org.mockito.ArgumentCaptor;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -212,14 +217,21 @@ public class SW360MetaDataUpdaterTest {
     @Test
     public void testUploadAttachments() {
         final SW360Release release = new SW360Release();
-        when(releaseClientAdapter.uploadAttachments(release, Collections.emptyMap()))
-                .thenReturn(release);
+        Path uploadPath = Paths.get("upload.doc");
+        SW360AttachmentType attachmentType = SW360AttachmentType.SOURCE;
+        Map<Path, SW360AttachmentType> attachments = Collections.singletonMap(uploadPath, attachmentType);
+        AttachmentUploadRequest expRequest = AttachmentUploadRequest.builder(release)
+                .addAttachment(uploadPath, attachmentType)
+                .build();
+        AttachmentUploadResult result = new AttachmentUploadResult(release);
+        when(releaseClientAdapter.uploadAttachments(expRequest))
+                .thenReturn(result);
 
         setUp(true, false);
 
-        final SW360Release releaseWithAttachment = metaDataUpdater.uploadAttachments(release, Collections.emptyMap());
+        final SW360Release releaseWithAttachment = metaDataUpdater.uploadAttachments(release, attachments);
 
         assertThat(releaseWithAttachment).isEqualTo(release);
-        verify(releaseClientAdapter).uploadAttachments(release, Collections.emptyMap());
+        verify(releaseClientAdapter).uploadAttachments(expRequest);
     }
 }

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -220,7 +220,7 @@ public class SW360MetaDataUpdaterTest {
         Path uploadPath = Paths.get("upload.doc");
         SW360AttachmentType attachmentType = SW360AttachmentType.SOURCE;
         Map<Path, SW360AttachmentType> attachments = Collections.singletonMap(uploadPath, attachmentType);
-        AttachmentUploadRequest expRequest = AttachmentUploadRequest.builder(release)
+        AttachmentUploadRequest<SW360Release> expRequest = AttachmentUploadRequest.builder(release)
                 .addAttachment(uploadPath, attachmentType)
                 .build();
         AttachmentUploadResult result = new AttachmentUploadResult(release);

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -101,9 +101,12 @@ public class SW360MetaDataUpdaterTest {
     @Test
     public void testGetOrCreateRelease() {
         final SW360Release release = new SW360Release();
+        release.setName("test-component");
+        release.setVersion("0.1-alpha");
         final SW360Release newRelease = new SW360Release();
-        when(releaseClientAdapter.getReleaseByExternalIds(any())).thenReturn(Optional.empty());
-        when(releaseClientAdapter.getReleaseByNameAndVersion(release)).thenReturn(Optional.empty());
+        when(releaseClientAdapter.getSparseReleaseByExternalIds(any())).thenReturn(Optional.empty());
+        when(releaseClientAdapter.getSparseReleaseByNameAndVersion(release.getName(), release.getVersion()))
+                .thenReturn(Optional.empty());
         when(releaseClientAdapter.createRelease(release)).thenReturn(newRelease);
         setUp(true, true);
 
@@ -121,7 +124,7 @@ public class SW360MetaDataUpdaterTest {
         final String copyright = "(C) Test copyright";
         queryRelease.setExternalIds(extIDs);
         foundRelease.setCopyrights(copyright);
-        when(releaseClientAdapter.getReleaseByExternalIds(extIDs)).thenReturn(Optional.of(sparseRelease));
+        when(releaseClientAdapter.getSparseReleaseByExternalIds(extIDs)).thenReturn(Optional.of(sparseRelease));
         when(releaseClientAdapter.enrichSparseRelease(sparseRelease)).thenReturn(Optional.of(foundRelease));
         when(releaseClientAdapter.updateRelease(any()))
                 .thenAnswer((Answer<SW360Release>) invocationOnMock -> {
@@ -142,8 +145,11 @@ public class SW360MetaDataUpdaterTest {
         SW360Release queryRelease = new SW360Release();
         queryRelease.setExternalIds(Collections.singletonMap("id", "42"));
         foundRelease.setExternalIds(Collections.singletonMap("id2", "47"));
-        when(releaseClientAdapter.getReleaseByExternalIds(queryRelease.getExternalIds())).thenReturn(Optional.empty());
-        when(releaseClientAdapter.getReleaseByNameAndVersion(queryRelease)).thenReturn(Optional.of(sparseRelease));
+        queryRelease.setName("theComponent");
+        queryRelease.setVersion("100.0");
+        when(releaseClientAdapter.getSparseReleaseByExternalIds(queryRelease.getExternalIds())).thenReturn(Optional.empty());
+        when(releaseClientAdapter.getSparseReleaseByNameAndVersion(queryRelease.getName(), queryRelease.getVersion()))
+                .thenReturn(Optional.of(sparseRelease));
         when(releaseClientAdapter.enrichSparseRelease(sparseRelease)).thenReturn(Optional.of(foundRelease));
         setUp(true, false);
 


### PR DESCRIPTION
Issue 426

This PR is part of the redesign of the SW360 client library. It focuses on the API of the client for releases with the goal to remove methods specific to Antenna use cases and replace them with more generic methods. Antenna-specific logic therefore has been moved to the classes in the workflow and compliance-tool packages.

Methods considered Antenna-specific are for instance getOrCreateRelease() with an integrated update of an existing release entity, or the methods that lookup releases based on a passed in release object.

A missing update() method has been added, and the API to upload attachments has been improved.

Javadoc has been added to all methods in the interfaces.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi @blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
Where necessary, existing unit tests have been adapted where logic has been moved. For new classes, new unit tests have been created.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
