### PR TITLE
Neubs bsi/ct/clearing doc gen exception

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 
 import java.io.IOException;
@@ -29,7 +28,7 @@ public class ClearingReportGenerator {
             mapper.writeValue(Files.newBufferedWriter(clearingDocument), release);
             return clearingDocument;
         } catch (IOException e) {
-            throw new ExecutionException("Could not create clearing document " + clearingDocument.toString(), e);
+            throw new IllegalStateException("Could not create clearing document " + clearingDocument.toString(), e);
         }
     }
 }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,7 +29,7 @@ public class ClearingReportGenerator {
             mapper.writeValue(Files.newBufferedWriter(clearingDocument), release);
             return clearingDocument;
         } catch (IOException e) {
-            throw new IllegalStateException("Could not create clearing document " + clearingDocument.toString(), e);
+            throw new SW360ClientException("Could not create clearing document " + clearingDocument.toString(), e);
         }
     }
 }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -110,7 +110,7 @@ public class SW360Updater {
                     removeClearingDocument(clearingDoc);
                 }
             }
-        } catch (SW360ClientException e) {
+        } catch (SW360ClientException | IllegalStateException e) {
             LOGGER.error("Failed to process artifact {}.", artifact, e);
         }
     }

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360Updater.java
@@ -110,7 +110,7 @@ public class SW360Updater {
                     removeClearingDocument(clearingDoc);
                 }
             }
-        } catch (SW360ClientException | IllegalStateException e) {
+        } catch (SW360ClientException e) {
             LOGGER.error("Failed to process artifact {}.", artifact, e);
         }
     }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterParameterizedTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterParameterizedTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
