### PR TITLE
Fixed some packages of processors in the Antenna documentation.

### DIFF
--- a/antenna-documentation/src/site/markdown/processors/artifact-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/artifact-resolver.md
@@ -8,7 +8,7 @@ Add the following step into the `<processors>` section of your workflow.xml
 ```xml
 <step>
     <name>Maven Artifact Resolver</name>
-    <classHint>org.eclipse.sw360.antenna.workflow.processors.enricher.MavenArtifactResolver</classHint>
+    <classHint>org.eclipse.sw360.antenna.maven.workflow.processors.enricher.MavenArtifactResolver</classHint>
     <configuration>
         <entry key="sourcesRepositoryUrl" value="https://my.url.to/repo"/>
         <entry key="preferredSourceClassifier" value="sources-ext"/>

--- a/antenna-documentation/src/site/markdown/processors/license-resolver.md
+++ b/antenna-documentation/src/site/markdown/processors/license-resolver.md
@@ -6,9 +6,9 @@ if this is configured in the config.xml.
 ## HowTo use
 Add the following step into the `<processors>` section of your workflow.xml
 
-```
+```xml
 <step>
     <name>License Resolver</name>
-    <classHint>org.eclipse.sw360.antenna.workflow.processors.enricher.LicenseResolver</classHint>
+    <classHint>org.eclipse.sw360.antenna.workflow.processors.LicenseResolver</classHint>
 </step>
 ```

--- a/antenna-documentation/src/site/markdown/processors/ort-downloader.md
+++ b/antenna-documentation/src/site/markdown/processors/ort-downloader.md
@@ -8,6 +8,6 @@ Add the following step into the `<processors>` section of your workflow.xml
 ```xml
 <step>
     <name>ORT Downloader</name>
-    <classHint>org.eclipse.sw360.antenna.workflow.processors.enricher.OrtDownloaderProcessor</classHint>
+    <classHint>org.eclipse.sw360.antenna.ort.workflow.processors.enricher.OrtDownloaderProcessor</classHint>
 </step>
 ```


### PR DESCRIPTION
Issue: eclipse#539.

In the Antenna documentation some examples of the usage of processors
contained incorrect fully-qualified class names. They are fixed by this PR.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@bs-ondem @neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
documentation update

### How Has This Been Tested?
The updated site documentation now shows the correct package names.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have updated the documentation accordingly to my changes 
