### PR TITLE
Oheger bosch/compliance/#529 workflow support exporter

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SourcesExporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SourcesExporter.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.exporter;
+
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapterAsync;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+/**
+ * <p>
+ * An internally used helper class that handles the download of source
+ * attachments for releases.
+ * </p>
+ * <p>
+ * The compliance tool exporter delegates to an instance of this class for all
+ * download-related functionality.
+ * </p>
+ */
+class SourcesExporter {
+    private static final Logger LOG = LoggerFactory.getLogger(SourcesExporter.class);
+
+    private final Path sourcePath;
+
+    /**
+     * Creates a new instance of {@code SourcesExporter} and sets the directory
+     * where sources are to be downloaded.
+     *
+     * @param sourcePath the path to the sources directory
+     */
+    public SourcesExporter(Path sourcePath) {
+        this.sourcePath = sourcePath;
+    }
+
+    /**
+     * Downloads all source attachments for the given list of releases to the
+     * configured download directory. The method ignores (just logs) errors and
+     * returns a collection with information about the releases and the
+     * attachments that could be downloaded successfully. The download is done
+     * in parallel as far as possible (limited by the thread pool used by the
+     * HTTP client).
+     *
+     * @param releaseAdapter the SW360 release client adapter
+     * @param releases       the list with releases to be processed
+     * @return a collection with the releases and the attachment paths that
+     * were downloaded
+     */
+    public Collection<ReleaseWithSources> downloadSources(SW360ReleaseClientAdapterAsync releaseAdapter,
+                                                          Collection<SW360Release> releases) {
+        final ConcurrentMap<ReleaseWithSources, Boolean> processedReleases = new ConcurrentHashMap<>();
+        CompletableFuture<?>[] releaseFutures = releases.stream()
+                .map(release -> downloadSourcesForRelease(releaseAdapter, release)
+                        .thenApply(relWithSrc -> processedReleases.put(relWithSrc, Boolean.TRUE)))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture<Void> downloadFuture = CompletableFuture.allOf(releaseFutures);
+
+        downloadFuture.join();
+        return processedReleases.keySet();
+    }
+
+    /**
+     * Removes all files from the sources directory which are not referenced by
+     * one of the given releases. This method can be called after the download
+     * is complete to clean-up the directory from files that are no longer
+     * relevant for the compliance workflow.
+     *
+     * @param releases the list with currently relevant releases
+     */
+    public void removeUnreferencedFiles(Collection<ReleaseWithSources> releases) {
+        Set<Path> referencedPaths = releases.stream()
+                .flatMap(release -> release.getSourceAttachmentPaths().stream())
+                .collect(Collectors.toSet());
+
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(sourcePath)) {
+            for (Path path : dirStream) {
+                if (!referencedPaths.contains(path)) {
+                    LOG.info("Removing unreferenced source attachment {}.", path);
+                    try {
+                        Files.delete(path);
+                    } catch (IOException e) {
+                        LOG.warn("Could not delete source attachment {}", path, e);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOG.error("Could not open stream for sources directory {}", sourcePath, e);
+        }
+    }
+
+    /**
+     * Handles the attachment downloads for a single release. All attachments
+     * of type <em>source</em> assigned to the release are downloaded (in
+     * parallel). A future with the resulting {@code ReleaseWithSources} object
+     * is returned.
+     *
+     * @param releaseAdapter the SW360 release client adapter
+     * @param release        the release to be processed
+     * @return an object with the result of the download operations
+     */
+    private CompletableFuture<ReleaseWithSources>
+    downloadSourcesForRelease(SW360ReleaseClientAdapterAsync releaseAdapter, SW360Release release) {
+        final ConcurrentMap<Path, Boolean> paths = new ConcurrentHashMap<>();
+        CompletableFuture<?>[] downloads = release.getEmbedded().getAttachments().stream()
+                .filter(attachment -> attachment.getAttachmentType() == SW360AttachmentType.SOURCE)
+                .map(attachment -> downloadAttachment(releaseAdapter, release, attachment, paths))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(downloads)
+                .thenApply(v -> new ReleaseWithSources(release, paths.keySet()));
+    }
+
+    /**
+     * Downloads a single source attachment. If the download is successful,
+     * the result is stored in the given map.
+     *
+     * @param releaseAdapter the release adapter
+     * @param release        the release the download is for
+     * @param attachment     the attachment to be downloaded
+     * @param paths          the map for storing the download result
+     * @return a future that completes when the download is finished
+     */
+    private CompletableFuture<Object> downloadAttachment(SW360ReleaseClientAdapterAsync releaseAdapter,
+                                                         SW360Release release, SW360SparseAttachment attachment,
+                                                         ConcurrentMap<Path, Boolean> paths) {
+        return releaseAdapter.downloadAttachment(release, attachment, sourcePath)
+                .handle((optPath, ex) -> {
+                    if (ex == null) {
+                        if (optPath.isPresent()) {
+                            paths.put(optPath.get(), Boolean.TRUE);
+                        } else {
+                            LOG.warn("Could not resolve attachment {} for release {}:{}", attachment.getFilename(),
+                                    release.getName(), release.getVersion());
+                        }
+                    } else {
+                        LOG.error("Failed to download attachment {} for release {}:{}", attachment.getFilename(),
+                                release.getName(), release.getVersion(), ex);
+                    }
+                    return null;
+                });
+    }
+
+    /**
+     * A data class storing information about a release and the paths to the
+     * source attachments that have been downloaded.
+     */
+    static final class ReleaseWithSources {
+        /**
+         * The release.
+         */
+        private final SW360Release release;
+
+        /**
+         * A set with paths to source attachments that have been downloaded.
+         */
+        private final Set<Path> sourceAttachmentPaths;
+
+        public ReleaseWithSources(SW360Release release, Set<Path> sourceAttachmentPaths) {
+            this.release = release;
+            this.sourceAttachmentPaths = Collections.unmodifiableSet(new HashSet<>(sourceAttachmentPaths));
+        }
+
+        /**
+         * Returns the release.
+         *
+         * @return the release
+         */
+        public SW360Release getRelease() {
+            return release;
+        }
+
+        /**
+         * Returns an unmodifiable set with paths to attachments that have been
+         * downloaded.
+         *
+         * @return the set of downloaded attachment paths
+         */
+        public Set<Path> getSourceAttachmentPaths() {
+            return sourceAttachmentPaths;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ReleaseWithSources that = (ReleaseWithSources) o;
+            return Objects.equals(getRelease(), that.getRelease()) &&
+                    Objects.equals(getSourceAttachmentPaths(), that.getSourceAttachmentPaths());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getRelease(), getSourceAttachmentPaths());
+        }
+    }
+}

--- a/assembly/compliance-tool/src/site/markdown/index.md.vm
+++ b/assembly/compliance-tool/src/site/markdown/index.md.vm
@@ -47,6 +47,7 @@ The csv file follows the csv format accepted by the CSV Analyzer of ${docNameCap
 - `sourcesDirectory`: Directory where the sources downloaded are stored
 - `basedir`: Base directory of the execution
 - `csvFilePath`: Path and name where the csv file should be saved
+- `removeUnreferencedSources`: A boolean property that controls whether the exporter should do some cleanup on the sources directory. If set to *true*, the exporter checks after the download of sources whether the directory contains any files that are not referenced by any of the components that have been written to the CSV file. Such files are then removed, so that the directory contains only the sources of components that are currently in focus. The default value of this flag if *false*. 
 - `proxyHost`: If a proxy is in use, supply the host name
 - `proxyPort`: If a proxy is in use, supply the port
 - `proxyUse`: If a proxy is in use, this should be set to true

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SourcesExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SourcesExporterTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2019.
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.exporter;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapterAsync;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseEmbedded;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils.failedFuture;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SourcesExporterTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * The path where to store downloaded files.
+     */
+    private Path sourcePath;
+
+    /**
+     * Mock for the release client adapter.
+     */
+    private SW360ReleaseClientAdapterAsync releaseAdapter;
+
+    /**
+     * The exporter to be tested.
+     */
+    private SourcesExporter sourcesExporter;
+
+    @Before
+    public void setUp() throws IOException {
+        sourcePath = folder.newFolder().toPath();
+        releaseAdapter = mock(SW360ReleaseClientAdapterAsync.class);
+        sourcesExporter = new SourcesExporter(sourcePath);
+    }
+
+    /**
+     * Generates a number of source attachments for a test release.
+     *
+     * @param releaseIndex    the index of the test release
+     * @param attachmentCount the number of attachments to generate
+     * @return a set with the generated attachments
+     */
+    private static Set<SW360SparseAttachment> createAttachments(int releaseIndex, int attachmentCount) {
+        Set<SW360SparseAttachment> attachments = new HashSet<>();
+        for (int i = 0; i < attachmentCount; i++) {
+            SW360SparseAttachment attachment = createAttachment(releaseIndex, i);
+            attachments.add(attachment);
+        }
+        return attachments;
+    }
+
+    /**
+     * Creates a test attachment from the given parameters.
+     *
+     * @param releaseIndex    the index of the test release
+     * @param attachmentIndex the index of the test attachment
+     * @return the test attachment
+     */
+    private static SW360SparseAttachment createAttachment(int releaseIndex, int attachmentIndex) {
+        SW360SparseAttachment attachment = new SW360SparseAttachment();
+        attachment.setAttachmentType(SW360AttachmentType.SOURCE);
+        attachment.setFilename("release" + releaseIndex + "_source" + attachmentIndex + ".jar");
+        return attachment;
+    }
+
+    /**
+     * Creates a test release that contains the given set of attachments.
+     * attachments.
+     *
+     * @param releaseIndex the index of the test release
+     * @param attachments  the set with attachments
+     * @return the test release
+     */
+    private static SW360Release createReleaseWithAttachments(int releaseIndex, Set<SW360SparseAttachment> attachments) {
+        SW360Release release = new SW360Release();
+        release.setName("release" + releaseIndex);
+        SW360ReleaseEmbedded embedded = new SW360ReleaseEmbedded();
+        release.setEmbedded(embedded);
+        embedded.setAttachments(attachments);
+        return release;
+    }
+
+    /**
+     * Generates the path for the given attachment.
+     *
+     * @param attachment the attachment
+     * @return the path where to download this attachment
+     */
+    private Path attachmentPath(SW360SparseAttachment attachment) {
+        return sourcePath.resolve(attachment.getFilename());
+    }
+
+    /**
+     * Creates a {@code ReleaseWithSources} object from the given data.
+     *
+     * @param release     the release
+     * @param attachments the set with attachments
+     * @return the resulting release with sources
+     */
+    private SourcesExporter.ReleaseWithSources createReleaseWithSources(SW360Release release,
+                                                                        Set<SW360SparseAttachment> attachments) {
+        Set<Path> paths = attachments.stream()
+                .map(this::attachmentPath)
+                .collect(Collectors.toSet());
+        return new SourcesExporter.ReleaseWithSources(release, paths);
+    }
+
+    /**
+     * Prepares the mock for release client to expect successful download
+     * operations for the given set of attachments.
+     *
+     * @param release     the release affected
+     * @param attachments the attachments to be downloaded
+     */
+    private void expectDownloads(SW360Release release, Set<SW360SparseAttachment> attachments) {
+        attachments.forEach(attachment -> {
+            Path path = attachmentPath(attachment);
+            when(releaseAdapter.downloadAttachment(release, attachment, sourcePath))
+                    .thenReturn(CompletableFuture.completedFuture(Optional.of(path)));
+        });
+    }
+
+    @Test
+    public void testEqualsReleaseWithSources() {
+        EqualsVerifier.forClass(SourcesExporter.ReleaseWithSources.class)
+                .verify();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReleaseWithSourcesAttachmentsUnmodifiable() {
+        Set<SW360SparseAttachment> attachments = createAttachments(3, 8);
+        SourcesExporter.ReleaseWithSources releaseWithSources =
+                createReleaseWithSources(createReleaseWithAttachments(3, attachments), attachments);
+
+        releaseWithSources.getSourceAttachmentPaths().clear();
+    }
+
+    @Test
+    public void testAttachmentsAreDownloadedSuccessfully() {
+        Set<SW360SparseAttachment> attachments1 = createAttachments(1, 1);
+        Set<SW360SparseAttachment> attachments2 = createAttachments(2, 2);
+        SW360Release release1 = createReleaseWithAttachments(1, attachments1);
+        SW360Release release2 = createReleaseWithAttachments(2, attachments2);
+        List<SW360Release> releases = Arrays.asList(release1, release2);
+        List<SourcesExporter.ReleaseWithSources> expResult =
+                Arrays.asList(createReleaseWithSources(release1, attachments1),
+                        createReleaseWithSources(release2, attachments2));
+        expectDownloads(release1, attachments1);
+        expectDownloads(release2, attachments2);
+
+        Collection<SourcesExporter.ReleaseWithSources> result =
+                sourcesExporter.downloadSources(releaseAdapter, releases);
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expResult);
+    }
+
+    @Test
+    public void testUnresolvableAttachmentsAreHandled() {
+        SW360SparseAttachment attachment = createAttachment(1, 1);
+        SW360Release release = createReleaseWithAttachments(1, Collections.singleton(attachment));
+        when(releaseAdapter.downloadAttachment(release, attachment, sourcePath))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        Collection<SourcesExporter.ReleaseWithSources> result =
+                sourcesExporter.downloadSources(releaseAdapter, Collections.singleton(release));
+        assertThat(result).containsOnly(new SourcesExporter.ReleaseWithSources(release, Collections.emptySet()));
+    }
+
+    @Test
+    public void testOnlySourceAttachmentsAreDownloaded() {
+        Set<SW360SparseAttachment> sourceAttachments = createAttachments(1, 4);
+        SW360SparseAttachment otherAttachment = createAttachment(1, 42);
+        otherAttachment.setAttachmentType(SW360AttachmentType.SCREENSHOT);
+        Set<SW360SparseAttachment> attachments = new HashSet<>(sourceAttachments);
+        attachments.add(otherAttachment);
+        SW360Release release = createReleaseWithAttachments(1, attachments);
+        SourcesExporter.ReleaseWithSources releaseWithSources = createReleaseWithSources(release, sourceAttachments);
+        expectDownloads(release, sourceAttachments);
+
+        Collection<SourcesExporter.ReleaseWithSources> result =
+                sourcesExporter.downloadSources(releaseAdapter, Collections.singleton(release));
+        assertThat(result).containsOnly(releaseWithSources);
+    }
+
+    @Test
+    public void testExceptionsDuringAttachmentDownloadAreHandled() {
+        Set<SW360SparseAttachment> sourceAttachments = createAttachments(1, 2);
+        SW360SparseAttachment failedAttachment = createAttachment(1, 42);
+        Set<SW360SparseAttachment> attachments = new HashSet<>(sourceAttachments);
+        attachments.add(failedAttachment);
+        SW360Release release = createReleaseWithAttachments(1, attachments);
+        SourcesExporter.ReleaseWithSources releaseWithSources = createReleaseWithSources(release, sourceAttachments);
+        expectDownloads(release, sourceAttachments);
+        when(releaseAdapter.downloadAttachment(release, failedAttachment, sourcePath))
+                .thenReturn(failedFuture(new IOException("Download failed")));
+
+        Collection<SourcesExporter.ReleaseWithSources> result =
+                sourcesExporter.downloadSources(releaseAdapter, Collections.singleton(release));
+        assertThat(result).containsOnly(releaseWithSources);
+    }
+
+    /**
+     * Creates a test file at the given location.
+     *
+     * @param path the path of the test file
+     * @return the path to the file that was created
+     */
+    private static Path createTestFile(Path path) {
+        try {
+            return Files.write(path, "This is a test file".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new AssertionError("Could not create test file " + path);
+        }
+    }
+
+    /**
+     * Creates files for all the attachments of the given release.
+     *
+     * @param releaseWithSources the release
+     */
+    private static void createAttachmentFiles(SourcesExporter.ReleaseWithSources releaseWithSources) {
+        releaseWithSources.getSourceAttachmentPaths()
+                .forEach(SourcesExporterTest::createTestFile);
+    }
+
+    /**
+     * Checks that the given file exists.
+     *
+     * @param path the path to be checked
+     * @return a flag whether this file exists
+     */
+    private static boolean checkFileExists(Path path) {
+        return Files.exists(path);
+    }
+
+    /**
+     * Checks that all the attachment files referenced by the given release
+     * exist on the local disk.
+     *
+     * @param release the release to be checked
+     */
+    private static void checkAllAttachmentsExist(SourcesExporter.ReleaseWithSources release) {
+        assertThat(release.getSourceAttachmentPaths().stream().allMatch(SourcesExporterTest::checkFileExists))
+                .isTrue();
+    }
+
+    @Test
+    public void testUnreferencedFilesCanBeRemoved() {
+        Set<SW360SparseAttachment> attachments1 = createAttachments(1, 2);
+        Set<SW360SparseAttachment> attachments2 = createAttachments(2, 3);
+        SourcesExporter.ReleaseWithSources release1 =
+                createReleaseWithSources(createReleaseWithAttachments(1, attachments1), attachments1);
+        SourcesExporter.ReleaseWithSources release2 =
+                createReleaseWithSources(createReleaseWithAttachments(2, attachments2), attachments2);
+        Path unreferencedPath = attachmentPath(createAttachment(17, 47));
+        createTestFile(unreferencedPath);
+        createAttachmentFiles(release1);
+        createAttachmentFiles(release2);
+
+        sourcesExporter.removeUnreferencedFiles(Arrays.asList(release1, release2));
+        checkAllAttachmentsExist(release1);
+        checkAllAttachmentsExist(release2);
+        assertThat(checkFileExists(unreferencedPath)).isFalse();
+    }
+
+    @Test
+    public void testIOExceptionIsHandledWhenRemovingUnreferencedFiles() {
+        Path nonExisting = sourcePath.resolve("non/existing/sub/folder");
+        sourcesExporter = new SourcesExporter(nonExisting);
+
+        sourcesExporter.removeUnreferencedFiles(Collections.emptyList());
+    }
+
+    @Test
+    public void testIOExceptionDuringSingleFileRemoveOperationIsIgnored() throws IOException {
+        Path subFolder = Files.createDirectory(sourcePath.resolve("sub"));
+        Path subFile = createTestFile(subFolder.resolve("test.txt"));
+        Path file1 = createTestFile(sourcePath.resolve("file1.txt"));
+        Path file2 = createTestFile(sourcePath.resolve("ultimateFile.txt"));
+
+        sourcesExporter.removeUnreferencedFiles(Collections.emptyList());
+        assertThat(checkFileExists(file1)).isFalse();
+        assertThat(checkFileExists(file2)).isFalse();
+        assertThat(checkFileExists(subFile)).isTrue();
+    }
+}


### PR DESCRIPTION
Issue 529.

This PR extends the exporter of the compliance tool by the functionality to remove unreferenced sources from the sources directory. The functionality can be enabled by a new setting in the configuration properties file. If enabled, as a final step, the exporter iterates over the files in the sources directory and checks whether they belong to one of the current components. If not, they are deleted.

The export logic related to source attachments has been moved into a new class _SourcesExporter_. It is invoked from the main export process. The download of source attachments now also makes use of the asynchronous capabilities of the SW360 client library; this enables a concurrent download of attachments.

The documentation of the compliance tool has been extended to cover the new configuration property.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
new feature

### How Has This Been Tested?
A new test class for the new _SourcesExporter_ class has been added. The test cases for the exporter have been extended to check the collaboration with the sources exporter and the processing of the new configuration property.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
