### PR TITLE
Compliance Tool: Refactor Updater Release Creation

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -20,6 +20,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360Att
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.utils.ArtifactToAttachmentUtils;
+import org.eclipse.sw360.antenna.sw360.utils.ArtifactToReleaseUtils;
 import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,11 +88,12 @@ public class SW360Updater {
     private void uploadReleaseWithClearingDocumentFromArtifact(Artifact artifact) {
         LOGGER.info("Processing {}.", artifact);
         try {
-            SW360Release release = updater.artifactToReleaseInSW360(artifact);
+            final SW360Release sw360ReleaseFromArtifact = ArtifactToReleaseUtils.convertToReleaseWithoutAttachments(artifact);
 
-            if (release.getClearingState() != null &&
-                    !release.getClearingState().isEmpty() &&
-                    ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITIAL) {
+            if (sw360ReleaseFromArtifact.getClearingState() != null &&
+                    !sw360ReleaseFromArtifact.getClearingState().isEmpty() &&
+                    ArtifactClearingState.ClearingState.valueOf(sw360ReleaseFromArtifact.getClearingState()) != ArtifactClearingState.ClearingState.INITIAL) {
+                SW360Release release = updater.artifactToReleaseInSW360(artifact, sw360ReleaseFromArtifact);
                 SW360ReleaseClientAdapter releaseClientAdapter = configuration.getConnection().getReleaseAdapter();
 
                 Path clearingDoc = getOrGenerateClearingDocument(release, artifact);

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -88,11 +88,12 @@ public class SW360Updater {
         LOGGER.info("Processing {}.", artifact);
         try {
             SW360Release release = updater.artifactToReleaseInSW360(artifact);
-            SW360ReleaseClientAdapter releaseClientAdapter = configuration.getConnection().getReleaseAdapter();
 
             if (release.getClearingState() != null &&
                     !release.getClearingState().isEmpty() &&
                     ArtifactClearingState.ClearingState.valueOf(release.getClearingState()) != ArtifactClearingState.ClearingState.INITIAL) {
+                SW360ReleaseClientAdapter releaseClientAdapter = configuration.getConnection().getReleaseAdapter();
+
                 Path clearingDoc = getOrGenerateClearingDocument(release, artifact);
                 AttachmentUploadRequest<SW360Release> uploadRequest = AttachmentUploadRequest.builder(release)
                         .addAttachment(clearingDoc,

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -43,10 +43,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(Parameterized.class)
 public class SW360UpdaterTest {
@@ -217,6 +214,8 @@ public class SW360UpdaterTest {
                     .map(entry -> new AttachmentUploadRequest.Item(entry.getKey(), entry.getValue()))
                     .collect(Collectors.toList());
             assertThat(uploadRequest.getItems()).containsAll(expItems);
+        } else {
+            verify(configurationMock, never()).getConnection();
         }
 
         boolean sourcePresent = Files.exists(sourceAttachment);

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/workflow/generators/SW360UpdaterImpl.java
@@ -58,13 +58,34 @@ public class SW360UpdaterImpl {
         sw360MetaDataUpdater.createProject(projectName, projectVersion, releases);
         return Collections.emptyMap();
     }
-    
-    public SW360Release artifactToReleaseInSW360(Artifact artifact) {
-        Set<String> licenseIds = getSetOfLicenseIds(artifact);
 
+    /**
+     * Maps an artifact onto an SW360Release object and either gets
+     * information about it from a SW360 instance or, if it does not
+     * exist in the instance yet, creates it
+     * @param artifact artifact to be transformed to release
+     * @return SW360Release on which artifact and additional information
+     * form SW360 instance have been mapped on.
+     */
+    public SW360Release artifactToReleaseInSW360(Artifact artifact) {
         final SW360Release sw360ReleaseFromArtifact = ArtifactToReleaseUtils.convertToReleaseWithoutAttachments(artifact);
-        sw360ReleaseFromArtifact.setMainLicenseIds(licenseIds);
-        SW360Release sw360ReleaseFinal = sw360MetaDataUpdater.getOrCreateRelease(sw360ReleaseFromArtifact);
+
+        return artifactToReleaseInSW360(artifact, sw360ReleaseFromArtifact);
+    }
+
+    /**
+     * Maps an artifacts licenses and sources onto an SW360Release object and
+     * either gets information about it from a SW360 instance or,
+     * if it does not exist in the instance yet, creates it.
+     * @param artifact artifact to be transformed to release
+     * @param release release on which artifact license, sources and
+     *                information form sw360 instance will be mapped
+     * @return mapped SW360Release
+     */
+    public SW360Release artifactToReleaseInSW360(Artifact artifact, SW360Release release) {
+        Set<String> licenseIds = getSetOfLicenseIds(artifact);
+        release.setMainLicenseIds(licenseIds);
+        SW360Release sw360ReleaseFinal = sw360MetaDataUpdater.getOrCreateRelease(release);
 
         sw360ReleaseFinal = handleSources(sw360ReleaseFinal, artifact);
 


### PR DESCRIPTION
Issue: #529 

This PR separates the creation of the release from the artifact and the enriching of information from the SW360 instance. 
This allows to check the set clearing state of the release created from the artifact before fetching the release from the SW360 instance. Thus, if no changes should be mode on the release, because the clearing state is still INITAL or null, no unnecessary calls are made. 

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  Improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Tests were adapted

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
