### PR TITLE
Replaces unavailable characters for the AttributionDocumentGenerator

### DIFF
--- a/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/ArtifactAdapter.java
+++ b/modules/attribution-document/attribution-document-generator/src/main/java/org/eclipse/sw360/antenna/attribution/document/workflow/generators/ArtifactAdapter.java
@@ -61,9 +61,17 @@ public class ArtifactAdapter implements ArtifactAndLicense {
     */
    public static String getLicenseText(License license) {
       String text = license.getText();
-      text = StringUtils.isNotBlank(text) ? text : "No license text available";
+      if (StringUtils.isBlank(text)) {
+         return "No license text available";
+      }
+
       // remove the magic unicode as it will likely not be in a unicode font set.
-      return StringUtils.replace(text, "\uFEFF", "");
+      return text
+              .replace("\u0009", "    ")
+              .replace("\u00a0", " ")
+              .replace("\u200b", "")
+              .replace("\u2028", "\n")
+              .replace("\ufeff", "");
    }
 
    /**


### PR DESCRIPTION
The AttributionDocumentGenerator cannot handle unicodes like tabs
(U+0009) and newlines (U+2028) for layout purposes. Therefore it
will be replaced manually.

### Request Reviewer
@sschuberth 

### Type of Change
*bug fix*
