### PR TITLE
Oheger bosch/http/#558 error responses

### DIFF
--- a/http-support/pom.xml
+++ b/http-support/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -62,11 +66,6 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/FailedRequestException.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/utils/FailedRequestException.java
@@ -44,7 +44,20 @@ public class FailedRequestException extends IOException {
      * @param statusCode the HTTP status code
      */
     public FailedRequestException(String tag, int statusCode) {
-        super(generateMessage(tag, statusCode));
+        this(tag, statusCode, null);
+    }
+
+    /**
+     * Creates a new instance of {@code FailedRequestException} and initializes
+     * it with a tag, the error status code, and the message sent from the
+     * server as response to the failed request.
+     *
+     * @param tag           a tag to identify the failed request
+     * @param statusCode    the HTTP status code
+     * @param serverMessage the error message sent by the server
+     */
+    public FailedRequestException(String tag, int statusCode, String serverMessage) {
+        super(generateMessage(tag, statusCode, serverMessage));
         this.tag = tag;
         this.statusCode = statusCode;
     }
@@ -72,12 +85,25 @@ public class FailedRequestException extends IOException {
      * Generates a message for this exception based on the parameters passed
      * in.
      *
-     * @param tag        a tag to identify the failed request
-     * @param statusCode the HTTP status code
+     * @param tag           a tag to identify the failed request
+     * @param statusCode    the HTTP status code
+     * @param serverMessage the error message sent by the server
      * @return the exception message
      */
-    private static String generateMessage(String tag, int statusCode) {
-        String prefix = (tag != null) ? "The request '" + tag + "'" : "A request";
-        return prefix + " failed with status code " + statusCode;
+    private static String generateMessage(String tag, int statusCode, String serverMessage) {
+        StringBuilder buf = new StringBuilder();
+        if (tag != null) {
+            buf.append("The request '").append(tag).append('\'');
+        } else {
+            buf.append("A request");
+        }
+        buf.append(" failed with status code ").append(statusCode).append('.');
+
+        if (serverMessage != null && !serverMessage.isEmpty()) {
+            buf.append(" Message from the server:")
+                    .append(System.lineSeparator())
+                    .append('"').append(serverMessage).append('"');
+        }
+        return buf.toString();
     }
 }

--- a/http-support/src/site/markdown/index_http.md.vm
+++ b/http-support/src/site/markdown/index_http.md.vm
@@ -303,6 +303,7 @@ the HTTP client.
 
 The functions are named _checkResponse()_. There are multiple overloaded
 variants; they support the following arguments:
+
 * the original _ResponseProcessor_; as has already been explained, this
   processor is decorated with the checking logic.
 * a predicate defining the checking logic. This is a function that expects a
@@ -318,6 +319,17 @@ a default one which just checks whether the HTTP status is in the successful
 range. This may be sufficient for many use cases. If more control is needed, 
 the _hasStatus()_ function is a candidate: it is passed a status code, and it
 returns *true* if and only if a response has exactly this status.
+
+When detecting a failed request the functions throw an exception of type
+_FailedRequestException_. This exception becomes the result of the future
+returned by the HTTP client. From its properties, the caller can gain some
+useful information about the failure:
+
+* the HTTP status code
+* the tag of the request (if provided)
+* the body of the response; this is the content sent by the server in the
+  response - depending on the server, this may contain additional information
+  why the request failed
 
 #[[###]]# JSON deserialization support
 

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpRequestExecutionIT.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpRequestExecutionIT.java
@@ -391,6 +391,22 @@ public class HttpRequestExecutionIT {
     }
 
     @Test
+    public void testGetWithFailedResponseStatusAndErrorMessage() throws IOException {
+        final String serverError = "Server did not like this request!";
+        wireMockRule.stubFor(get(ENDPOINT)
+        .willReturn(aResponse().withStatus(STATUS_ERR_BAD_REQUEST)
+        .withBody(serverError)));
+
+        try {
+            waitFor(httpClient.execute(HttpUtils.get(endpointUri()),
+                    checkResponse(response -> new Object())));
+        } catch (FailedRequestException e) {
+            assertThat(e.getStatusCode()).isEqualTo(STATUS_ERR_BAD_REQUEST);
+            assertThat(e.getMessage()).contains(String.valueOf(STATUS_ERR_BAD_REQUEST), serverError);
+        }
+    }
+
+    @Test
     public void testJsonResponse() throws IOException {
         JsonBean bean = new JsonBean();
         bean.setTitle("JSON serialization test");

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR fixes #558 

The handling of failed requests in the HTTP client library has been extended to read the entity of the response returned by the server and store it as property in the resulting _FailedRequestException_ exception. So callers have access to this information, which may be useful to diagnose the reason for the failed request.

The dependency to commons-io has been upgraded from 2.6 to 2.7 because the new version has a method to read an input stream into a string buffer.

### Request Reviewer
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
The integration test for sending HTTP requests now checks whether a failure response is stored in the resulting exception. A new unit test case has been added to check exception handling when reading the response from the server.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes: a paragraph has been added to the documentation about _FailedRequestException_ and its properties
