### PR TITLE
Make AttributionDocumentGeneratorImpl work with passed fonts

### DIFF
--- a/modules/attribution-document/attribution-document-core/pom.xml
+++ b/modules/attribution-document/attribution-document-core/pom.xml
@@ -50,6 +50,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- ################################ testing dependencies ################################ -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/AttributionDocumentGeneratorImpl.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/AttributionDocumentGeneratorImpl.java
@@ -76,12 +76,16 @@ public class AttributionDocumentGeneratorImpl {
      * @param back (non-null) template PDF file for the back page.
      * @return (non - null) the file handle of the generated attribution document.
      */
+    public File generate(List<ArtifactAndLicense> artifacts, File cover, File copyright, File content, File back) {
+        return generate(artifacts, cover, copyright, content, back, null, null, null, null);
+    }
+
     public File generate(List<ArtifactAndLicense> artifacts,
-                         File cover,
-                         File copyright,
-                         File content,
-                         File back) {
-        try (Templates templates = TemplateLoaderUtil.load(cover, copyright, content, back)) {
+                         File cover, File copyright, File content, File back,
+                         File regular, File bold, File boldItalic, File italic) {
+        try (Templates templates = TemplateLoaderUtil.load(cover, copyright, content, back,
+                Optional.ofNullable(regular), Optional.ofNullable(bold),
+                Optional.ofNullable(boldItalic), Optional.ofNullable(italic))) {
             return generate(artifacts, templates);
         }
     }

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/Templates.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/core/Templates.java
@@ -95,8 +95,8 @@ public class Templates implements Closeable {
 
     private static byte[] loadFontData(Optional<InputStream> fontData) {
         if (fontData.isPresent()) {
-            try {
-                return IOUtils.toByteArray(fontData.get());
+            try (InputStream i = fontData.get()) {
+                return IOUtils.toByteArray(i);
             } catch (IOException e) {
                 throw new ExecutionException("Unable to load font.", e);
             }

--- a/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/utils/TemplateLoaderUtil.java
+++ b/modules/attribution-document/attribution-document-core/src/main/java/org/eclipse/sw360/antenna/attribution/document/utils/TemplateLoaderUtil.java
@@ -12,9 +12,11 @@
 package org.eclipse.sw360.antenna.attribution.document.utils;
 
 import java.io.*;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
 import org.eclipse.sw360.antenna.attribution.document.core.TemplateBundle;
@@ -37,6 +39,12 @@ public final class TemplateLoaderUtil {
     }
 
     public static Templates load(File cover, File copyright, File content, File back) {
+        return load(cover, copyright, content, back,
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public static Templates load(File cover, File copyright, File content, File back, Optional<File> regular,
+                                 Optional<File> bold, Optional<File> boldItalic, Optional<File> italic) {
         return load(new TemplateBundle() {
             @Override
             public String key() {
@@ -76,6 +84,62 @@ public final class TemplateLoaderUtil {
                     return new FileInputStream(back);
                 } catch (IOException e) {
                     throw new ExecutionException("Could not load back template PDF", e);
+                }
+            }
+
+            @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "Will be closed in Templates.")
+            @Override
+            public Optional<InputStream> loadSansFont() {
+                if (!regular.isPresent()) {
+                    return Optional.empty();
+                }
+
+                try {
+                    return Optional.of(new FileInputStream(regular.get()));
+                } catch (IOException e) {
+                    throw new ExecutionException("Could not load regular sans font", e);
+                }
+            }
+
+            @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "Will be closed in Templates.")
+            @Override
+            public Optional<InputStream> loadSansItalicFont() {
+                if (!italic.isPresent()) {
+                    return Optional.empty();
+                }
+
+                try {
+                    return Optional.of(new FileInputStream(italic.get()));
+                } catch (IOException e) {
+                    throw new ExecutionException("Could not load italic font", e);
+                }
+            }
+
+            @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "Will be closed in Templates.")
+            @Override
+            public Optional<InputStream> loadSansBoldFont() {
+                if (!bold.isPresent()) {
+                    return Optional.empty();
+                }
+
+                try {
+                    return Optional.of(new FileInputStream(bold.get()));
+                } catch (IOException e) {
+                    throw new ExecutionException("Could not load bold font", e);
+                }
+            }
+
+            @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "Will be closed in Templates.")
+            @Override
+            public Optional<InputStream> loadSansBoldItalicFont() {
+                if (!boldItalic.isPresent()) {
+                    return Optional.empty();
+                }
+
+                try {
+                    return Optional.of(new FileInputStream(boldItalic.get()));
+                } catch (IOException e) {
+                    throw new ExecutionException("Could not load bold italic font", e);
                 }
             }
         });


### PR DESCRIPTION
A new generate method is added to the AttributionDocumentGeneratorImpl
class which gets passed font files in order to generate the attribution
document with the passed fonts.

Resolves #551.
