### PR TITLE
Removed Antenna runtime from attribution-document-core

### DIFF
--- a/modules/attribution-document/attribution-document-core/pom.xml
+++ b/modules/attribution-document/attribution-document-core/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.package-url</groupId>
-            <artifactId>packageurl-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/modules/attribution-document/attribution-document-core/pom.xml
+++ b/modules/attribution-document/attribution-document-core/pom.xml
@@ -31,11 +31,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.sw360.antenna</groupId>
-            <artifactId>runtime</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
The Antenna runtime was removed from the attribution-document-core due
to it was a unused dependency. As a result, there is no circular
dependency in the new ORT PDF reporter.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>

### Request Reviewer
@sschuberth 