### PR TITLE
Oheger bosch/sw360/#426 multi deletes

### DIFF
--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/RequestBuilder.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/RequestBuilder.java
@@ -81,6 +81,6 @@ public interface RequestBuilder {
      * An enumeration class for the HTTP methods supported by the HTTP client.
      */
     enum Method {
-        GET, POST, PUT, PATCH
+        GET, POST, PUT, PATCH, DELETE
     }
 }

--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpConstants.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpConstants.java
@@ -48,6 +48,13 @@ public final class HttpConstants {
     public static final int STATUS_NO_CONTENT = 204;
 
     /**
+     * Constant for the HTTP status code 207 MULTI_STATUS that is returned for
+     * operations affecting multiple entities. The response body typically
+     * contains more information about the single operations and their outcome.
+     */
+    public static final int STATUS_MULTI_STATUS = 207;
+
+    /**
      * Constant for the HTTP status code 400 BAD REQUEST indicating a general
      * problem with a request sent by a client.
      */

--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpUtils.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/HttpUtils.java
@@ -119,6 +119,19 @@ public final class HttpUtils {
     }
 
     /**
+     * Returns a flag whether the passed in response status code indicates a
+     * successful response. This is the case if the status code is in the range
+     * of [200, 300).
+     *
+     * @param status the status code to check
+     * @return <strong>true</strong> if the status code indicates a successful
+     * response; <strong>false</strong> otherwise
+     */
+    public static boolean isSuccessStatus(int status) {
+        return status >= HttpConstants.STATUS_OK && status < 300;
+    }
+
+    /**
      * Returns a {@code ResponseProcessor} that checks whether a request was
      * successful based on a given predicate and allows tagging the request.
      * The resulting processor invokes the given predicate on the response

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/utils/HttpUtilsTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/utils/HttpUtilsTest.java
@@ -234,4 +234,26 @@ public class HttpUtilsTest {
         assertThat(processor.process(response)).isNull();
         verifyZeroInteractions(response);
     }
+
+    @Test
+    public void testIsSuccessStatusTooSmall() {
+        assertThat(HttpUtils.isSuccessStatus(199)).isFalse();
+        assertThat(HttpUtils.isSuccessStatus(0)).isFalse();
+        assertThat(HttpUtils.isSuccessStatus(Integer.MIN_VALUE)).isFalse();
+    }
+
+    @Test
+    public void testIsSuccessStatusTrue() {
+        for (int i = 200; i < 300; i++) {
+            assertThat(HttpUtils.isSuccessStatus(i)).isTrue();
+        }
+    }
+
+    @Test
+    public void testIsSuccessStatusTooBig() {
+        assertThat(HttpUtils.isSuccessStatus(300)).isFalse();
+        assertThat(HttpUtils.isSuccessStatus(HttpConstants.STATUS_ERR_BAD_REQUEST)).isFalse();
+        assertThat(HttpUtils.isSuccessStatus(HttpConstants.STATUS_ERR_SERVER)).isFalse();
+        assertThat(HttpUtils.isSuccessStatus(Integer.MAX_VALUE)).isFalse();
+    }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -10,10 +10,12 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,4 +37,25 @@ public interface SW360ComponentClientAdapter {
     Optional<SW360Component> getComponentByName(String componentName);
 
     List<SW360SparseComponent> getComponents();
+
+    /**
+     * Triggers a multi-delete operation for the components with the IDs
+     * specified. Returns a {@code MultiStatusResponse} that allows checking
+     * whether all the components could be deleted successfully.
+     *
+     * @param idsToDelete a collection with the IDs of components to delete
+     * @return a {@code MultiStatusResponse} with the results of the operation
+     */
+    MultiStatusResponse deleteComponents(Collection<String> idsToDelete);
+
+    /**
+     * Deletes the component with the given ID. This is a convenience method for
+     * the special case that only a single component should be deleted. It
+     * inspects the {@link MultiStatusResponse} returned by SW360 and throws an
+     * exception if the operation was not successful.
+     *
+     * @param componentId the ID of the component to be deleted
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if the component could not be deleted
+     */
+    void deleteComponent(String componentId);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -10,10 +10,12 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -36,4 +38,26 @@ public interface SW360ComponentClientAdapterAsync {
     CompletableFuture<Optional<SW360Component>> getComponentByName(String componentName);
 
     CompletableFuture<List<SW360SparseComponent>> getComponents();
+
+    /**
+     * Triggers a multi-delete operation for the components with the IDs
+     * specified. Returns a {@code MultiStatusResponse} that allows checking
+     * whether all the components could be deleted successfully.
+     *
+     * @param idsToDelete a collection with the IDs of components to delete
+     * @return a future with the {@code MultiStatusResponse} with the results
+     * of the operation
+     */
+    CompletableFuture<MultiStatusResponse> deleteComponents(Collection<String> idsToDelete);
+
+    /**
+     * Deletes the component with the given ID. This is a convenience method for
+     * the special case that only a single component should be deleted. It
+     * inspects the {@link MultiStatusResponse} returned by SW360 and returns a
+     * failed future if the operation was not successful.
+     *
+     * @param componentId the ID of the component to be deleted
+     * @return a future indicating the result of the operation
+     */
+    CompletableFuture<Void> deleteComponent(String componentId);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
@@ -11,12 +11,18 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
+import org.eclipse.sw360.antenna.http.utils.HttpUtils;
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -77,5 +83,30 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
     @Override
     public CompletableFuture<List<SW360SparseComponent>> getComponents() {
         return getComponentClient().getComponents();
+    }
+
+    @Override
+    public CompletableFuture<MultiStatusResponse> deleteComponents(Collection<String> idsToDelete) {
+        return idsToDelete.isEmpty() ?
+                CompletableFuture.completedFuture(new MultiStatusResponse(new HashMap<>())) :
+                getComponentClient().deleteComponents(idsToDelete);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteComponent(String componentId) {
+        return deleteComponents(Collections.singleton(componentId))
+                .thenApply(status -> {
+                    if (status.responseCount() != 1 || !status.hasResourceId(componentId)) {
+                        throw new SW360ClientException("Unexpected multi-status response. Expected a response that " +
+                                "contains only a status for " + componentId + ", but got: " + status);
+                    }
+                    if (!HttpUtils.isSuccessStatus(status.getStatus(componentId))) {
+                        FailedRequestException requestException =
+                                new FailedRequestException("delete component " + componentId,
+                                        status.getStatus(componentId));
+                        throw new SW360ClientException("Delete operation failed", requestException);
+                    }
+                    return null;
+                });
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360DeleteUtils.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360DeleteUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.adapter;
+
+import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
+import org.eclipse.sw360.antenna.http.utils.HttpUtils;
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * <p>
+ * A helper class providing functionality related to deleting entities.
+ * </p>
+ * <p>
+ * SW360 at some places supports deleting multiple entities at once. This class
+ * offers methods to support such multi-delete operations and to deal with the
+ * multi-status responses they return.
+ * </p>
+ */
+class SW360DeleteUtils {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private SW360DeleteUtils() {
+    }
+
+    /**
+     * Deletes the entities specified using the given {@code EntityDeleter}.
+     * This method checks whether the collection with IDs to delete is not
+     * empty; in this case, the delete operation is skipped.
+     *
+     * @param deleter     the object handling delete requests
+     * @param idsToDelete a collection with the resource IDs to delete
+     * @return a future with the result of the multi-delete operation
+     */
+    public static CompletableFuture<MultiStatusResponse> deleteEntities(EntityDeleter deleter,
+                                                                        Collection<String> idsToDelete) {
+        return idsToDelete.isEmpty() ?
+                CompletableFuture.completedFuture(new MultiStatusResponse(Collections.emptyMap())) :
+                deleter.deleteEntities(idsToDelete);
+    }
+
+    /**
+     * Deletes a single entity using the given {@code EntityDeleter} and
+     * evaluates the {@link MultiStatusResponse} returned by the server. This
+     * method yields a failed future if the response from the server indicates
+     * that the entity could not be deleted or if an unexpected response is
+     * received.
+     *
+     * @param deleter      the object handling delete requests
+     * @param resourceId   the ID of the resource entity to be deleted
+     * @param resourceType a string for the resource type, to be used when
+     *                     generating error messages
+     * @return a future indicating the success of the operation
+     */
+    public static CompletableFuture<Void> deleteEntity(EntityDeleter deleter, String resourceId, String resourceType) {
+        return deleter.deleteEntities(Collections.singleton(resourceId))
+                .thenApply(status -> {
+                    checkResponse(status, resourceId, resourceType);
+                    return null;
+                });
+    }
+
+    /**
+     * Checks whether the given multi-status response reports a successful
+     * delete operation on the entity specified. If this is not the case, an
+     * exception is thrown, which will then cause the result future to fail.
+     *
+     * @param status       the status response to be checked
+     * @param resourceId   the ID of the resource entity to be deleted
+     * @param resourceType a string for the resource type
+     */
+    private static void checkResponse(MultiStatusResponse status, String resourceId,
+                                      String resourceType) {
+        if (status.responseCount() != 1 || !status.hasResourceId(resourceId)) {
+            throw new SW360ClientException("Unexpected multi-status response. Expected a response that " +
+                    "contains only a status for " + resourceId + ", but got: " + status);
+        }
+        if (!HttpUtils.isSuccessStatus(status.getStatus(resourceId))) {
+            FailedRequestException requestException =
+                    new FailedRequestException(generateDeleteTag(resourceId, resourceType),
+                            status.getStatus(resourceId));
+            throw new SW360ClientException("Delete operation failed", requestException);
+        }
+    }
+
+    /**
+     * Generates the tag for an exception indicating a failed request to delete
+     * the resource specified.
+     *
+     * @param resourceId   the ID of the resource entity
+     * @param resourceType the type of the resource
+     * @return the tag to describe the failed request
+     */
+    private static String generateDeleteTag(String resourceId, String resourceType) {
+        return "delete " + resourceType + " " + resourceId;
+    }
+
+    /**
+     * A specialized function interface to invoke the entity-specific delete
+     * operation for a given collection of IDs.
+     */
+    @FunctionalInterface
+    interface EntityDeleter {
+        /**
+         * Asynchronously deletes the entities with the IDs specified.
+         *
+         * @param idsToDelete a collection with the IDs to delete
+         * @return a future with the result of the multi-delete operation
+         */
+        CompletableFuture<MultiStatusResponse> deleteEntities(Collection<String> idsToDelete);
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapter.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
@@ -17,6 +18,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Releas
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -92,7 +94,7 @@ public interface SW360ReleaseClientAdapter {
      * {@link #enrichSparseRelease(SW360SparseRelease)} method.
      *
      * @param componentName the name of the component affected
-     * @param version the version of the desired release
+     * @param version       the version of the desired release
      * @return an {@code Optional} with the release that was found
      */
     Optional<SW360SparseRelease> getSparseReleaseByNameAndVersion(String componentName, String version);
@@ -139,4 +141,25 @@ public interface SW360ReleaseClientAdapter {
      * @return the updated release
      */
     SW360Release updateRelease(SW360Release release);
+
+    /**
+     * Triggers a multi-delete operation for the releases with the IDs
+     * specified. Returns a {@code MultiStatusResponse} that allows checking
+     * whether all the releases could be deleted successfully.
+     *
+     * @param idsToDelete a collection with the IDs of releases to delete
+     * @return a {@code MultiStatusResponse} with the results of the operation
+     */
+    MultiStatusResponse deleteReleases(Collection<String> idsToDelete);
+
+    /**
+     * Deletes the release with the given ID. This is a convenience method for
+     * the special case that only a single release should be deleted. It
+     * inspects the {@link MultiStatusResponse} returned by SW360 and throws an
+     * exception if the operation was not successful.
+     *
+     * @param releaseId the ID of the release to be deleted
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if the release could not be deleted
+     */
+    void deleteRelease(String releaseId);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsync.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
@@ -17,6 +18,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Releas
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -93,7 +95,7 @@ public interface SW360ReleaseClientAdapterAsync {
      * {@link #enrichSparseRelease(SW360SparseRelease)} method.
      *
      * @param componentName the name of the component affected
-     * @param version the version of the desired release
+     * @param version       the version of the desired release
      * @return a future with an {@code Optional} with the release that was
      * found
      */
@@ -144,4 +146,25 @@ public interface SW360ReleaseClientAdapterAsync {
      * @return a future with the updated release
      */
     CompletableFuture<SW360Release> updateRelease(SW360Release release);
+
+    /**
+     * Triggers a multi-delete operation for the releases with the IDs
+     * specified. Returns a {@code MultiStatusResponse} that allows checking
+     * whether all the releases could be deleted successfully.
+     *
+     * @param idsToDelete a collection with the IDs of releases to delete
+     * @return a future with {@code MultiStatusResponse} with the results of
+     * the operation
+     */
+    CompletableFuture<MultiStatusResponse> deleteReleases(Collection<String> idsToDelete);
+
+    /**
+     * Deletes the release with the given ID. This is a convenience method for
+     * the special case that only a single release should be deleted. It
+     * inspects the {@link MultiStatusResponse} returned by SW360 and returns a
+     * failed future if the operation was not successful.
+     *
+     * @param releaseId the ID of the release to be deleted
+     */
+    CompletableFuture<Void> deleteRelease(String releaseId);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ReleaseClientAdapterAsyncImpl.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ReleaseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
@@ -21,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Sparse
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -161,5 +163,15 @@ class SW360ReleaseClientAdapterAsyncImpl implements SW360ReleaseClientAdapterAsy
     @Override
     public CompletableFuture<SW360Release> updateRelease(SW360Release release) {
         return getReleaseClient().patchRelease(release);
+    }
+
+    @Override
+    public CompletableFuture<MultiStatusResponse> deleteReleases(Collection<String> idsToDelete) {
+        return SW360DeleteUtils.deleteEntities(getReleaseClient()::deleteReleases, idsToDelete);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteRelease(String releaseId) {
+        return SW360DeleteUtils.deleteEntity(getReleaseClient()::deleteReleases, releaseId, "release");
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/MultiStatusResponse.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/MultiStatusResponse.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.antenna.http.utils.HttpUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * <p>
+ * A class to represent an HTTP multi-status response.
+ * </p>
+ * <p>
+ * For some operations affecting multiple entities, SW360 sends responses of
+ * this type. From a response clients can find out whether the operation was
+ * successful or failed for some of the entities.
+ * </p>
+ */
+public final class MultiStatusResponse {
+    /**
+     * The property containing the status of an operation.
+     */
+    private static final String PROP_STATUS = "status";
+
+    /**
+     * The property containing the resource ID in JSON.
+     */
+    private static final String PROP_RES_ID = "resourceId";
+
+    /**
+     * Reference to parse a JSON representation with the correct data types.
+     */
+    private static final TypeReference<List<Map<String, Object>>> REF_MULTI_RESPONSE =
+            new TypeReference<List<Map<String, Object>>>() {
+            };
+
+    /**
+     * Stores the map with the responses managed by this instance.
+     */
+    private final Map<String, Integer> responses;
+
+    /**
+     * Creates a new instance of {@code MultiStatusResponse} with the given map
+     * of single response codes. The map contains the IDs of resources as keys
+     * and the corresponding status codes as values.
+     *
+     * @param responses the map with status codes
+     */
+    public MultiStatusResponse(Map<String, Integer> responses) {
+        this.responses = Collections.unmodifiableMap(new HashMap<>(responses));
+    }
+
+    /**
+     * Creates a new instance of {@code MultiStatusResponse} that is
+     * initialized from a JSON document. This method can be used to parse a
+     * response received from SW360.
+     *
+     * @param mapper the object mapper to parse the JSON stream
+     * @param stream the stream with the data
+     * @return the newly created instance
+     * @throws IOException if an error occurs
+     */
+    public static MultiStatusResponse fromJson(ObjectMapper mapper, InputStream stream) throws IOException {
+        List<Map<String, Object>> responses = mapper.readValue(stream, REF_MULTI_RESPONSE);
+        try {
+            Map<String, Integer> responseMap = responses.stream()
+                    .map(map -> new AbstractMap.SimpleEntry<>(extractResourceId(map), extractStatus(map)))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            return new MultiStatusResponse(responseMap);
+        } catch (IllegalArgumentException e) {
+            // Status extraction failed from JSON
+            throw new IOException("Failed to parse JSON response", e);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable map with the single responses stored in this
+     * object. The keys of the map are the IDs of the resources that were
+     * manipulated. The values are the status codes for the single operations.
+     *
+     * @return a map with the responses stored in this object
+     */
+    public Map<String, Integer> getResponses() {
+        return responses;
+    }
+
+    /**
+     * Returns the number of responses stored in this object.
+     *
+     * @return the number of responses
+     */
+    public int responseCount() {
+        return responses.size();
+    }
+
+    /**
+     * Returns a flag whether all the responses managed by this object have
+     * been successful.
+     *
+     * @return <strong>true</strong> if there are only success responses;
+     * <strong>false</strong> if there is at least one failure status code
+     */
+    public boolean isAllSuccess() {
+        return responses.values().stream()
+                .allMatch(HttpUtils::isSuccessStatus);
+    }
+
+    /**
+     * Returns a flag whether this object contains information about the
+     * resource ID specified.
+     *
+     * @param resId the resource ID in question
+     * @return a flag whether a status about this resource is stored in this
+     * object
+     */
+    public boolean hasResourceId(String resId) {
+        return responses.containsKey(resId);
+    }
+
+    /**
+     * Returns the status code for the resource with the given ID. The ID
+     * must be present, otherwise a {@code NoSuchElementException} exception is
+     * thrown.
+     *
+     * @param resId the ID of the resource in question
+     * @return the status code for this resource
+     * @throws java.util.NoSuchElementException if the resource is unknown
+     */
+    public int getStatus(String resId) {
+        Integer status = responses.get(resId);
+        if (status == null) {
+            throw new NoSuchElementException("Unknown resource ID: " + resId +
+                    "; not contained in this multi-status response.");
+        }
+        return status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultiStatusResponse response = (MultiStatusResponse) o;
+        return responses.equals(response.responses);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(responses);
+    }
+
+    @Override
+    public String toString() {
+        return "MultiStatusResponse{" +
+                "responses=" + responses +
+                '}';
+    }
+
+    /**
+     * Extracts the resource ID from the given object map. Throws an exception
+     * if the property does not exist.
+     *
+     * @param map the map
+     * @return the resource ID extracted from the map
+     * @throws IllegalArgumentException if the resource ID cannot be resolved
+     */
+    private static String extractResourceId(Map<String, Object> map) {
+        Object resourceId = map.get(PROP_RES_ID);
+        if (!(resourceId instanceof String)) {
+            throw new IllegalArgumentException("Unexpected JSON response. Expected resource ID, but found " +
+                    resourceId);
+        }
+        return (String) resourceId;
+    }
+
+    /**
+     * Extracts the status code property from the given object map. Throws an
+     * exception if this property is invalid or cannot be resolved.
+     *
+     * @param map the map
+     * @return the status code extracted from the map
+     * @throws IllegalArgumentException if the status code could not be extracted
+     */
+    private static Integer extractStatus(Map<String, Object> map) {
+        Object status = map.get(PROP_STATUS);
+        if (!(status instanceof Integer)) {
+            throw new IllegalArgumentException("Unexpected JSON response. Expected status code, but found " +
+                    status);
+        }
+        return (Integer) status;
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Comp
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentList;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,6 +52,11 @@ public class SW360ComponentClient extends SW360Client {
      * Tag for the request to create a new component.
      */
     static final String TAG_CREATE_COMPONENT = "post_create_component";
+
+    /**
+     * Tag for the request to delete components.
+     */
+    static final String TAG_DELETE_COMPONENTS = "delete_components";
 
     private static final String COMPONENTS_ENDPOINT = "components";
 
@@ -118,5 +124,17 @@ public class SW360ComponentClient extends SW360Client {
                         .uri(resourceUrl(COMPONENTS_ENDPOINT))
                         .body(body -> body.json(sw360Component)),
                 SW360Component.class, TAG_CREATE_COMPONENT);
+    }
+
+    /**
+     * Triggers a DELETE operation for the components identified by the given
+     * IDs.
+     *
+     * @param idsToDelete a collection with the IDs of the components to delete
+     * @return a future with the {@code MultiStatusResponse} returned by the
+     * server
+     */
+    public CompletableFuture<MultiStatusResponse> deleteComponents(Collection<String> idsToDelete) {
+        return executeDeleteRequest(COMPONENTS_ENDPOINT, idsToDelete, TAG_DELETE_COMPONENTS);
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ReleaseClient.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Releas
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +52,11 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
      * Tag for the request that modifies a release.
      */
     static final String TAG_UPDATE_RELEASE = "patch_update_release";
+
+    /**
+     * Tag for the request that deletes releases.
+     */
+    static final String TAG_DELETE_RELEASES = "delete_releases";
 
     private static final String RELEASES_ENDPOINT_APPENDIX = "releases";
     private static final String PATH_SEARCH_EXT_IDS = "searchByExternalIds";
@@ -134,5 +140,17 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
                         .uri(resourceUrl(RELEASES_ENDPOINT_APPENDIX, sw360Release.getId()))
                         .body(body -> body.json(sw360Release)),
                 SW360Release.class, TAG_UPDATE_RELEASE);
+    }
+
+    /**
+     * Triggers a DELETE operation for the releases identified by the given
+     * IDs.
+     *
+     * @param idsToDelete a collection with the IDs of the releases to delete
+     * @return a future with the {@code MultiStatusResponse} returned by the
+     * server
+     */
+    public CompletableFuture<MultiStatusResponse> deleteReleases(Collection<String> idsToDelete) {
+        return executeDeleteRequest(RELEASES_ENDPOINT_APPENDIX, idsToDelete, TAG_DELETE_RELEASES);
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
 import org.eclipse.sw360.antenna.http.utils.HttpConstants;
+import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
@@ -21,9 +22,14 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Spar
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +37,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils.block;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class SW360ComponentClientAdapterAsyncImplTest {
@@ -110,7 +117,7 @@ public class SW360ComponentClientAdapterAsyncImplTest {
         verify(componentClient).createComponent(component);
     }
 
-    @Test (expected = SW360ClientException.class)
+    @Test(expected = SW360ClientException.class)
     public void testCreateComponentNull() {
         block(componentClientAdapter.createComponent(this.component));
     }
@@ -181,6 +188,87 @@ public class SW360ComponentClientAdapterAsyncImplTest {
         assertThat(components).hasSize(1);
         assertThat(components).containsExactly(sparseComponent);
         verify(componentClient).getComponents();
+    }
+
+    @Test
+    public void testDeleteComponentsEmptyCollection() {
+        MultiStatusResponse response = block(componentClientAdapter.deleteComponents(Collections.emptySet()));
+
+        assertThat(response.responseCount()).isEqualTo(0);
+        verifyZeroInteractions(componentClient);
+    }
+
+    @Test
+    public void testDeleteMultipleComponents() {
+        Collection<String> componentsToDelete = Arrays.asList(COMPONENT_ID, "DEL-1", "DEL-2");
+        MultiStatusResponse expResponse = new MultiStatusResponse(Collections.singletonMap(COMPONENT_ID, 200));
+        when(componentClient.deleteComponents(componentsToDelete))
+                .thenReturn(CompletableFuture.completedFuture(expResponse));
+
+        MultiStatusResponse response = block(componentClientAdapter.deleteComponents(componentsToDelete));
+        assertThat(response).isEqualTo(expResponse);
+    }
+
+    @Test
+    public void testDeleteSingleComponentSuccess() {
+        MultiStatusResponse response = new MultiStatusResponse(Collections.singletonMap(COMPONENT_ID, 202));
+        Set<String> idsToDelete = Collections.singleton(COMPONENT_ID);
+        when(componentClient.deleteComponents(idsToDelete))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        block(componentClientAdapter.deleteComponent(COMPONENT_ID));
+        verify(componentClient).deleteComponents(idsToDelete);
+    }
+
+    @Test
+    public void testDeleteSingleComponentFailureStatus() {
+        MultiStatusResponse response =
+                new MultiStatusResponse(Collections.singletonMap(COMPONENT_ID, HttpConstants.STATUS_ERR_BAD_REQUEST));
+        Set<String> idsToDelete = Collections.singleton(COMPONENT_ID);
+        when(componentClient.deleteComponents(idsToDelete))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        try {
+            block(componentClientAdapter.deleteComponent(COMPONENT_ID));
+            fail("Failed delete operation not detected");
+        } catch (SW360ClientException e) {
+            assertThat(e.getCause()).isInstanceOf(FailedRequestException.class);
+            FailedRequestException reqEx = (FailedRequestException) e.getCause();
+            assertThat(reqEx.getStatusCode()).isEqualTo(HttpConstants.STATUS_ERR_BAD_REQUEST);
+            assertThat(reqEx.getTag()).isEqualTo("delete component " + COMPONENT_ID);
+        }
+    }
+
+    @Test
+    public void testDeleteSingleComponentUnexpectedResponse() {
+        Map<String, Integer> statusMap = new HashMap<>();
+        statusMap.put(COMPONENT_ID, HttpConstants.STATUS_OK);
+        statusMap.put("unexpectedId", HttpConstants.STATUS_OK);
+        MultiStatusResponse response = new MultiStatusResponse(statusMap);
+        when(componentClient.deleteComponents(Collections.singleton(COMPONENT_ID)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        try {
+            block(componentClientAdapter.deleteComponent(COMPONENT_ID));
+            fail("Invalid response not detected");
+        } catch (SW360ClientException e) {
+            assertThat(e.getMessage()).contains("Unexpected multi-status response", response.toString());
+        }
+    }
+
+    @Test
+    public void testDeleteSingleComponentResponseNoResourceId() {
+        MultiStatusResponse response =
+                new MultiStatusResponse(Collections.singletonMap("unexpectedId", HttpConstants.STATUS_ERR_BAD_REQUEST));
+        when(componentClient.deleteComponents(Collections.singleton(COMPONENT_ID)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        try {
+            block(componentClientAdapter.deleteComponent(COMPONENT_ID));
+            fail("Invalid response not detected");
+        } catch (SW360ClientException e) {
+            assertThat(e.getMessage()).contains("Unexpected multi-status response", response.toString());
+        }
     }
 
     private static LinkObjects makeLinkObjects() {

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/MultiStatusResponseTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/MultiStatusResponseTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultiStatusResponseTest {
+    /**
+     * Name of a test file that contains only successful responses.
+     */
+    private static final String FILE_SUCCESS_RESPONSE = "multi_status_success";
+
+    /**
+     * Name of a test file that contains responses with failures.
+     */
+    private static final String FILE_FAILURE_RESPONSE = "multi_status_failed";
+
+    /**
+     * Reads a multi-status response from a JSON test file from the classpath.
+     *
+     * @param file the name of the file to be loaded
+     * @return the response object
+     */
+    private static MultiStatusResponse fromJson(String file) throws IOException {
+        try (InputStream stream = MultiStatusResponseTest.class.getResourceAsStream("/__files/" +
+                file + ".json")) {
+            return MultiStatusResponse.fromJson(new ObjectMapper(), stream);
+        }
+    }
+
+    @Test
+    public void testSize() {
+        Map<String, Integer> responses = new HashMap<>();
+        responses.put("r1", 200);
+        responses.put("r2", 300);
+        responses.put("r3", 400);
+
+        MultiStatusResponse response = new MultiStatusResponse(responses);
+        assertThat(response.responseCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testDefensiveCopyOnCreation() {
+        Map<String, Integer> responses = new HashMap<>();
+        responses.put("r1", 1);
+        MultiStatusResponse multiResponse = new MultiStatusResponse(responses);
+
+        responses.put("r2", 2);
+        assertThat(multiResponse.responseCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testIsAllSuccessEmpty() {
+        MultiStatusResponse multiResponse = new MultiStatusResponse(Collections.emptyMap());
+
+        assertThat(multiResponse.isAllSuccess()).isTrue();
+    }
+
+    @Test
+    public void testIsAllSuccessWithFailures() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_FAILURE_RESPONSE);
+
+        assertThat(response.isAllSuccess()).isFalse();
+    }
+
+    @Test
+    public void testIsAllSuccessTrue() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_SUCCESS_RESPONSE);
+
+        assertThat(response.isAllSuccess()).isTrue();
+    }
+
+    @Test
+    public void testGetResponses() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_FAILURE_RESPONSE);
+
+        Map<String, Integer> responses = response.getResponses();
+        assertThat(responses).hasSize(3);
+        assertThat(responses.get("res-err-1")).isEqualTo(400);
+        assertThat(responses.get("res-success")).isEqualTo(200);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetResponsesUnmodifiable() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_SUCCESS_RESPONSE);
+
+        response.getResponses().put("more", 418);
+    }
+
+    @Test
+    public void testGetStatus() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_FAILURE_RESPONSE);
+
+        assertThat(response.getStatus("res-success")).isEqualTo(200);
+        assertThat(response.getStatus("res-err-2")).isEqualTo(500);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetStatusUnknownResourceId() {
+        MultiStatusResponse response = new MultiStatusResponse(Collections.singletonMap("foo", 42));
+
+        response.getStatus("nonExistingResource");
+    }
+
+    @Test
+    public void testHasResourceId() {
+        MultiStatusResponse response = new MultiStatusResponse(Collections.singletonMap("foo", 42));
+
+        assertThat(response.hasResourceId("foo")).isTrue();
+        assertThat(response.hasResourceId("bar")).isFalse();
+    }
+
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(MultiStatusResponse.class)
+                .withNonnullFields("responses")
+                .verify();
+    }
+
+    @Test
+    public void testToString() throws IOException {
+        MultiStatusResponse response = fromJson(FILE_SUCCESS_RESPONSE);
+        String s = response.toString();
+
+        assertThat(s).contains("res-1", "res-2");
+    }
+
+    @Test(expected = IOException.class)
+    public void testFromJsonInvalidStatusCodes() throws IOException {
+        String json = "[{\"resourceId\": \"res-1234\"," +
+                "\"status\": \"invalidStatus\"}]";
+        InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+
+        MultiStatusResponse.fromJson(new ObjectMapper(), stream);
+    }
+
+    @Test(expected = IOException.class)
+    public void testFromJsonMissingResourceId() throws IOException {
+        String json = "[{\"noResourceId\": \"res-undefined\"," +
+                "\"status\": 200}]";
+        InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+
+        MultiStatusResponse.fromJson(new ObjectMapper(), stream);
+    }
+}

--- a/modules/sw360/sw360-client/src/test/resources/__files/multi_status_failed.json
+++ b/modules/sw360/sw360-client/src/test/resources/__files/multi_status_failed.json
@@ -1,0 +1,14 @@
+[
+  {
+    "resourceId": "res-err-1",
+    "status": 400
+  },
+  {
+    "resourceId": "res-success",
+    "status": 200
+  },
+  {
+    "resourceId": "res-err-2",
+    "status": 500
+  }
+]

--- a/modules/sw360/sw360-client/src/test/resources/__files/multi_status_success.json
+++ b/modules/sw360/sw360-client/src/test/resources/__files/multi_status_success.json
@@ -1,0 +1,10 @@
+[
+  {
+    "resourceId": "res-1",
+    "status": 200
+  },
+  {
+    "resourceId": "res-2",
+    "status": 200
+  }
+]


### PR DESCRIPTION
Issue 426

This PR adds functionality to delete resource entities to the SW360 client library where it is supported (for components and releases).

SW360 supports deleting multiple entities in a single operation. It then returns a special multi-status response with the status codes of the single delete operations. This PR adds a new MultiStatusResponse class to represent this response.

The API of the components and releases client adapters has been extended to support delete operations for multiple entities or a single one. The latter is a convenience function that evaluates the multi-status response to simplify error handling.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi @blaumeiser-at-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
new feature

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
New test cases have been added for the new functionality provided by this PR.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
