### PR TITLE
URLs to download attachments are now resolved correctly.

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentAwareClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentAwareClient.java
@@ -133,7 +133,7 @@ public abstract class SW360AttachmentAwareClient<T extends SW360HalResource<?, ?
             }
             Path targetFile = downloadPath.resolve(attachment.getFilename());
 
-            return executeRequest(builder -> builder.uri(url)
+            return executeRequest(builder -> builder.uri(resolveAgainstBase(url).toString())
                     .header(HttpConstants.HEADER_ACCEPT, HttpConstants.CONTENT_OCTET_STREAM),
                     response -> {
                         Files.copy(response.bodyStream(), targetFile, StandardCopyOption.REPLACE_EXISTING);

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360AttachmentClientIT.java
@@ -148,7 +148,7 @@ public class SW360AttachmentClientIT extends AbstractMockServerTest {
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
                         .withBodyFile(testFile)));
 
-        Path path = waitFor(attachmentClient.downloadAttachment(wireMockRule.baseUrl() + itemRef,
+        Path path = waitFor(attachmentClient.downloadAttachment("https://host.to.be.ignored" + itemRef,
                 attachment, downloadDir));
         assertThat(path.getFileName().toString()).isEqualTo(ATTACHMENT_FILE);
         assertThat(path.getParent()).isEqualTo(downloadDir);


### PR DESCRIPTION
Issue: eclipse#426.

SW360AttachmentAwareClient generates the URI to download an attachment
from the self link of the entity affected. It therefore has to be
resolved against the configured base URI.

This is analogous to yesterday's PR for the attachment download operation.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
bug fix

### How Has This Been Tested?
The existing test was extended to cover the error case.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)

