### PR TITLE
Change csv file name to csv file path

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/ComplianceFeatureUtils.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -68,9 +69,9 @@ public class ComplianceFeatureUtils {
         }
     }
 
-    public static Collection<Artifact> getArtifactsFromCsvFile(Map<String, String> properties) {
+    public static Collection<Artifact> getArtifactsFromCsvFile(Map<String, String> properties, Path csvFilePath) {
         char delimiter = properties.get("delimiter").charAt(0);
-        File csvFile = new File(properties.get("csvFilePath"));
+        File csvFile = csvFilePath.toFile();
         if (!csvFile.exists()) {
             throw new ConfigurationException("csvFile for " + csvFile.getName() + " could not be found");
         }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360Configuration.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360Configuration.java
@@ -29,7 +29,7 @@ import static org.eclipse.sw360.antenna.frontend.compliancetool.sw360.Compliance
 public class SW360Configuration extends ConfigurableWorkflowItem {
     private final SW360ConnectionConfigurationFactory connectionFactory;
     private final Map<String, String> properties;
-    private final String csvFileName;
+    private final Path csvFilePath;
     private final SW360Connection connection;
     private final Path targetDir;
     private final Path sourcesPath;
@@ -57,8 +57,8 @@ public class SW360Configuration extends ConfigurableWorkflowItem {
         baseDir = Paths.get(properties.get("basedir"));
         targetDir = baseDir.resolve(properties.get("targetDir"));
         sourcesPath = baseDir.resolve(properties.get("sourcesDirectory"));
+        csvFilePath = baseDir.resolve(properties.get("csvFilePath"));
         connection = makeConnection();
-        csvFileName = properties.get("csvFilePath");
     }
 
     private SW360Connection makeConnection() {
@@ -92,8 +92,8 @@ public class SW360Configuration extends ConfigurableWorkflowItem {
         return targetDir;
     }
 
-    public String getCsvFileName() {
-        return csvFileName;
+    public Path getCsvFilePath() {
+        return csvFilePath;
     }
 
     public Map<String, String> getProperties() {

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -96,8 +96,7 @@ public class SW360Exporter {
                 .map(this::releaseAsArtifact)
                 .collect(Collectors.toList());
 
-        File csvFile = configuration.getTargetDir()
-                .resolve(configuration.getCsvFileName())
+        File csvFile =  configuration.getCsvFilePath()
                 .toFile();
 
         CSVArtifactMapper csvArtifactMapper = new CSVArtifactMapper(csvFile.toPath(),
@@ -112,11 +111,10 @@ public class SW360Exporter {
         }
 
         LOGGER.info("The SW360Exporter was executed from the base directory: {} " +
-                        "with the csv file written to the path: {}/{} " +
+                        "with the csv file written to the path: {} " +
                         "and the source files written to the folder: {}. ",
                 configuration.getBaseDir().toAbsolutePath(),
-                configuration.getBaseDir().toAbsolutePath(),
-                configuration.getCsvFileName(),
+                csvFile.toPath(),
                 configuration.getTargetDir().toAbsolutePath());
     }
 

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -61,18 +61,17 @@ public class SW360Updater {
 
     public void execute() {
         LOGGER.debug("{} has started.", SW360Updater.class.getName());
-        Collection<Artifact> artifacts = getArtifactsFromCsvFile(configuration.getProperties());
+        Collection<Artifact> artifacts = getArtifactsFromCsvFile(configuration.getProperties(), configuration.getCsvFilePath());
 
         artifacts.forEach(this::uploadReleaseWithClearingDocumentFromArtifact);
 
 
         LOGGER.info("The SW360Exporter was executed from the base directory: {} " +
                         "with the csv file taken from the path: {}, " +
-                        "the clearing reports taken or temporarily created in: {}/{} " +
+                        "the clearing reports taken or temporarily created in: {} " +
                         "and the source files taken from the folder: {}.",
                 configuration.getBaseDir().toAbsolutePath(),
-                configuration.getBaseDir().toAbsolutePath(),
-                configuration.getCsvFileName(),
+                configuration.getCsvFilePath().toAbsolutePath(),
                 configuration.getTargetDir().toAbsolutePath(),
                 configuration.getSourcesPath().toAbsolutePath());
     }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/SW360ConfigurationTest.java
@@ -62,7 +62,7 @@ public class SW360ConfigurationTest {
         File propertiesFile = configFile("compliancetool-exporter.properties");
         SW360Configuration configuration = new SW360Configuration(propertiesFile);
         assertThat(configuration.getTargetDir()).isEqualTo(Paths.get("./"));
-        assertThat(configuration.getCsvFileName()).isEqualTo("sample.csv");
+        assertThat(configuration.getCsvFilePath()).isEqualTo(Paths.get("sample.csv"));
         assertThat(configuration.getConnection().getReleaseAdapter()).isNotNull();
         assertThat(configuration.getConnection().getComponentAdapter()).isNotNull();
     }
@@ -71,7 +71,7 @@ public class SW360ConfigurationTest {
     public void testConfigurationWithUpdaterPropertiesFile() {
         File propertiesFile = configFile("compliancetool-updater.properties");
         SW360Configuration configuration = new SW360Configuration(propertiesFile);
-        assertThat(new File(configuration.getCsvFileName()).getName()).isEqualTo("compliancetool_updater_test.csv");
+        assertThat(configuration.getCsvFilePath().toFile().getName()).isEqualTo("compliancetool_updater_test.csv");
         assertThat(configuration.getProperties().get("delimiter")).isEqualTo(",");
         assertThat(configuration.getProperties().get("sw360updateReleases")).isEqualTo("true");
         assertThat(configuration.getProperties().get("sw360uploadSources")).isEqualTo("false");

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterTest.java
@@ -161,8 +161,8 @@ public class SW360ExporterTest {
         when(config.getConnection())
                 .thenReturn(connectionMock);
         csvFile = folder.newFile("sample.csv");
-        when(config.getCsvFileName())
-                .thenReturn(csvFile.getName());
+        when(config.getCsvFilePath())
+                .thenReturn(csvFile.toPath());
         Path basePath = Paths.get(csvFile.getParent());
         when(config.getBaseDir())
                 .thenReturn(basePath);

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -99,12 +98,13 @@ public class SW360UpdaterTest {
 
     private void initBasicConfiguration(Path sourceAttachment, Map<String, String> propertiesMap) throws IOException {
         Path csvFile = writeCsvFile(sourceAttachment.toString());
-        propertiesMap.put("csvFilePath", csvFile.toString());
 
-        when(configurationMock.getProperties()).
-                thenReturn(propertiesMap);
+        when(configurationMock.getProperties())
+                .thenReturn(propertiesMap);
         when(configurationMock.getBaseDir())
-                .thenReturn(Paths.get(propertiesMap.get("csvFilePath")).getParent());
+                .thenReturn(csvFile.getParent());
+        when(configurationMock.getCsvFilePath())
+                .thenReturn(csvFile);
         when(configurationMock.getTargetDir())
                 .thenReturn(getTargetDir());
         when(configurationMock.getSourcesPath())


### PR DESCRIPTION
This way the Exporter does not use the target dir anymore and
both sources directory and csv file path can be given in the same
format.

This also gets rid of the issue, that the Logger message does
not reflect the actual path the csv file was written to, as
it mistakingly gave the basir+csvFileName as opposed to
targetdir+csvFileName

Issue: #529 

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bog fix / improvement

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

Tests are adapted to change

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
