### PR TITLE
OrtDownloaderProcessor: Make the configMap immutable

### DIFF
--- a/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
+++ b/modules/ort/src/main/kotlin/workflow/processors/enricher/OrtDownloaderProcessor.kt
@@ -27,7 +27,7 @@ class OrtDownloaderProcessor : AbstractProcessor() {
 
     private lateinit var sourcesZipDirectory: File
 
-    override fun configure(configMap: MutableMap<String, String>) {
+    override fun configure(configMap: Map<String, String>) {
         sourcesZipDirectory = context.toolConfiguration.antennaTargetDirectory.resolve(ORT_DOWNLOADER_DIR).toFile()
         if (!sourcesZipDirectory.isDirectory && !sourcesZipDirectory.mkdirs()) {
             throw ConfigurationException("Failed to create directory '${sourcesZipDirectory.absolutePath}' " +


### PR DESCRIPTION
The configure() function is never supposed to modify this.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
