### PR TITLE
Oheger bosch/sw360/#426 bug attachment upload

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/config/SW360ClientConfig.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/config/SW360ClientConfig.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.Validate;
 import org.eclipse.sw360.antenna.http.HttpClient;
 import org.eclipse.sw360.antenna.http.utils.HttpConstants;
 
+import java.net.URI;
 import java.util.Objects;
 
 /**
@@ -45,7 +46,7 @@ public final class SW360ClientConfig {
     /**
      * The base URL of the SW360 REST API.
      */
-    private final String restURL;
+    private final URI baseURI;
 
     /**
      * The URL of the token endpoint to query access tokens.
@@ -82,9 +83,9 @@ public final class SW360ClientConfig {
      */
     private final ObjectMapper objectMapper;
 
-    private SW360ClientConfig(String restURL, String authURL, String user, String password, String clientId,
+    private SW360ClientConfig(URI baseURI, String authURL, String user, String password, String clientId,
                               String clientPassword, HttpClient httpClient, ObjectMapper objectMapper) {
-        this.restURL = restURL;
+        this.baseURI = baseURI;
         this.authURL = authURL;
         this.user = user;
         this.password = password;
@@ -99,6 +100,7 @@ public final class SW360ClientConfig {
      * provided.
      *
      * @param restURL        the base URL for REST requests to the SW360 instance
+     *                       (must be a valid URL)
      * @param authURL        the URL to request access tokens
      * @param user           the SW360 user
      * @param password       the password of the user
@@ -109,12 +111,13 @@ public final class SW360ClientConfig {
      * @return the newly created instance
      * @throws NullPointerException     if a required parameter is missing
      * @throws IllegalArgumentException if a required string parameter is empty
+     *                                  or has an invalid value
      */
     public static SW360ClientConfig createConfig(String restURL, String authURL, String user,
                                                  String password, String clientId, String clientPassword,
                                                  HttpClient httpClient, ObjectMapper mapper) {
         return new SW360ClientConfig(
-                stripTrailingSeparator(Validate.notEmpty(restURL, "Undefined REST URL")),
+                URI.create(stripTrailingSeparator(Validate.notEmpty(restURL, "Undefined REST URL"))),
                 stripTrailingSeparator(Validate.notEmpty(authURL, "Undefined authentication URL")),
                 Validate.notEmpty(user, "Undefined user"),
                 Validate.notEmpty(password, "Undefined password"),
@@ -132,7 +135,19 @@ public final class SW360ClientConfig {
      * @return the SW360 base REST URL
      */
     public String getRestURL() {
-        return restURL;
+        return baseURI.toString();
+    }
+
+    /**
+     * Returns the base URI for sending REST requests to the configured SW360
+     * server. This method returns an equivalent URI as {@link #getRestURL()};
+     * however, the return type URI allows for more complex operations with the
+     * URL.
+     *
+     * @return the base URI for REST requests
+     */
+    public URI getBaseURI() {
+        return baseURI;
     }
 
     /**

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentAwareClient.java
@@ -98,7 +98,7 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?, ?
         SW360Attachment sw360Attachment = new SW360Attachment(fileToAttach, kindToAttach);
         final String self = itemToModify.getLinks().getSelf().getHref();
         return executeJsonRequest(builder -> builder.method(RequestBuilder.Method.POST)
-                        .uri(self + ATTACHMENTS_ENDPOINT)
+                        .uri(resolveAgainstBase(self + ATTACHMENTS_ENDPOINT).toString())
                         .multiPart("attachment", part ->
                                 part.json(sw360Attachment))
                         .multiPart("file", part ->

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/config/SW360ClientConfigTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/config/SW360ClientConfigTest.java
@@ -54,6 +54,12 @@ public class SW360ClientConfigTest {
         SW360ClientConfig.createConfig("", AUTH_URL, USER, PASSWORD, CLIENT_ID, CLIENT_PASS, httpClient, mapper);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidResUrlThrows() {
+        SW360ClientConfig.createConfig("this is not a valid URL?!", AUTH_URL, USER, PASSWORD, CLIENT_ID,
+                CLIENT_PASS, httpClient, mapper);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testNullAuthUrlThrows() {
         SW360ClientConfig.createConfig(REST_URL, null, USER, PASSWORD, CLIENT_ID, CLIENT_PASS, httpClient, mapper);
@@ -128,6 +134,7 @@ public class SW360ClientConfigTest {
         assertThat(config.getClientPassword()).isEqualTo(CLIENT_PASS);
         assertThat(config.getHttpClient()).isEqualTo(httpClient);
         assertThat(config.getObjectMapper()).isEqualTo(mapper);
+        assertThat(config.getBaseURI().toString()).isEqualTo(REST_URL);
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentClientIT.java
@@ -80,7 +80,7 @@ public class SW360AttachmentClientIT extends AbstractMockServerTest {
     @Test
     public void testUploadAttachment() throws URISyntaxException, IOException {
         String urlPath = "/releases/rel1234567890";
-        String selfUrl = wireMockRule.baseUrl() + urlPath;
+        String selfUrl = "https://some.uri.to.be.replaced" + urlPath;
         Path attachmentPath = Paths.get(resolveTestFileURL("license.json").toURI());
         byte[] attachmentContent = Files.readAllBytes(attachmentPath);
         SW360Attachment attachment = new SW360Attachment(attachmentPath, SW360AttachmentType.DOCUMENT);

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ClientTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ClientTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.antenna.http.HttpClient;
+import org.eclipse.sw360.antenna.sw360.client.auth.AccessTokenProvider;
+import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class SW360ClientTest {
+    private static final String BASE = "https://scott:tiger@www.eclipse.org";
+    private static final String BASE_REST_URI = BASE + "/sw360";
+
+    private SW360Client client;
+
+    @Before
+    public void setUp() {
+        SW360ClientConfig config = SW360ClientConfig.createConfig(BASE_REST_URI,
+                BASE_REST_URI + "/auth/token",
+                "scott", "tiger", "CLIENT_ID", "CLIENT_PASSWORD",
+                mock(HttpClient.class), mock(ObjectMapper.class));
+        client = new SW360ComponentClient(config, mock(AccessTokenProvider.class));
+    }
+
+    @Test
+    public void testCorrectUriIsResolved() {
+        final String uri = BASE_REST_URI + "/releases/1234567890/attachments";
+
+        assertThat(client.resolveAgainstBase(uri).toString()).isEqualTo(uri);
+    }
+
+    @Test
+    public void testBaseIsCorrectlySetWhenResolving() {
+        final String path = "/some/relative/path?foo=bar&baz=blub#fragment";
+        final String uri = "http://other.host.org" + path;
+
+        assertThat(client.resolveAgainstBase(uri).toString()).isEqualTo(BASE_REST_URI + path);
+    }
+
+    @Test
+    public void testRelativeUriCanBeResolved() {
+        final String relativeUri = "/some/relative/path";
+
+        assertThat(client.resolveAgainstBase(relativeUri).toString()).isEqualTo(BASE_REST_URI + relativeUri);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testErrorHandling() {
+        client.resolveAgainstBase(":");
+    }
+}


### PR DESCRIPTION
Issue 426

This PR is part of the tuning/redesign of the SW360 client API. It addresses a problem with the upload of attachments to SW360.

The URLs used to upload attachments are generated based on the self links returned in responses of SW360. In some cases, these URLs are not correct though. For instance, when running behind a load-balancer in the cloud, the URLs use http:// as scheme, while actually https:// requests must be issued.

To deal with this behavior, a method was added to _SW360Client_ which constructs a URL relative to the configured base REST URI of the SW360 instance. This makes sure that the correct endpoint is used. The client class supporting attachments now uses this method to generate the correct URL for POST requests to upload attachments.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
bug fix

### How Has This Been Tested?
Tests have been added for the new functionality to resolve URIs. The integration test for attachment uploads now also checks whether the URL is correctly generated.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
