### PR TITLE
Oheger bosch/compliance/#529 updater workflow

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -24,6 +24,7 @@ public class ClearingReportGenerator {
     Path createClearingDocument(SW360Release release, Path targetDir) {
         Path clearingDocument = targetDir.resolve(release.getId() + CLEARING_DOC_SUFFIX);
         try {
+            Files.createDirectories(targetDir);
             ObjectMapper mapper = new ObjectMapper();
             mapper.writeValue(Files.newBufferedWriter(clearingDocument), release);
             return clearingDocument;

--- a/assembly/compliance-tool/src/site/markdown/index.md.vm
+++ b/assembly/compliance-tool/src/site/markdown/index.md.vm
@@ -72,7 +72,8 @@ It has the ability to update release information of already existing releases.
 - `csvFilePath`: Path and name to the csv file with the release information
 - `delimiter`: Delimiter used in the csv file to separate columns (by default it is `,`)
 - `encoding`: Encoding of the csv file, normally `UTF-8` 
-- `removeClearedSources`: A boolean property that controls whether the exporter should remove the source attachments of a release from the local sources directory once the release has been cleared. Cleared releases are no longer relevant for the workflow of the compliance tool; so by setting this property to *true*, an automatic cleanup of the sources directory can be enabled. The default value is *false*.
+- `removeClearedSources`: A boolean property that controls whether the updater should remove the source attachments of a release from the local sources directory once the release has been cleared. Cleared releases are no longer relevant for the workflow of the compliance tool; so by setting this property to *true*, an automatic cleanup of the sources directory can be enabled. The default value is *false*.
+- `removeClearingDocuments`: A boolean property that controls whether clearing documents for releases should be removed after the release has been cleared. The default value is *false*.
 - `proxyHost`: If a proxy is in use, supply the host name
 - `proxyPort`: If a proxy is in use, supply the port
 - `proxyUse`: If a proxy is in use, this should be set to true

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360TestUtils;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 import org.junit.Before;
@@ -23,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,10 +57,13 @@ public class ClearingReportGeneratorTest {
         System.out.println(content);
     }
 
-    @Test(expected = ExecutionException.class)
-    public void testExceptionIsThrownOnFailedCreation() {
-        Path nonExistingFolder = Paths.get("non", "existing", "folder");
-        SW360Release release = SW360TestUtils.mkSW360Release("crash");
-        generator.createClearingDocument(release, nonExistingFolder);
+    @Test
+    public void testMissingFolderIsCreated() throws IOException {
+        Path root = folder.newFolder().toPath();
+        Path nonExistingFolder = root.resolve("non/existing/folder");
+        SW360Release release = SW360TestUtils.mkSW360Release("create");
+
+        Path clearingDocument = generator.createClearingDocument(release, nonExistingFolder);
+        assertThat(Files.exists(clearingDocument)).isTrue();
     }
 }


### PR DESCRIPTION
Issue 529.

This PR adds some improvements to the compliance tool updater:
* For automatically created clearing documents it is now guaranteed that the target directory is created if it does not exist.
* A new configuration property was added to control whether clearing documents should be removed after a release was cleared.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other


*Type of change*:  
new feature

### How Has This Been Tested?
Tests have been added to check the new functionality.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
- [X] I have updated the documentation accordingly to my changes 
