### PR TITLE
Oheger bosch/compliance/#529 updater workflow

### DIFF
--- a/assembly/compliance-tool/src/site/markdown/index.md.vm
+++ b/assembly/compliance-tool/src/site/markdown/index.md.vm
@@ -72,6 +72,7 @@ It has the ability to update release information of already existing releases.
 - `csvFilePath`: Path and name to the csv file with the release information
 - `delimiter`: Delimiter used in the csv file to separate columns (by default it is `,`)
 - `encoding`: Encoding of the csv file, normally `UTF-8` 
+- `removeClearedSources`: A boolean property that controls whether the exporter should remove the source attachments of a release from the local sources directory once the release has been cleared. Cleared releases are no longer relevant for the workflow of the compliance tool; so by setting this property to *true*, an automatic cleanup of the sources directory can be enabled. The default value is *false*.
 - `proxyHost`: If a proxy is in use, supply the host name
 - `proxyPort`: If a proxy is in use, supply the port
 - `proxyUse`: If a proxy is in use, this should be set to true


### PR DESCRIPTION
Issue 529:

This PR adds another property to the configuration of the Compliance Tool Updater. If set to *true*, the exporter removes the source attachments from the local sources directory when a release has been cleared. So the directory gets cleaned up automatically when releases are no longer relevant for the compliance tool workflow.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
new feature

### How Has This Been Tested?
The existing test cases for the updater have been extended to cover the new functionality.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
