### PR TITLE
Oheger bosch/sw360/#426 licenses

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapter.java
@@ -36,12 +36,39 @@ public interface SW360LicenseClientAdapter {
      * Returns a list with all licenses known to the system.
      *
      * @return a list with all the licenses known
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if an error occurs
      */
     List<SW360SparseLicense> getLicenses();
 
-    boolean isLicenseOfArtifactAvailable(String license);
+    /**
+     * Queries a license from SW360 by its (short) name. If the server
+     * responds with a 404 status indicating that the license is unknown,
+     * result is an empty {@code Optional}.
+     *
+     * @param license the ID of the desired license
+     * @return an {@code Optional} with the license fetched from the server
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if an error occurs
+     */
+    Optional<SW360License> getLicenseByName(String license);
 
-    Optional<SW360License> getSW360LicenseByAntennaLicense(String license);
+    /**
+     * Transforms the given sparse license to an entity with full properties.
+     * This method looks up the license on the server by its name. It expects
+     * the license to be present. If the lookup fails, an exception is thrown.
+     *
+     * @param sparseLicense the entity object for the sparse license
+     * @return the resolved license
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if an error occurs
+     */
+    SW360License enrichSparseLicense(SW360SparseLicense sparseLicense);
 
-    Optional<SW360License> getLicenseDetails(SW360SparseLicense sparseLicense);
+    /**
+     * Creates a new license in SW360 based on the properties of the data
+     * object passed in.
+     *
+     * @param license the data object for the new license
+     * @return the newly created license
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if an error occurs
+     */
+    SW360License createLicense(SW360License license);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapter.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,7 +24,20 @@ import java.util.Optional;
  * </p>
  */
 public interface SW360LicenseClientAdapter {
+    /**
+     * Returns the {@code SW360LicenseClient} used for the interaction with
+     * the SW360 server.
+     *
+     * @return the underlying {@code SW360LicenseClient}
+     */
     SW360LicenseClient getLicenseClient();
+
+    /**
+     * Returns a list with all licenses known to the system.
+     *
+     * @return a list with all the licenses known
+     */
+    List<SW360SparseLicense> getLicenses();
 
     boolean isLicenseOfArtifactAvailable(String license);
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsync.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,7 +25,20 @@ import java.util.concurrent.CompletableFuture;
  * </p>
  */
 public interface SW360LicenseClientAdapterAsync {
+    /**
+     * Returns the {@code SW360LicenseClient} used for the interaction with
+     * the SW360 server.
+     *
+     * @return the underlying {@code SW360LicenseClient}
+     */
     SW360LicenseClient getLicenseClient();
+
+    /**
+     * Returns a list with all licenses known to the system.
+     *
+     * @return a future with the list with all the licenses known
+     */
+    CompletableFuture<List<SW360SparseLicense>> getLicenses();
 
     CompletableFuture<Boolean> isLicenseOfArtifactAvailable(String license);
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsync.java
@@ -40,9 +40,34 @@ public interface SW360LicenseClientAdapterAsync {
      */
     CompletableFuture<List<SW360SparseLicense>> getLicenses();
 
-    CompletableFuture<Boolean> isLicenseOfArtifactAvailable(String license);
+    /**
+     * Queries a license from SW360 by its (short) name. If the server
+     * responds with a 404 status indicating that the license is unknown,
+     * result is an empty {@code Optional}.
+     *
+     * @param license the ID of the desired license
+     * @return a future with an {@code Optional} with the license fetched from
+     * the server
+     */
+    CompletableFuture<Optional<SW360License>> getLicenseByName(String license);
 
-    CompletableFuture<Optional<SW360License>> getSW360LicenseByAntennaLicense(String license);
+    /**
+     * Transforms the given sparse license to an entity with full properties.
+     * This method looks up the license on the server by its name. It expects
+     * the license to be present. If the lookup fails, the future completes
+     * with a failure.
+     *
+     * @param sparseLicense the entity object for the sparse license
+     * @return a future with the resolved license
+     */
+    CompletableFuture<SW360License> enrichSparseLicense(SW360SparseLicense sparseLicense);
 
-    CompletableFuture<Optional<SW360License>> getLicenseDetails(SW360SparseLicense sparseLicense);
+    /**
+     * Creates a new license in SW360 based on the properties of the data
+     * object passed in.
+     *
+     * @param license the data object for the new license
+     * @return a future with the newly created license
+     */
+    CompletableFuture<SW360License> createLicense(SW360License license);
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImpl.java
@@ -42,20 +42,17 @@ class SW360LicenseClientAdapterAsyncImpl implements SW360LicenseClientAdapterAsy
     }
 
     @Override
-    public CompletableFuture<Boolean> isLicenseOfArtifactAvailable(String license) {
-        return getLicenseClient().getLicenses()
-                .thenApply(sw360Licenses -> sw360Licenses.stream()
-                        .map(SW360SparseLicense::getShortName)
-                        .anyMatch(n -> n.equals(license)));
-    }
-
-    @Override
-    public CompletableFuture<Optional<SW360License>> getSW360LicenseByAntennaLicense(String license) {
+    public CompletableFuture<Optional<SW360License>> getLicenseByName(String license) {
         return optionalFuture(getLicenseClient().getLicenseByName(license));
     }
 
     @Override
-    public CompletableFuture<Optional<SW360License>> getLicenseDetails(SW360SparseLicense sparseLicense) {
-        return optionalFuture(getLicenseClient().getLicenseByName(sparseLicense.getShortName()));
+    public CompletableFuture<SW360License> enrichSparseLicense(SW360SparseLicense sparseLicense) {
+        return getLicenseClient().getLicenseByName(sparseLicense.getShortName());
+    }
+
+    @Override
+    public CompletableFuture<SW360License> createLicense(SW360License license) {
+        return getLicenseClient().createLicense(license);
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -33,6 +34,11 @@ class SW360LicenseClientAdapterAsyncImpl implements SW360LicenseClientAdapterAsy
     @Override
     public SW360LicenseClient getLicenseClient() {
         return licenseClient;
+    }
+
+    @Override
+    public CompletableFuture<List<SW360SparseLicense>> getLicenses() {
+        return getLicenseClient().getLicenses();
     }
 
     @Override

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360LicenseClient.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.rest;
 
+import org.eclipse.sw360.antenna.http.RequestBuilder;
 import org.eclipse.sw360.antenna.http.utils.HttpUtils;
 import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig;
 import org.eclipse.sw360.antenna.sw360.client.auth.AccessTokenProvider;
@@ -39,6 +40,11 @@ public class SW360LicenseClient extends SW360Client {
      * Tag for the request that queries the details for a specific license.
      */
     static final String TAG_GET_LICENSE_BY_NAME = "get_license_by_name";
+
+    /**
+     * Tag for the request to create a new license.
+     */
+    static final String TAG_CREATE_LICENSE = "post_create_license";
 
     private static final String LICENSES_ENDPOINT = "licenses";
 
@@ -77,5 +83,20 @@ public class SW360LicenseClient extends SW360Client {
     public CompletableFuture<SW360License> getLicenseByName(String name) {
         return executeJsonRequest(HttpUtils.get(resourceUrl(LICENSES_ENDPOINT, name)), SW360License.class,
                 TAG_GET_LICENSE_BY_NAME);
+    }
+
+    /**
+     * Creates a new license based on the properties of the data object passed
+     * in.
+     *
+     * @param license the data object for the license to be created
+     * @return a future with the newly created license
+     */
+    public CompletableFuture<SW360License> createLicense(SW360License license) {
+        return executeJsonRequest(builder ->
+                        builder.uri(resourceUrl(LICENSES_ENDPOINT))
+                                .method(RequestBuilder.Method.POST)
+                                .body(bodyBuilder -> bodyBuilder.json(license)),
+                SW360License.class, TAG_CREATE_LICENSE);
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImplTest.java
@@ -16,7 +16,9 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360Sparse
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -38,6 +40,17 @@ public class SW360LicenseClientAdapterAsyncImplTest {
     public void setUp() {
         licenseClient = mock(SW360LicenseClient.class);
         licenseClientAdapter = new SW360LicenseClientAdapterAsyncImpl(licenseClient);
+    }
+
+    @Test
+    public void testGetLicenses() {
+        List<SW360SparseLicense> licenses = Arrays.asList(new SW360SparseLicense().setShortName("l1"),
+                new SW360SparseLicense().setShortName("l2"));
+        when(licenseClient.getLicenses())
+                .thenReturn(CompletableFuture.completedFuture(licenses));
+
+        List<SW360SparseLicense> result = block(licenseClientAdapter.getLicenses());
+        assertThat(result).isEqualTo(licenses);
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360LicenseClientAdapterAsyncImplTest.java
@@ -10,14 +10,16 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
+import org.eclipse.sw360.antenna.http.utils.HttpConstants;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360LicenseClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
+import org.eclipse.sw360.antenna.sw360.client.utils.FutureUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -54,51 +56,50 @@ public class SW360LicenseClientAdapterAsyncImplTest {
     }
 
     @Test
-    public void testIsLicenseOfArtifactAvailableIsAvailable() {
-        SW360SparseLicense sparseLicense = new SW360SparseLicense()
-                .setShortName(LICENSE_NAME);
-        when(licenseClient.getLicenses())
-                .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseLicense)));
-
-        boolean licenseOfArtifactAvailable = block(licenseClientAdapter.isLicenseOfArtifactAvailable(LICENSE_NAME));
-
-        assertThat(licenseOfArtifactAvailable).isTrue();
-        verify(licenseClient, atLeastOnce()).getLicenses();
-    }
-
-    @Test
-    public void testIsLicenseOfArtifactAvailableIsNotAvailable() {
-        SW360SparseLicense sparseLicense = new SW360SparseLicense()
-                .setShortName(LICENSE_NAME);
-        when(licenseClient.getLicenses())
-                .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseLicense)));
-
-        boolean licenseOfArtifactAvailable =
-                block(licenseClientAdapter.isLicenseOfArtifactAvailable(LICENSE_NAME + "-no"));
-
-        assertThat(licenseOfArtifactAvailable).isFalse();
-        verify(licenseClient, atLeastOnce()).getLicenses();
-    }
-
-    @Test
-    public void testGetSW360LicenseByAntennaLicense() {
+    public void testGetLicenseByName() {
         SW360License license = prepareLicenseClientGetLicenseByName();
 
         Optional<SW360License> sw360LicenseByAntennaLicense =
-                block(licenseClientAdapter.getSW360LicenseByAntennaLicense(LICENSE_NAME));
+                block(licenseClientAdapter.getLicenseByName(LICENSE_NAME));
 
-        assertLicenseByNameResult(license, sw360LicenseByAntennaLicense);
+        assertThat(sw360LicenseByAntennaLicense).isPresent();
+        assertThat(sw360LicenseByAntennaLicense).hasValue(license);
+        verify(licenseClient, atLeastOnce()).getLicenseByName(LICENSE_NAME);
     }
 
     @Test
-    public void testGetLicenseDetails() {
+    public void testGetLicenseByNameUnresolved() {
+        FailedRequestException exception =
+                new FailedRequestException("get_license", HttpConstants.STATUS_ERR_NOT_FOUND);
+        when(licenseClient.getLicenseByName(LICENSE_NAME))
+                .thenReturn(FutureUtils.failedFuture(exception));
+
+        Optional<SW360License> result = block(licenseClientAdapter.getLicenseByName(LICENSE_NAME));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testEnrichSparseLicense() {
         SW360License license = prepareLicenseClientGetLicenseByName();
         SW360SparseLicense sparseLicense = new SW360SparseLicense()
                 .setShortName(LICENSE_NAME);
 
-        Optional<SW360License> licenseDetails = block(licenseClientAdapter.getLicenseDetails(sparseLicense));
+        SW360License licenseDetails = block(licenseClientAdapter.enrichSparseLicense(sparseLicense));
+        assertThat(licenseDetails).isEqualTo(license);
+    }
 
-        assertLicenseByNameResult(license, licenseDetails);
+    @Test
+    public void testCreateLicense() {
+        SW360License licenseTemplate = new SW360License()
+                .setFullName("testLicense");
+        SW360License licenseCreated = new SW360License()
+                .setShortName("createdLicense")
+                .setFullName("testLicense");
+        when(licenseClient.createLicense(licenseTemplate))
+                .thenReturn(CompletableFuture.completedFuture(licenseCreated));
+
+        SW360License result = block(licenseClientAdapter.createLicense(licenseTemplate));
+        assertThat(result).isEqualTo(licenseCreated);
     }
 
     private SW360License prepareLicenseClientGetLicenseByName() {
@@ -109,11 +110,4 @@ public class SW360LicenseClientAdapterAsyncImplTest {
 
         return license;
     }
-
-    private void assertLicenseByNameResult(SW360License license, Optional<SW360License> sw360LicenseByAntennaLicense) {
-        assertThat(sw360LicenseByAntennaLicense).isPresent();
-        assertThat(sw360LicenseByAntennaLicense).hasValue(license);
-        verify(licenseClient, atLeastOnce()).getLicenseByName(LICENSE_NAME);
-    }
-
 }

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiver.java
@@ -23,6 +23,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Comp
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.utils.ArtifactToComponentUtils;
 import org.eclipse.sw360.antenna.sw360.utils.ArtifactToReleaseUtils;
 import org.slf4j.Logger;
@@ -56,7 +57,12 @@ public class SW360MetaDataReceiver {
     }
 
     public Optional<SW360License> getLicenseDetails(SW360SparseLicense sparseLicense) {
-        return licenseClientAdapter.getLicenseDetails(sparseLicense);
+        try {
+            return Optional.of(licenseClientAdapter.enrichSparseLicense(sparseLicense));
+        } catch (SW360ClientException e) {
+            LOGGER.debug("Failed to lookup sparse license {}.", sparseLicense.getShortName(), e);
+            return Optional.empty();
+        }
     }
 
     public Optional<Path> downloadAttachment(SW360Release release, SW360SparseAttachment attachment, Path downloadPath) {

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -71,7 +71,7 @@ public class SW360MetaDataUpdater {
     public Set<SW360License> getLicenses(Collection<License> licenses) {
         return licenses.stream()
                 .filter(this::isLicenseInSW360)
-                .map(license -> licenseClientAdapter.getSW360LicenseByAntennaLicense(license.getId()))
+                .map(license -> licenseClientAdapter.getLicenseByName(license.getId()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toSet());

--- a/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
+++ b/modules/sw360/sw360-workflow/src/main/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdater.java
@@ -25,6 +25,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360Visibility;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class SW360MetaDataUpdater {
@@ -51,10 +53,17 @@ public class SW360MetaDataUpdater {
     private final boolean updateReleases;
     private final boolean uploadSources;
 
+    /**
+     * Stores a set with the IDs of licenses known to SW360. This set is
+     * populated on demand and then cached to speed up further license checks.
+     */
+    private final AtomicReference<Set<String>> knownSW360LicenseIds;
+
     public SW360MetaDataUpdater(SW360Connection connection, boolean updateReleases, boolean uploadSources) {
         projectClientAdapter = connection.getProjectAdapter();
         licenseClientAdapter = connection.getLicenseAdapter();
         releaseClientAdapter = connection.getReleaseAdapter();
+        knownSW360LicenseIds = new AtomicReference<>();
         this.updateReleases = updateReleases;
         this.uploadSources = uploadSources;
     }
@@ -69,12 +78,42 @@ public class SW360MetaDataUpdater {
     }
 
     private boolean isLicenseInSW360(License license) {
-        if (licenseClientAdapter.isLicenseOfArtifactAvailable(license.getId())) {
+        if (getSW360Licenses().contains(license.getId())) {
             LOGGER.debug("License [{}] found in SW360.", license.getId());
             return true;
         }
         LOGGER.debug("License [{}] unknown in SW360.", license.getId());
         return false;
+    }
+
+    /**
+     * Returns a set with the licenses known to SW360. The set is retrieved
+     * once and then cached. Note that an atomic reference is used to make
+     * sure that the initialization happens in a thread-safe way.
+     *
+     * @return the set with licenses known to SW360
+     */
+    private Set<String> getSW360Licenses() {
+        Set<String> licenseIds = knownSW360LicenseIds.get();
+        while (licenseIds == null) {
+            licenseIds = loadLicensesFromSW360();
+            if (!knownSW360LicenseIds.compareAndSet(null, licenseIds)) {
+                licenseIds = knownSW360LicenseIds.get();
+            }
+        }
+        return licenseIds;
+    }
+
+    /**
+     * Queries the licenses known to SW360 and generates a set with their IDs.
+     *
+     * @return the set with IDs of all known licenses in SW360
+     */
+    private Set<String> loadLicensesFromSW360() {
+        LOGGER.info("Querying existing licenses from SW360.");
+        return licenseClientAdapter.getLicenses().stream()
+                .map(SW360SparseLicense::getShortName)
+                .collect(Collectors.toSet());
     }
 
     public SW360Release getOrCreateRelease(SW360Release sw360ReleaseFromArtifact) {

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiverTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataReceiverTest.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Comp
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.utils.ArtifactToComponentUtils;
 import org.junit.Test;
 
@@ -106,14 +107,25 @@ public class SW360MetaDataReceiverTest {
     public void testGetLicenseDetails() {
         SW360SparseLicense sparseLicense = new SW360SparseLicense();
         SW360License sw360License = new SW360License();
-        when(licenseClientAdapter.getLicenseDetails(sparseLicense))
-                .thenReturn(Optional.of(sw360License));
+        when(licenseClientAdapter.enrichSparseLicense(sparseLicense))
+                .thenReturn(sw360License);
         setUp();
 
         Optional<SW360License> licenseDetails = metaDataReceiver.getLicenseDetails(sparseLicense);
 
         assertThat(licenseDetails).hasValue(sw360License);
-        verify(licenseClientAdapter, times(1)).getLicenseDetails(sparseLicense);
+        verify(licenseClientAdapter, times(1)).enrichSparseLicense(sparseLicense);
+    }
+
+    @Test
+    public void testGetLicenseDetailsException() {
+        SW360SparseLicense license = new SW360SparseLicense().setShortName("foo");
+        when(licenseClientAdapter.enrichSparseLicense(license))
+                .thenThrow(new SW360ClientException("License lookup failed"));
+        setUp();
+
+        Optional<SW360License> licenseDetails = metaDataReceiver.getLicenseDetails(license);
+        assertThat(licenseDetails).isEmpty();
     }
 
     @Test

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -177,6 +177,7 @@ public class SW360MetaDataUpdaterTest {
 
         assertThat(licenses).hasSize(1);
 
+        verify(licenseClientAdapter, times(1)).getLicenses();
         verify(licenseClientAdapter, times(1)).getLicenseByName(licenseName);
     }
 
@@ -196,6 +197,7 @@ public class SW360MetaDataUpdaterTest {
         final Set<SW360License> licenses = metaDataUpdater.getLicenses(Collections.singletonList(licenseAntenna));
 
         assertThat(licenses).hasSize(0);
+        verify(licenseClientAdapter, times(1)).getLicenses();
     }
 
     @Test

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360License;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -39,9 +40,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -131,15 +135,40 @@ public class SW360MetaDataUpdaterTest {
         return folder.getRoot().toPath().resolve(name);
     }
 
+    /**
+     * Creates a test license with the given name.
+     *
+     * @param name the license name
+     * @return the test license with this name
+     */
+    private static SW360SparseLicense createLicense(String name) {
+        SW360SparseLicense license = new SW360SparseLicense();
+        return license.setShortName(name)
+                .setFullName(name + "_full");
+    }
+
+    /**
+     * Generates a list with test licenses.
+     *
+     * @return the list with test licenses
+     */
+    private static List<SW360SparseLicense> createTestLicenses() {
+        return IntStream.range(1, 9)
+                .mapToObj(idx -> "testLicense" + idx)
+                .map(SW360MetaDataUpdaterTest::createLicense)
+                .collect(Collectors.toList());
+    }
+
     @Test
     public void testGetLicensesWithExistingLicense() {
         final String licenseName = "licenseName";
+        List<SW360SparseLicense> testLicenses = createTestLicenses();
+        testLicenses.add(createLicense(licenseName));
         final SW360License license = new SW360License()
                 .setShortName(licenseName);
         License licenseAntenna = new License();
         licenseAntenna.setId(licenseName);
-        when(licenseClientAdapter.isLicenseOfArtifactAvailable(licenseName))
-                .thenReturn(true);
+        when(licenseClientAdapter.getLicenses()).thenReturn(testLicenses);
         when(licenseClientAdapter.getSW360LicenseByAntennaLicense(licenseName))
                 .thenReturn(Optional.of(license));
         setUp(true, false);
@@ -148,7 +177,6 @@ public class SW360MetaDataUpdaterTest {
 
         assertThat(licenses).hasSize(1);
 
-        verify(licenseClientAdapter, times(1)).isLicenseOfArtifactAvailable(licenseName);
         verify(licenseClientAdapter, times(1)).getSW360LicenseByAntennaLicense(licenseName);
     }
 
@@ -159,8 +187,8 @@ public class SW360MetaDataUpdaterTest {
                 .setShortName(licenseName);
         License licenseAntenna = new License();
         licenseAntenna.setId(licenseName);
-        when(licenseClientAdapter.isLicenseOfArtifactAvailable(licenseName))
-                .thenReturn(false);
+        when(licenseClientAdapter.getLicenses())
+                .thenReturn(createTestLicenses());
         when(licenseClientAdapter.getSW360LicenseByAntennaLicense(licenseName))
                 .thenReturn(Optional.of(license));
         setUp(true, false);
@@ -168,8 +196,6 @@ public class SW360MetaDataUpdaterTest {
         final Set<SW360License> licenses = metaDataUpdater.getLicenses(Collections.singletonList(licenseAntenna));
 
         assertThat(licenses).hasSize(0);
-
-        verify(licenseClientAdapter, times(1)).isLicenseOfArtifactAvailable(licenseName);
     }
 
     @Test

--- a/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
+++ b/modules/sw360/sw360-workflow/src/test/java/org/eclipse/sw360/antenna/sw360/SW360MetaDataUpdaterTest.java
@@ -169,7 +169,7 @@ public class SW360MetaDataUpdaterTest {
         License licenseAntenna = new License();
         licenseAntenna.setId(licenseName);
         when(licenseClientAdapter.getLicenses()).thenReturn(testLicenses);
-        when(licenseClientAdapter.getSW360LicenseByAntennaLicense(licenseName))
+        when(licenseClientAdapter.getLicenseByName(licenseName))
                 .thenReturn(Optional.of(license));
         setUp(true, false);
 
@@ -177,7 +177,7 @@ public class SW360MetaDataUpdaterTest {
 
         assertThat(licenses).hasSize(1);
 
-        verify(licenseClientAdapter, times(1)).getSW360LicenseByAntennaLicense(licenseName);
+        verify(licenseClientAdapter, times(1)).getLicenseByName(licenseName);
     }
 
     @Test
@@ -189,7 +189,7 @@ public class SW360MetaDataUpdaterTest {
         licenseAntenna.setId(licenseName);
         when(licenseClientAdapter.getLicenses())
                 .thenReturn(createTestLicenses());
-        when(licenseClientAdapter.getSW360LicenseByAntennaLicense(licenseName))
+        when(licenseClientAdapter.getLicenseByName(licenseName))
                 .thenReturn(Optional.of(license));
         setUp(true, false);
 


### PR DESCRIPTION
Issue 426

This PR is about fine-tuning the license part of the SW360 client library.

The API was slightly reworked, new functionality to create licenses was added, Javadoc has been improved.

As a side-effect, access to licenses in SW360MetaDataUpdater has been reworked: the updater no longer asks the license adapter for each license (which was an expensive operation); rather, the licenses IDs available are loaded once and then cached locally.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
Existing test cases have been adapted. For new functionality, new tests have been added.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
