### PR TITLE
Add ort downloader to processor list in documentation

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/ort-downloader.md
+++ b/antenna-documentation/src/site/markdown/processors/ort-downloader.md
@@ -1,5 +1,6 @@
 ## ORT Downloader 
 The ORT Downloader processor downloads the sources of each artifact if no `ArtifactSourceFile` fact is present.
+For a source to be downloaded the artifact requires either a source url or version control information. 
 
 ### HowTo Use
 Add the following step into the `<processors>` section of your workflow.xml

--- a/antenna-documentation/src/site/markdown/processors/processors.md
+++ b/antenna-documentation/src/site/markdown/processors/processors.md
@@ -8,6 +8,7 @@ specific attributes of the artifacts. Aside from a processor enriching artifact 
 * [License Knowledgebase resolver](./license-knowledgebase-resolver.html)
 * [License resolver](./license-resolver.html)
 * [Manifest resolver](manifest-resolver.html)
+* [Ort Downloader](ort-downloader.html)
 * [SW360 Enricher](./sw360-enricher.html)
 
 ### Validators


### PR DESCRIPTION
Ort downloader is now included in the list of processors. 
Additionally, a line was added that explains what information is needed in the artifact. 

### Request Reviewer
> You can add desired reviewers here with an @mention.
@bs-ondem 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  documentation update

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