+
+import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils;
+import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
+import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadRequest;
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
+import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class SW360UpdaterParameterizedTest {
+    private static final String CLEARING_DOC = "clearing.doc";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private final SW360Configuration configurationMock = mock(SW360Configuration.class);
+    private final SW360ReleaseClientAdapter releaseClientAdapter = mock(SW360ReleaseClientAdapter.class);
+
+    private final String clearingState;
+    private final boolean clearingDocAvailable;
+    private final boolean expectUpload;
+
+    public SW360UpdaterParameterizedTest(String clearingState, boolean clearingDocAvailable, boolean expectUpload) {
+        this.clearingState = clearingState;
+        this.clearingDocAvailable = clearingDocAvailable;
+        this.expectUpload = expectUpload;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"OSM_APPROVED", true, true},
+                {"EXTERNAL_SOURCE", true, true},
+                {"AUTO_EXTRACT", true, true},
+                {"PROJECT_APPROVED", true, true},
+                {"INITIAL", true, false},
+                {"", true, false},
+                {"OSM_APPROVED", false, true},
+                {"EXTERNAL_SOURCE", false, true},
+                {"AUTO_EXTRACT", false, true},
+                {"PROJECT_APPROVED", false, true},
+                {"INITIAL", false, false},
+                {"", false, false}
+
+        });
+    }
+
+    private void initConnectionConfiguration() {
+        SW360Connection connectionConfiguration = mock(SW360Connection.class);
+
+        when(connectionConfiguration.getReleaseAdapter())
+                .thenReturn(releaseClientAdapter);
+        when(configurationMock.getConnection())
+                .thenReturn(connectionConfiguration);
+    }
+
+    private void initBasicConfiguration(Path sourceAttachment, Map<String, String> propertiesMap) throws IOException {
+        Path csvFile = writeCsvFile(sourceAttachment.toString());
+
+        when(configurationMock.getProperties())
+                .thenReturn(propertiesMap);
+        when(configurationMock.getBaseDir())
+                .thenReturn(csvFile.getParent());
+        when(configurationMock.getCsvFilePath())
+                .thenReturn(csvFile);
+        when(configurationMock.getTargetDir())
+                .thenReturn(getTargetDir());
+        when(configurationMock.getSourcesPath())
+                .thenReturn(sourceAttachment.getParent());
+    }
+
+    private Map<String, String> getConfigProperties() {
+        String propertiesFilePath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).getPath();
+        return ComplianceFeatureUtils.mapPropertiesFile(new File(propertiesFilePath));
+    }
+
+    private Path createSourceAttachment() throws IOException {
+        Path sourcesPath = folder.newFolder("sources").toPath();
+        Path sourceAttachment = sourcesPath.resolve("testSources.zip");
+        return Files.write(sourceAttachment, "The whole source code".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @NotNull
+    private Path getTargetDir() {
+        return folder.getRoot().toPath();
+    }
+
+    @Test
+    public void testExecute() throws IOException {
+        runUpdaterTest(getConfigProperties(), false, true, false);
+    }
+
+    @Test
+    public void testExecuteWithSourcesCleanup() throws IOException {
+        Map<String, String> configProperties = getConfigProperties();
+        configProperties.put(SW360Updater.PROP_REMOVE_CLEARED_SOURCES, String.valueOf(true));
+
+        runUpdaterTest(configProperties, true, true, false);
+    }
+
+    @Test
+    public void testExecuteWithClearingDocumentRemoved() throws IOException {
+        Map<String, String> configProperties = getConfigProperties();
+        configProperties.put(SW360Updater.PROP_REMOVE_CLEARING_DOCS, String.valueOf(true));
+
+        runUpdaterTest(configProperties, false, true, true);
+    }
+
+    @Test
+    public void testErrorsWhenRemovingSourceFilesAreIgnored() throws IOException {
+        Map<String, String> configProperties = getConfigProperties();
+        configProperties.put(SW360Updater.PROP_REMOVE_CLEARED_SOURCES, String.valueOf(true));
+
+        runUpdaterTest(configProperties, false, false, false);
+    }
+
+    private void runUpdaterTest(Map<String, String> config, boolean expectSourceRemoved, boolean attachmentExists, boolean expectClearingDocRemoved)
+            throws IOException {
+        Path sourceAttachment = createSourceAttachment();
+        initBasicConfiguration(sourceAttachment, config);
+
+        initConnectionConfiguration();
+
+        SW360UpdaterImpl updater = mock(SW360UpdaterImpl.class);
+        SW360Release release = new SW360Release();
+        release.setClearingState(clearingState);
+        when(updater.artifactToReleaseInSW360(any(), any()))
+                .thenAnswer((Answer<SW360Release>) invocationOnMock -> {
+                    deleteSourceFileIfNotAttachmentExists(attachmentExists, sourceAttachment);
+                    return release;
+                })
+                .thenThrow(new SW360ClientException("Boo"));
+
+        ClearingReportGenerator generator = mock(ClearingReportGenerator.class);
+        Path clearingDoc = getTargetDir().resolve(CLEARING_DOC);
+        Files.write(clearingDoc, "The clearing document".getBytes(StandardCharsets.UTF_8));
+        when(generator.createClearingDocument(any(), any()))
+                .thenReturn(clearingDoc);
+
+        SW360Updater sw360Updater = new SW360Updater(updater, configurationMock, generator);
+
+        sw360Updater.execute();
+
+        Map<Path, SW360AttachmentType> testAttachmentMap = createExpectedAttachmentMap();
+
+        if (expectUpload && !clearingDocAvailable) {
+            verify(generator).createClearingDocument(release, getTargetDir());
+        }
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<AttachmentUploadRequest<SW360Release>> captor = ArgumentCaptor.forClass(AttachmentUploadRequest.class);
+        verify(releaseClientAdapter, times(expectUpload ? 1 : 0)).uploadAttachments(captor.capture());
+        if (expectUpload) {
+            verify(updater, times(2)).artifactToReleaseInSW360(any(), any());
+            AttachmentUploadRequest<SW360Release> uploadRequest = captor.getValue();
+            List<AttachmentUploadRequest.Item> expItems = testAttachmentMap.entrySet().stream()
+                    .map(entry -> new AttachmentUploadRequest.Item(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList());
+            assertThat(uploadRequest.getItems()).containsAll(expItems);
+        } else {
+            deleteSourceFileIfNotAttachmentExists(attachmentExists, sourceAttachment);
+            verify(updater, never()).artifactToReleaseInSW360(any(), any());
+        }
+
+        boolean sourcePresent = Files.exists(sourceAttachment);
+        assertThat(sourcePresent).isEqualTo((!expectUpload || !expectSourceRemoved) && attachmentExists);
+
+        boolean clearingDocPresent = Files.exists(clearingDoc);
+        assertThat(clearingDocPresent).isEqualTo(!expectUpload || !expectClearingDocRemoved);
+    }
+
+    /**
+     * This deletes the file at the given path if the boolean
+     * given is false.
+     *
+     * @param attachmentExists determines if file should exist or not
+     * @param sourceAttachment path to file that might get deleted
+     * @throws IOException
+     */
+    private void deleteSourceFileIfNotAttachmentExists(boolean attachmentExists, Path sourceAttachment) throws IOException {
+        if (!attachmentExists) {
+            // Provoke an error when deleting the attachment. Note that the attachment must be
+            // present when the CSV file is read; so we delete it afterwards.
+            Files.delete(sourceAttachment);
+        }
+    }
+
+    private Map<Path, SW360AttachmentType> createExpectedAttachmentMap() {
+        if (clearingDocAvailable) {
+            return Collections
+                    .singletonMap(configurationMock.getBaseDir().resolve(CLEARING_DOC), SW360AttachmentType.CLEARING_REPORT);
+        } else if (expectUpload) {
+            return Collections
+                    .singletonMap(getTargetDir().resolve(CLEARING_DOC), SW360AttachmentType.CLEARING_REPORT);
+        }
+
+        return Collections.emptyMap();
+    }
+
+    private Path writeCsvFile(String sourceAttachment) throws IOException {
+        final File tempCsvFile = folder.newFile("test.csv");
+        String clearingDocPath = "";
+        if (clearingDocAvailable) {
+            File clearingDoc = folder.newFile(CLEARING_DOC);
+            clearingDocPath = clearingDoc.getPath();
+        }
+        String csvContent = String.format("Artifact Id,Group Id,Version,Coordinate Type,Clearing State,Clearing Document,File Name%s" +
+                        "test,test,x.x.x,mvn,%s,%s,%s%s" +
+                        "error,error,y.y.y,mvn,%s,%s,%s", System.lineSeparator(), clearingState, clearingDocPath,
+                sourceAttachment, System.lineSeparator(), clearingState, clearingDocPath, System.lineSeparator());
+        Files.write(tempCsvFile.toPath(), csvContent.getBytes(StandardCharsets.UTF_8));
+        return tempCsvFile.toPath();
+    }
+}

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -10,119 +10,31 @@
  */
 package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.updater;
 
+
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils;
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuration;
-import org.eclipse.sw360.antenna.sw360.client.adapter.AttachmentUploadRequest;
+import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360TestUtils;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
-import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.mockito.ArgumentCaptor;
-import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith(Parameterized.class)
 public class SW360UpdaterTest {
-    private static final String CLEARING_DOC = "clearing.doc";
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
     private final SW360Configuration configurationMock = mock(SW360Configuration.class);
-    private final SW360ReleaseClientAdapter releaseClientAdapter = mock(SW360ReleaseClientAdapter.class);
-
-    private final String clearingState;
-    private final boolean clearingDocAvailable;
-    private final boolean expectUpload;
-
-    public SW360UpdaterTest(String clearingState, boolean clearingDocAvailable, boolean expectUpload) {
-        this.clearingState = clearingState;
-        this.clearingDocAvailable = clearingDocAvailable;
-        this.expectUpload = expectUpload;
-    }
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"OSM_APPROVED", true, true},
-                {"EXTERNAL_SOURCE", true, true},
-                {"AUTO_EXTRACT", true, true},
-                {"PROJECT_APPROVED", true, true},
-                {"INITIAL", true, false},
-                {"", true, false},
-                {"OSM_APPROVED", false, true},
-                {"EXTERNAL_SOURCE", false, true},
-                {"AUTO_EXTRACT", false, true},
-                {"PROJECT_APPROVED", false, true},
-                {"INITIAL", false, false},
-                {"", false, false}
-
-        });
-    }
-
-    private void initConnectionConfiguration() {
-        SW360Connection connectionConfiguration = mock(SW360Connection.class);
-
-        when(connectionConfiguration.getReleaseAdapter())
-                .thenReturn(releaseClientAdapter);
-        when(configurationMock.getConnection())
-                .thenReturn(connectionConfiguration);
-    }
-
-    private void initBasicConfiguration(Path sourceAttachment, Map<String, String> propertiesMap) throws IOException {
-        Path csvFile = writeCsvFile(sourceAttachment.toString());
-
-        when(configurationMock.getProperties())
-                .thenReturn(propertiesMap);
-        when(configurationMock.getBaseDir())
-                .thenReturn(csvFile.getParent());
-        when(configurationMock.getCsvFilePath())
-                .thenReturn(csvFile);
-        when(configurationMock.getTargetDir())
-                .thenReturn(getTargetDir());
-        when(configurationMock.getSourcesPath())
-                .thenReturn(sourceAttachment.getParent());
-    }
-
-    private Map<String, String> getConfigProperties() {
-        String propertiesFilePath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).getPath();
-        return ComplianceFeatureUtils.mapPropertiesFile(new File(propertiesFilePath));
-    }
-
-    private Path createSourceAttachment() throws IOException {
-        Path sourcesPath = folder.newFolder("sources").toPath();
-        Path sourceAttachment = sourcesPath.resolve("testSources.zip");
-        return Files.write(sourceAttachment, "The whole source code".getBytes(StandardCharsets.UTF_8));
-    }
-
-    @NotNull
-    private Path getTargetDir() {
-        return folder.getRoot().toPath();
-    }
 
     @Test(expected = NullPointerException.class)
     public void testUpdaterImplMustNotBeNull() {
@@ -140,126 +52,42 @@ public class SW360UpdaterTest {
     }
 
     @Test
-    public void testExecute() throws IOException {
-        runUpdaterTest(getConfigProperties(), false, true, false);
+    public void testIllegalStateIsCaught() throws IOException {
+        SW360UpdaterImpl updaterImpl = mock(SW360UpdaterImpl.class);
+        when(updaterImpl.artifactToReleaseInSW360(any(), any()))
+                .thenReturn(SW360TestUtils.mkSW360Release("test"));
+
+        String propertiesFilePath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("compliancetool-updater.properties")).getPath();
+        final Map<String, String> properties = ComplianceFeatureUtils.mapPropertiesFile(new File(propertiesFilePath));
+        initConfiguration(properties);
+
+        SW360ReleaseClientAdapter releaseClientAdapter = mock(SW360ReleaseClientAdapter.class);
+
+        SW360Connection connection = mock(SW360Connection.class);
+        when(connection.getReleaseAdapter())
+                .thenReturn(releaseClientAdapter);
+
+        final ClearingReportGenerator clearingReportGenerator = mock(ClearingReportGenerator.class);
+        when(clearingReportGenerator.createClearingDocument(any(), any()))
+                .thenThrow(new IllegalStateException());
+        SW360Updater updater = new SW360Updater(updaterImpl, configurationMock, clearingReportGenerator);
+        updater.execute();
+
+        verify(releaseClientAdapter, never()).uploadAttachments(any());
     }
 
-    @Test
-    public void testExecuteWithSourcesCleanup() throws IOException {
-        Map<String, String> configProperties = getConfigProperties();
-        configProperties.put(SW360Updater.PROP_REMOVE_CLEARED_SOURCES, String.valueOf(true));
+    private void initConfiguration(Map<String, String> propertiesMap) throws IOException {
+        Path csvFile = folder.newFile("csvFile.csv").toPath();
 
-        runUpdaterTest(configProperties, true, true, false);
-    }
-
-    @Test
-    public void testExecuteWithClearingDocumentRemoved() throws IOException {
-        Map<String, String> configProperties = getConfigProperties();
-        configProperties.put(SW360Updater.PROP_REMOVE_CLEARING_DOCS, String.valueOf(true));
-
-        runUpdaterTest(configProperties, false, true, true);
-    }
-
-    @Test
-    public void testErrorsWhenRemovingSourceFilesAreIgnored() throws IOException {
-        Map<String, String> configProperties = getConfigProperties();
-        configProperties.put(SW360Updater.PROP_REMOVE_CLEARED_SOURCES, String.valueOf(true));
-
-        runUpdaterTest(configProperties, false, false, false);
-    }
-
-    private void runUpdaterTest(Map<String, String> config, boolean expectSourceRemoved, boolean attachmentExists, boolean expectClearingDocRemoved)
-            throws IOException {
-        Path sourceAttachment = createSourceAttachment();
-        initBasicConfiguration(sourceAttachment, config);
-
-        initConnectionConfiguration();
-
-        SW360UpdaterImpl updater = mock(SW360UpdaterImpl.class);
-        SW360Release release = new SW360Release();
-        release.setClearingState(clearingState);
-        when(updater.artifactToReleaseInSW360(any(), any()))
-                .thenAnswer((Answer<SW360Release>) invocationOnMock -> {
-                    deleteSourceAttachmentIfAttachmentExists(attachmentExists, sourceAttachment);
-                    return release;
-                })
-                .thenThrow(new SW360ClientException("Boo"));
-
-        ClearingReportGenerator generator = mock(ClearingReportGenerator.class);
-        Path clearingDoc = getTargetDir().resolve(CLEARING_DOC);
-        Files.write(clearingDoc, "The clearing document".getBytes(StandardCharsets.UTF_8));
-        when(generator.createClearingDocument(any(), any()))
-                .thenReturn(clearingDoc);
-
-        SW360Updater sw360Updater = new SW360Updater(updater, configurationMock, generator);
-
-        sw360Updater.execute();
-
-        Map<Path, SW360AttachmentType> testAttachmentMap = createExpectedAttachmentMap();
-
-        if (expectUpload && !clearingDocAvailable) {
-            verify(generator).createClearingDocument(release, getTargetDir());
-        }
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<AttachmentUploadRequest<SW360Release>> captor = ArgumentCaptor.forClass(AttachmentUploadRequest.class);
-        verify(releaseClientAdapter, times(expectUpload ? 1 : 0)).uploadAttachments(captor.capture());
-        if (expectUpload) {
-            verify(updater, times(2)).artifactToReleaseInSW360(any(), any());
-            AttachmentUploadRequest<SW360Release> uploadRequest = captor.getValue();
-            List<AttachmentUploadRequest.Item> expItems = testAttachmentMap.entrySet().stream()
-                    .map(entry -> new AttachmentUploadRequest.Item(entry.getKey(), entry.getValue()))
-                    .collect(Collectors.toList());
-            assertThat(uploadRequest.getItems()).containsAll(expItems);
-        } else {
-            deleteSourceAttachmentIfAttachmentExists(attachmentExists, sourceAttachment);
-            verify(updater, never()).artifactToReleaseInSW360(any(), any());
-        }
-
-        boolean sourcePresent = Files.exists(sourceAttachment);
-        assertThat(sourcePresent).isEqualTo((!expectUpload || !expectSourceRemoved) && attachmentExists);
-
-        boolean clearingDocPresent = Files.exists(clearingDoc);
-        assertThat(clearingDocPresent).isEqualTo(!expectUpload || !expectClearingDocRemoved);
-    }
-
-    /**
-     * deletes the file of the given path if the given boolean is true
-     * @param attachmentExists determines if the file at the given path should remain existing
-     * @param sourceAttachment path to file that might get deleted
-     * @throws IOException
-     */
-    private void deleteSourceAttachmentIfAttachmentExists(boolean attachmentExists, Path sourceAttachment) throws IOException {
-        if (!attachmentExists) {
-            // Provoke an error when deleting the attachment. Note that the attachment must be
-            // present when the CSV file is read; so we delete it afterwards.
-            Files.delete(sourceAttachment);
-        }
-    }
-
-    private Map<Path, SW360AttachmentType> createExpectedAttachmentMap() {
-        if (clearingDocAvailable) {
-            return Collections
-                    .singletonMap(configurationMock.getBaseDir().resolve(CLEARING_DOC), SW360AttachmentType.CLEARING_REPORT);
-        } else if (expectUpload) {
-            return Collections
-                    .singletonMap(getTargetDir().resolve(CLEARING_DOC), SW360AttachmentType.CLEARING_REPORT);
-        }
-
-        return Collections.emptyMap();
-    }
-
-    private Path writeCsvFile(String sourceAttachment) throws IOException {
-        final File tempCsvFile = folder.newFile("test.csv");
-        String clearingDocPath = "";
-        if (clearingDocAvailable) {
-            File clearingDoc = folder.newFile(CLEARING_DOC);
-            clearingDocPath = clearingDoc.getPath();
-        }
-        String csvContent = String.format("Artifact Id,Group Id,Version,Coordinate Type,Clearing State,Clearing Document,File Name%s" +
-                        "test,test,x.x.x,mvn,%s,%s,%s%s" +
-                        "error,error,y.y.y,mvn,%s,%s,%s", System.lineSeparator(), clearingState, clearingDocPath,
-                sourceAttachment, System.lineSeparator(), clearingState, clearingDocPath, System.lineSeparator());
-        Files.write(tempCsvFile.toPath(), csvContent.getBytes(StandardCharsets.UTF_8));
-        return tempCsvFile.toPath();
+        when(configurationMock.getProperties())
+                .thenReturn(propertiesMap);
+        when(configurationMock.getBaseDir())
+                .thenReturn(csvFile.getParent());
+        when(configurationMock.getCsvFilePath())
+                .thenReturn(csvFile);
+        when(configurationMock.getTargetDir())
+                .thenReturn(folder.getRoot().toPath());
+        when(configurationMock.getSourcesPath())
+                .thenReturn(folder.getRoot().toPath());
     }
 }

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/SW360UpdaterTest.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360Configuratio
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.SW360TestUtils;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.workflow.generators.SW360UpdaterImpl;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class SW360UpdaterTest {
 
         final ClearingReportGenerator clearingReportGenerator = mock(ClearingReportGenerator.class);
         when(clearingReportGenerator.createClearingDocument(any(), any()))
-                .thenThrow(new IllegalStateException());
+                .thenThrow(new SW360ClientException("Clearing doc generation error"));
         SW360Updater updater = new SW360Updater(updaterImpl, configurationMock, clearingReportGenerator);
         updater.execute();
 


### PR DESCRIPTION
Issue: #529 
This is changing the exception thrown when a clearing document could not be generated and catches it were all exceptions are caught when something goes wrong when an artifact is updated. 

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Tests were adapted

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
