### PR TITLE
Change default values taken for productName and productFullname

### DIFF
--- a/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AntennaCLISettingsReader.java
+++ b/core/frontend-stubs/cli-frontend-stub/src/main/java/org/eclipse/sw360/antenna/frontend/stub/cli/AntennaCLISettingsReader.java
@@ -161,8 +161,8 @@ public class AntennaCLISettingsReader {
         readProjectStringSetting(reader, "artifactId", project::setProjectId);
         readAntennaStringSetting(reader, "antennaTargetDirectory", getDefaultAntennaTargetDirectory(project), toolConfigBuilder::setAntennaTargetDirectory);
         readAntennaStringSetting(reader, "scanDir", toolConfigBuilder::setScanDir);
-        readAntennaStringSetting(reader, "productName", reader.getStringProperty("name"), toolConfigBuilder::setProductName);
-        readAntennaStringSetting(reader, "productFullname", reader.getStringProperty("name"), toolConfigBuilder::setProductFullName);
+        readAntennaStringSetting(reader, "productName", reader.getStringProperty("productName"), toolConfigBuilder::setProductName);
+        readAntennaStringSetting(reader, "productFullname", reader.getStringProperty("productFullname"), toolConfigBuilder::setProductFullName);
         readAntennaStringSetting(reader, "version", "1.0", toolConfigBuilder::setVersion);
         readAntennaStringSetting(reader, "companyName", toolConfigBuilder::setCompanyName);
         readAntennaStringSetting(reader, "copyrightHoldersName", toolConfigBuilder::setCopyrightHoldersName);


### PR DESCRIPTION
Issue: #541

The previous default "name" was using the first atttribute which
was named "name" which in CLI is mostly the first workflow step
item.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
