### PR TITLE
Oheger bosch/sw360/#429 component search api

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360Exporter.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.antenna.model.artifact.Artifact;
 import org.eclipse.sw360.antenna.model.artifact.facts.ArtifactSourceFile;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
@@ -80,7 +81,7 @@ public class SW360Exporter {
         LOGGER.debug("{} has started.", SW360Exporter.class.getName());
         connection = configuration.getConnection();
 
-        Collection<SW360SparseComponent> components = connection.getComponentAdapter().getComponents();
+        Collection<SW360SparseComponent> components = connection.getComponentAdapter().search(ComponentSearchParams.ALL_COMPONENTS);
 
         Collection<SW360SparseRelease> sw360SparseReleases = getReleasesFromComponents(components);
 

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRGetClearedReleases.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRGetClearedReleases.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.reporter;
 
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 
@@ -29,7 +30,7 @@ public class IRGetClearedReleases extends IRForReleases {
 
     @Override
     public Collection<SW360Release> execute(SW360Connection connection) {
-        final List<SW360SparseComponent> components = connection.getComponentAdapter().getComponents();
+        final List<SW360SparseComponent> components = connection.getComponentAdapter().search(ComponentSearchParams.ALL_COMPONENTS);
 
         final Predicate<SW360Release> isApproved = ComplianceFeatureUtils::isApproved;
         return getReleasesFromComponentsByPredicate(connection, components, isApproved);

--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRGetNotClearedReleases.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRGetNotClearedReleases.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.frontend.compliancetool.sw360.reporter;
 
 import org.eclipse.sw360.antenna.frontend.compliancetool.sw360.ComplianceFeatureUtils;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
 
@@ -29,7 +30,7 @@ public class IRGetNotClearedReleases extends IRForReleases {
 
     @Override
     public Collection<SW360Release> execute(SW360Connection connection) {
-        final List<SW360SparseComponent> components = connection.getComponentAdapter().getComponents();
+        final List<SW360SparseComponent> components = connection.getComponentAdapter().search(ComponentSearchParams.ALL_COMPONENTS);
 
         final Predicate<SW360Release> releasePredicate = sw360release -> !ComplianceFeatureUtils.isApproved(sw360release);
         return getReleasesFromComponentsByPredicate(connection, components, releasePredicate);

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterParametrizedTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/exporter/SW360ExporterParametrizedTest.java
@@ -20,6 +20,7 @@ import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapterAsync;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ClearingState;
@@ -126,7 +127,7 @@ public class SW360ExporterParametrizedTest {
     @Before
     public void setUp() throws IOException {
         SW360SparseComponent sparseComponent = SW360TestUtils.mkSW360SparseComponent("testComponent");
-        when(componentClientAdapterMock.getComponents())
+        when(componentClientAdapterMock.search(ComponentSearchParams.ALL_COMPONENTS))
                 .thenReturn(Collections.singletonList(sparseComponent));
 
         SW360Component component =

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRForReleasesHelper.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/reporter/IRForReleasesHelper.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection;
 import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ReleaseClientAdapter;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentEmbedded;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
@@ -54,7 +55,7 @@ public class IRForReleasesHelper {
         when(componentClientAdapter.getComponentById(any()))
                 .thenReturn(Optional.of((component)));
         SW360SparseComponent sparseComponent = SW360TestUtils.mkSW360SparseComponent(name);
-        when(componentClientAdapter.getComponents())
+        when(componentClientAdapter.search(ComponentSearchParams.ALL_COMPONENTS))
                 .thenReturn(Collections.singletonList(sparseComponent));
         when(connection.getComponentAdapter())
                 .thenReturn(componentClientAdapter);

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/utils/HttpUtilsTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/utils/HttpUtilsTest.java
@@ -241,10 +241,24 @@ public class HttpUtilsTest {
         params.put("foo", "bar");
         params.put("test", Boolean.TRUE);
         params.put("complex param", "this must be encoded");
+        params.put("nullValue", null);
+        params.put("emptyValue", "");
         String url = "https://test.antenna.org/query";
-        String expResult = url + "?foo=bar&test=true&complex+param=this+must+be+encoded";
+        String expResult = url + "?foo=bar&test=true&complex+param=this+must+be+encoded&nullValue=&emptyValue=";
 
         assertThat(HttpUtils.addQueryParameters(url, params)).isEqualTo(expResult);
+    }
+
+    @Test
+    public void testAddQueryParametersFiltersNullOrEmptyValues() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("nullValue", null);
+        params.put("emptyValue", "");
+        params.put("foo", "bar");
+        String url = "https://test.antenna.org/query";
+        String expResult = url + "?foo=bar";
+
+        assertThat(HttpUtils.addQueryParameters(url, params, true)).isEqualTo(expResult);
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
+import org.eclipse.sw360.antenna.sw360.client.rest.PagingResult;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
@@ -38,12 +39,28 @@ public interface SW360ComponentClientAdapter {
     Optional<SW360Component> getComponentByName(String componentName);
 
     /**
-     * Searches for components based on the criteria provided.
+     * Searches for components based on the criteria provided. Like
+     * {@link #searchWithPaging(ComponentSearchParams)}, this method supports
+     * arbitrary searches, but it ignores the paging information in the result
+     * and only returns the list of entities found. So using this method is
+     * more convenient if the caller is not interested in paging.
      *
      * @param searchParams the object with search parameters
      * @return a list with the components found by the search
      */
     List<SW360SparseComponent> search(ComponentSearchParams searchParams);
+
+    /**
+     * Searches for components based on the criteria provided and returns a
+     * {@code PagingResult} with the entities found and additional paging
+     * information. Note that paging information is available only if the
+     * search parameters make use of the paging mechanism; otherwise, in the
+     * result object only the list with entities is populated.
+     *
+     * @param searchParams the object with search parameters
+     * @return an object representing the result of the search
+     */
+    PagingResult<SW360SparseComponent> searchWithPaging(ComponentSearchParams searchParams);
 
     /**
      * Triggers a multi-delete operation for the components with the IDs

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
@@ -36,7 +37,13 @@ public interface SW360ComponentClientAdapter {
 
     Optional<SW360Component> getComponentByName(String componentName);
 
-    List<SW360SparseComponent> getComponents();
+    /**
+     * Searches for components based on the criteria provided.
+     *
+     * @param searchParams the object with search parameters
+     * @return a list with the components found by the search
+     */
+    List<SW360SparseComponent> search(ComponentSearchParams searchParams);
 
     /**
      * Triggers a multi-delete operation for the components with the IDs

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
+import org.eclipse.sw360.antenna.sw360.client.rest.PagingResult;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
@@ -39,12 +40,28 @@ public interface SW360ComponentClientAdapterAsync {
     CompletableFuture<Optional<SW360Component>> getComponentByName(String componentName);
 
     /**
-     * Searches for components based on the criteria provided.
+     * Searches for components based on the criteria provided. Like
+     * {@link #searchWithPaging(ComponentSearchParams)}, this method supports
+     * arbitrary searches, but it ignores the paging information in the result
+     * and only returns the list of entities found. So using this method is
+     * more convenient if the caller is not interested in paging.
      *
      * @param searchParams the object with search parameters
      * @return a future with the list of the components found by the search
      */
     CompletableFuture<List<SW360SparseComponent>> search(ComponentSearchParams searchParams);
+
+    /**
+     * Searches for components based on the criteria provided and returns a
+     * {@code PagingResult} with the entities found and additional paging
+     * information. Note that paging information is available only if the
+     * search parameters make use of the paging mechanism; otherwise, in the
+     * result object only the list with entities is populated.
+     *
+     * @param searchParams the object with search parameters
+     * @return a future with the object representing the result of the search
+     */
+    CompletableFuture<PagingResult<SW360SparseComponent>> searchWithPaging(ComponentSearchParams searchParams);
 
     /**
      * Triggers a multi-delete operation for the components with the IDs

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 
@@ -37,7 +38,13 @@ public interface SW360ComponentClientAdapterAsync {
 
     CompletableFuture<Optional<SW360Component>> getComponentByName(String componentName);
 
-    CompletableFuture<List<SW360SparseComponent>> getComponents();
+    /**
+     * Searches for components based on the criteria provided.
+     *
+     * @param searchParams the object with search parameters
+     * @return a future with the list of the components found by the search
+     */
+    CompletableFuture<List<SW360SparseComponent>> search(ComponentSearchParams searchParams);
 
     /**
      * Triggers a multi-delete operation for the components with the IDs

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
@@ -81,8 +81,8 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
     }
 
     @Override
-    public CompletableFuture<List<SW360SparseComponent>> getComponents() {
-        return getComponentClient().getComponents();
+    public CompletableFuture<List<SW360SparseComponent>> search(ComponentSearchParams searchParams) {
+        return getComponentClient().search(searchParams);
     }
 
     @Override

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
+import org.eclipse.sw360.antenna.sw360.client.rest.PagingResult;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResourceUtility;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
@@ -71,7 +72,7 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
                 .build();
         return getComponentClient().search(searchParams)
                 .thenCompose(components ->
-                        components.stream()
+                        components.getResult().stream()
                                 .filter(c -> c.getName().equals(componentName))
                                 .map(c -> SW360HalResourceUtility.getLastIndexOfSelfLink(c.getLinks()).orElse(""))
                                 .map(this::getComponentById)
@@ -82,6 +83,12 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
 
     @Override
     public CompletableFuture<List<SW360SparseComponent>> search(ComponentSearchParams searchParams) {
+        return searchWithPaging(searchParams)
+                .thenApply(PagingResult::getResult);
+    }
+
+    @Override
+    public CompletableFuture<PagingResult<SW360SparseComponent>> searchWithPaging(ComponentSearchParams searchParams) {
         return getComponentClient().search(searchParams);
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResourceUtility;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
@@ -65,7 +66,10 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
 
     @Override
     public CompletableFuture<Optional<SW360Component>> getComponentByName(String componentName) {
-        return getComponentClient().searchByName(componentName)
+        ComponentSearchParams searchParams = ComponentSearchParams.builder()
+                .withName(componentName)
+                .build();
+        return getComponentClient().search(searchParams)
                 .thenCompose(components ->
                         components.stream()
                                 .filter(c -> c.getName().equals(componentName))

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/PagingResult.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/PagingResult.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest;
+
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.Paging;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.PagingLinkObjects;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * <p>
+ * A data class holding the result of a search query together with paging
+ * information.
+ * </p>
+ * <p>
+ * This class can be used to represent the result of a query that makes use of
+ * paging. In this case, the result set consists of multiple pages of a defined
+ * size. A single request yields a specific page. So the whole result set can
+ * be processed in multiple chunks.
+ * </p>
+ * <p>
+ * Results for paging requests in SW360 contain some additional objects. Next
+ * to the actual result, there are special links supporting the navigation
+ * through the result set. There is some paging-related metadata as well, such
+ * as the number of total pages available. This class exposes this additional
+ * information.
+ * </p>
+ * <p>
+ * Note: This class does not require the passed in paging-related data objects
+ * to be actually defined; it accepts <strong>null</strong> objects without
+ * complaining. Thus, it is possible to create an instance from a query result
+ * that does not contain paging information. However, this means that clients
+ * must be prepared that get methods can also return <strong>null</strong>.
+ * The result list must be non <strong>null</strong> though.
+ * </p>
+ *
+ * @param <T> the type of the result objects contained in this result
+ */
+public final class PagingResult<T> {
+    /**
+     * The list with the actual result.
+     */
+    private final List<T> result;
+
+    /**
+     * An object with metadata related to paging.
+     */
+    private final Paging paging;
+
+    /**
+     * An object with links supporting navigation through pages.
+     */
+    private final PagingLinkObjects pagingLinkObjects;
+
+    /**
+     * Creates a new instance of {@code PagingResult} and initializes it with
+     * the data to be hold.
+     *
+     * @param result            the query result (must not be <strong>null</strong>)
+     * @param paging            the paging metadata
+     * @param pagingLinkObjects the paging links
+     * @throws NullPointerException if the result list is <strong>null</strong>
+     */
+    public PagingResult(Collection<? extends T> result, Paging paging, PagingLinkObjects pagingLinkObjects) {
+        this.result = Collections.unmodifiableList(new ArrayList<>(result));
+        this.paging = paging;
+        this.pagingLinkObjects = pagingLinkObjects;
+    }
+
+    /**
+     * Returns a (unmodifiable) list with the actual search results.
+     *
+     * @return a list with the entities returned by the search
+     */
+    public List<T> getResult() {
+        return result;
+    }
+
+    /**
+     * Returns the {@code Paging} object with metadata about the pages
+     * available in the search result. This can be <strong>null</strong> if no
+     * paging information has been provided at construction.
+     *
+     * @return the {@code Paging} object
+     */
+    public Paging getPaging() {
+        return paging;
+    }
+
+    /**
+     * Returns the object with links to navigate through the result pages. This
+     * can be <strong>null</strong> if no paging information has been provided
+     * at construction.
+     *
+     * @return the {@code PagingLinkObjects}
+     */
+    public PagingLinkObjects getPagingLinkObjects() {
+        return pagingLinkObjects;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PagingResult<?> result1 = (PagingResult<?>) o;
+        return getResult().equals(result1.getResult()) &&
+                Objects.equals(getPaging(), result1.getPaging()) &&
+                Objects.equals(getPagingLinkObjects(), result1.getPagingLinkObjects());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getResult(), getPaging(), getPagingLinkObjects());
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -113,18 +113,6 @@ public class SW360ComponentClient extends SW360Client {
     }
 
     /**
-     * Returns a future with a list containing all the components known to the
-     * system.
-     *
-     * @return a future with a list with all existing components
-     */
-    public CompletableFuture<List<SW360SparseComponent>> getComponents() {
-        return executeJsonRequestWithDefault(HttpUtils.get(resourceUrl(COMPONENTS_ENDPOINT)), SW360ComponentList.class,
-                TAG_GET_COMPONENTS, SW360ComponentList::new)
-                .thenApply(SW360ResourceUtils::getSw360SparseComponents);
-    }
-
-    /**
      * Returns a future with the list of all the components in the SW360
      * instance that match the search parameters specified.
      *

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -113,18 +113,21 @@ public class SW360ComponentClient extends SW360Client {
     }
 
     /**
-     * Returns a future with the list of all the components in the SW360
-     * instance that match the search parameters specified.
+     * Executes a search query based on the parameters provided and returns a
+     * future with a result object. The result contains the entities matched by
+     * the search criteria and paging-related metadata if available. (If the
+     * search parameters do not use paging, the paging-related objects in the
+     * result are <strong>null</strong>.)
      *
      * @param searchParams the object with search parameters
-     * @return a future with the list of the components that were matched
+     * @return a future with an object holding the search results
      */
-    public CompletableFuture<List<SW360SparseComponent>> search(ComponentSearchParams searchParams) {
+    public CompletableFuture<PagingResult<SW360SparseComponent>> search(ComponentSearchParams searchParams) {
         Map<String, Object> params = createSearchQueryParameters(searchParams);
         String url = HttpUtils.addQueryParameters(resourceUrl(COMPONENTS_ENDPOINT), params, true);
         return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ComponentList.class,
                 TAG_GET_COMPONENTS, SW360ComponentList::new)
-                .thenApply(SW360ResourceUtils::getSw360SparseComponents);
+                .thenApply(SW360ComponentClient::createPagingComponentResult);
     }
 
     /**
@@ -180,5 +183,16 @@ public class SW360ComponentClient extends SW360Client {
      */
     private static String multiParam(List<String> values) {
         return String.join(",", values);
+    }
+
+    /**
+     * Converts the given component list to a paging result.
+     *
+     * @param componentList the component list
+     * @return the result with the components and paging information
+     */
+    private static PagingResult<SW360SparseComponent> createPagingComponentResult(SW360ComponentList componentList) {
+        List<SW360SparseComponent> components = SW360ResourceUtils.getSw360SparseComponents(componentList);
+        return new PagingResult<>(components, componentList.getPage(), componentList.getLinks());
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -16,7 +16,6 @@ import org.eclipse.sw360.antenna.http.RequestBuilder;
 import org.eclipse.sw360.antenna.http.utils.HttpUtils;
 import org.eclipse.sw360.antenna.sw360.client.auth.AccessTokenProvider;
 import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360Attributes;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentList;
@@ -45,11 +44,6 @@ public class SW360ComponentClient extends SW360Client {
      * Tag for the query that returns details about a specific component.
      */
     static final String TAG_GET_COMPONENT = "get_component";
-
-    /**
-     * Tag for the query that searches for components by name.
-     */
-    static final String TAG_GET_COMPONENTS_BY_NAME = "get_components_by_name";
 
     /**
      * Tag for the request to create a new component.
@@ -142,21 +136,6 @@ public class SW360ComponentClient extends SW360Client {
         String url = HttpUtils.addQueryParameters(resourceUrl(COMPONENTS_ENDPOINT), params, true);
         return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ComponentList.class,
                 TAG_GET_COMPONENTS, SW360ComponentList::new)
-                .thenApply(SW360ResourceUtils::getSw360SparseComponents);
-    }
-
-    /**
-     * Returns a future with a list containing all the components whose name
-     * matches the given pattern.
-     *
-     * @param name the search pattern for the component name
-     * @return a future with a list with all matching components
-     */
-    public CompletableFuture<List<SW360SparseComponent>> searchByName(String name) {
-        String url = HttpUtils.addQueryParameter(resourceUrl(COMPONENTS_ENDPOINT),
-                SW360Attributes.COMPONENT_SEARCH_BY_NAME, name);
-        return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ComponentList.class,
-                TAG_GET_COMPONENTS_BY_NAME, SW360ComponentList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseComponents);
     }
 

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ProjectClient.java
@@ -13,18 +13,17 @@
 
 package org.eclipse.sw360.antenna.sw360.client.rest;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.antenna.http.RequestBuilder;
 import org.eclipse.sw360.antenna.http.utils.HttpUtils;
-import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig;
 import org.eclipse.sw360.antenna.sw360.client.auth.AccessTokenProvider;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.ProjectSearchParams;
-import org.eclipse.sw360.antenna.sw360.client.utils.SW360ResourceUtils;
+import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360Attributes;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.ProjectSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360Project;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectList;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseList;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ResourceUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -85,7 +84,7 @@ public class SW360ProjectClient extends SW360Client {
      */
     public CompletableFuture<List<SW360Project>> search(ProjectSearchParams searchParams) {
         String queryUrl = HttpUtils.addQueryParameters(resourceUrl(PROJECTS_ENDPOINT),
-                parametersMap(searchParams));
+                parametersMap(searchParams), true);
         return executeJsonRequestWithDefault(HttpUtils.get(queryUrl), SW360ProjectList.class,
                 TAG_SEARCH_PROJECTS, SW360ProjectList::new)
                 .thenApply(SW360ResourceUtils::getSw360Projects);
@@ -160,25 +159,12 @@ public class SW360ProjectClient extends SW360Client {
      */
     private static Map<String, String> parametersMap(ProjectSearchParams params) {
         Map<String, String> paramMap = new HashMap<>();
-        appendQueryParameter(paramMap, SW360Attributes.PROJECT_SEARCH_BY_NAME, params.getName());
-        appendQueryParameter(paramMap, SW360Attributes.PROJECT_SEARCH_BY_UNIT, params.getBusinessUnit());
-        appendQueryParameter(paramMap, SW360Attributes.PROJECT_SEARCH_BY_TAG, params.getTag());
+        paramMap.put(SW360Attributes.PROJECT_SEARCH_BY_NAME, params.getName());
+        paramMap.put(SW360Attributes.PROJECT_SEARCH_BY_UNIT, params.getBusinessUnit());
+        paramMap.put(SW360Attributes.PROJECT_SEARCH_BY_TAG, params.getTag());
         if (params.getType() != null) {
             paramMap.put(SW360Attributes.PROJECT_SEARCH_BY_TYPE, params.getType().name());
         }
         return paramMap;
-    }
-
-    /**
-     * Adds a query parameter to a map with parameters only if it is defined.
-     *
-     * @param map   the parameter map
-     * @param key   the key of the parameter
-     * @param value the value of the parameter
-     */
-    private static void appendQueryParameter(Map<String, String> map, String key, String value) {
-        if (StringUtils.isNotEmpty(value)) {
-            map.put(key, value);
-        }
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/LinkObjects.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/LinkObjects.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017-2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -30,11 +31,25 @@ public class LinkObjects {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LinkObjects that = (LinkObjects) o;
-        return Objects.equals(self, that.self);
+        return that.canEqual(this) && Objects.equals(self, that.self);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(self);
+    }
+
+    /**
+     * Checks whether an equals comparison to the given object is possible.
+     * This is needed to support sub classes with additional state while
+     * keeping the contract of equals(). Refer to
+     * <a href="https://www.artima.com/lejava/articles/equality.html">this
+     * article</a> for further details.
+     *
+     * @param o the object to compare to
+     * @return a flag whether this object can be equal to this
+     */
+    public boolean canEqual(Object o) {
+        return o instanceof LinkObjects;
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/Paging.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/Paging.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * <p>
+ * A data class to collect the information related to paging from an SW360
+ * search result.
+ * </p>
+ * <p>
+ * To reduce the size of search results, SW360 offers support for paging for
+ * some requests. Clients can specify a page size and the index of the current
+ * page, and the result will contain only the items on this page.
+ * </p>
+ * <p>
+ * When paging is used the results contain information about the boundaries for
+ * paging requests, such as the number of total records and pages. This
+ * information is represented by this class. It can be used by clients to
+ * control an iteration over the total data set.
+ * </p>
+ */
+public final class Paging {
+    /**
+     * The current page size.
+     */
+    private final int size;
+
+    /**
+     * The current page index.
+     */
+    private final int number;
+
+    /**
+     * The total number of elements that can be queried.
+     */
+    private final int totalElements;
+
+    /**
+     * The total number of pages available.
+     */
+    private final int totalPages;
+
+    /**
+     * Creates a new instance of {@code Paging} with the data specified.
+     *
+     * @param size          the page size
+     * @param number        the page index
+     * @param totalElements the total number of elements
+     * @param totalPages    the total number of pages
+     */
+    @JsonCreator
+    public Paging(@JsonProperty("size") int size, @JsonProperty("number") int number,
+                  @JsonProperty("totalElements") int totalElements, @JsonProperty("totalPages") int totalPages) {
+        this.size = size;
+        this.number = number;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    /**
+     * Returns the current page size. This is the number of elements contained
+     * on a single result page.
+     *
+     * @return the current page size
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Returns the index of the current page.
+     *
+     * @return the index of the current page
+     */
+    public int getNumber() {
+        return number;
+    }
+
+    /**
+     * Returns the total number of records available.
+     *
+     * @return the total number of records
+     */
+    public int getTotalElements() {
+        return totalElements;
+    }
+
+    /**
+     * Returns the total number of pages available. Requesting a page with an
+     * index beyond this limit causes a failure response.
+     *
+     * @return the total number of pages
+     */
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Paging paging = (Paging) o;
+        return getSize() == paging.getSize() &&
+                getNumber() == paging.getNumber() &&
+                getTotalElements() == paging.getTotalElements() &&
+                getTotalPages() == paging.getTotalPages();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSize(), getNumber(), getTotalElements(), getTotalPages());
+    }
+
+    @Override
+    public String toString() {
+        return "Paging{" +
+                "size=" + size +
+                ", number=" + number +
+                ", totalElements=" + totalElements +
+                ", totalPages=" + totalPages +
+                '}';
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingLinkObjects.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingLinkObjects.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource;
+
+import java.util.Objects;
+
+/**
+ * <p>
+ * A special implementation of {@code LinkObjects} that supports the links in
+ * paged results.
+ * </p>
+ * <p>
+ * When using paging the results contain some additional links to navigate
+ * through the result set, e.g. to go to the next page or skip to the last
+ * one. This specialized {@code LinkObjects} implementation exposes these
+ * links directly via properties.
+ * </p>
+ */
+public final class PagingLinkObjects extends LinkObjects {
+    /**
+     * Holds the link to the first result page.
+     */
+    private Self first;
+
+    /**
+     * Holds the link to the previous result page.
+     */
+    private Self previous;
+
+    /**
+     * Holds the link to the next result page.
+     */
+    private Self next;
+
+    /**
+     * Holds the link to the last result page.
+     */
+    private Self last;
+
+    /**
+     * Returns the link to the first result page.
+     *
+     * @return the link to the first result page
+     */
+    public Self getFirst() {
+        return first;
+    }
+
+    /**
+     * Sets the link to the first result page.
+     *
+     * @param first the link to the first result page
+     */
+    public void setFirst(Self first) {
+        this.first = first;
+    }
+
+    /**
+     * Returns the link to the previous result page. This may be
+     * <strong>null</strong> if the current page is the first page.
+     *
+     * @return the link to the previous result page
+     */
+    public Self getPrevious() {
+        return previous;
+    }
+
+    /**
+     * Sets the link to the previous result page.
+     *
+     * @param previous the link to the previous result page
+     */
+    public void setPrevious(Self previous) {
+        this.previous = previous;
+    }
+
+    /**
+     * Returns the link to the next result page. This may be
+     * <strong>null</strong> if the current page is the last page.
+     *
+     * @return the link to the next result page
+     */
+    public Self getNext() {
+        return next;
+    }
+
+    /**
+     * Sets the link to the next result page.
+     *
+     * @param next the link to the next result page
+     */
+    public void setNext(Self next) {
+        this.next = next;
+    }
+
+    /**
+     * Returns the link to the last result page.
+     *
+     * @return the link to the last result page
+     */
+    public Self getLast() {
+        return last;
+    }
+
+    /**
+     * Sets the link to the last result page.
+     *
+     * @param last the link to the last result page
+     */
+    public void setLast(Self last) {
+        this.last = last;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PagingLinkObjects) || !super.equals(o)) return false;
+        PagingLinkObjects that = (PagingLinkObjects) o;
+        return Objects.equals(getFirst(), that.getFirst()) &&
+                Objects.equals(getPrevious(), that.getPrevious()) &&
+                Objects.equals(getNext(), that.getNext()) &&
+                Objects.equals(getLast(), that.getLast());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getFirst(), getPrevious(), getNext(), getLast());
+    }
+
+    @Override
+    public boolean canEqual(Object o) {
+        return o instanceof PagingLinkObjects;
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/ComponentSearchParams.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/ComponentSearchParams.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource.components;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * <p>
+ * A data class that allows specifying parameters for a search for SW360
+ * components.
+ * </p>
+ * <p>
+ * The SW360 components endpoint supports a number of parameters to restrict
+ * the components returned by a search. This class makes the search criteria
+ * available explicit; so a search can be defined by setting the corresponding
+ * properties on an instance. Instances are created using a builder class.
+ * </p>
+ */
+public final class ComponentSearchParams {
+    /**
+     * Constant for a {@code ComponentSearchParams} instance that triggers an
+     * unrestricted search on all components. This should be used with care, as
+     * the search might yield a huge result set.
+     */
+    public static final ComponentSearchParams ALL_COMPONENTS = builder().build();
+
+    /**
+     * Constant for ascending sort order.
+     */
+    private static final String SORT_ASC = ",ASC";
+
+    /**
+     * Constant for descending sort order.
+     */
+    private static final String SORT_DESC = ",DESC";
+
+    /**
+     * Criterion to search by component name.
+     */
+    private final String name;
+
+    /**
+     * Criterion to search by component type.
+     */
+    private final String componentType;
+
+    /**
+     * The parameter for the page to request if using paging.
+     */
+    private final String pageIndex;
+
+    /**
+     * The parameter for the number of elements on a page if using paging.
+     */
+    private final String pageSize;
+
+    /**
+     * The order clauses to sort the result.
+     */
+    private final List<String> orderClauses;
+
+    /**
+     * The names of the fields to be contained in the result.
+     */
+    private final List<String> fields;
+
+    /**
+     * Creates a new instance of {@code ComponentSearchParams} that is
+     * initialized from the passed in builder object.
+     *
+     * @param builder the builder
+     */
+    private ComponentSearchParams(Builder builder) {
+        name = builder.name;
+        componentType = builder.componentType != null ? builder.componentType.name() : null;
+        pageIndex = builder.pageIndex >= 0 ? String.valueOf(builder.pageIndex) : null;
+        pageSize = builder.pageSize > 0 ? String.valueOf(builder.pageSize) : null;
+        orderClauses = Collections.unmodifiableList(new ArrayList<>(builder.orderClauses));
+        fields = Collections.unmodifiableList(new ArrayList<>(builder.fields));
+    }
+
+    /**
+     * Returns a new, uninitialized {@code Builder} object that can be used to
+     * create a new instance of this class. Initially, all search criteria are
+     * disabled. By setting properties of the builder, filter criteria for the
+     * search can be specified.
+     *
+     * @return the new builder for {@code ComponentSearchParams} objects
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the component name to search for. A <strong>null</strong>
+     * value or empty string means that this search criterion is disabled.
+     *
+     * @return the component name to search for
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the component type to search for or <strong>null</strong> if
+     * this search criterion is disabled.
+     *
+     * @return the component type to search for
+     */
+    public String getComponentType() {
+        return componentType;
+    }
+
+    /**
+     * Returns the parameter for the page index to be requested from the
+     * server. A <strong>null</strong> or empty value means that paging is not
+     * used for the search.
+     *
+     * @return the parameter for the page index
+     */
+    public String getPageIndex() {
+        return pageIndex;
+    }
+
+    /**
+     * Returns the parameter for the page size. This determines the number of
+     * components to be contained on a result page. A <strong>null</strong> or
+     * empty value means that paging is disabled or the default page size
+     * should be used.
+     *
+     * @return the parameter for the page size
+     */
+    public String getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Returns a (unmodifiable) list with the clauses defining the order of the
+     * search result. Each clause consists of a field name and an optional
+     * direction (ASC for ascending or DESC for descending).
+     *
+     * @return the list with order clauses
+     */
+    public List<String> getOrderClauses() {
+        return orderClauses;
+    }
+
+    /**
+     * Returns a (unmodifiable) list with the names of fields to be returned in
+     * the search result. This allows to restrict the search result to a set of
+     * fields relevant for the current use case.
+     *
+     * @return the list with the fields to request from the server
+     */
+    public List<String> getFields() {
+        return fields;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ComponentSearchParams params = (ComponentSearchParams) o;
+        return Objects.equals(getName(), params.getName()) &&
+                Objects.equals(getComponentType(), params.getComponentType()) &&
+                Objects.equals(getPageIndex(), params.getPageIndex()) &&
+                Objects.equals(getPageSize(), params.getPageSize()) &&
+                getOrderClauses().equals(params.getOrderClauses()) &&
+                getFields().equals(params.getFields());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getComponentType(), getPageIndex(), getPageSize(), getOrderClauses(), getFields());
+    }
+
+    /**
+     * A builder class for creating instances of {@link ComponentSearchParams}.
+     */
+    public static class Builder {
+        /**
+         * Criterion to search by component name.
+         */
+        private String name;
+
+        /**
+         * The component type to search for.
+         */
+        private SW360ComponentType componentType;
+
+        /**
+         * Index of the page to request if using paging.
+         */
+        private int pageIndex;
+
+        /**
+         * Number of elements on a page when using paging.
+         */
+        private int pageSize;
+
+        /**
+         * Stores the order clauses for sorting the result.
+         */
+        private final List<String> orderClauses;
+
+        /**
+         * The names of the fields to load from the server.
+         */
+        private final List<String> fields;
+
+        /**
+         * Creates a new instance of {@code Builder} that is initialized with
+         * some default values. All search criteria are disabled per default.
+         */
+        private Builder() {
+            orderClauses = new ArrayList<>();
+            fields = new ArrayList<>();
+            pageIndex = -1;
+            pageSize = -1;
+        }
+
+        /**
+         * Sets the search criterion for the component name. The search result
+         * will contain all the components whose name includes this string.
+         *
+         * @param name a component name to search for
+         * @return this builder
+         */
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the search criterion for the component type. This limits the
+         * search result to components with this type.
+         *
+         * @param componentType the component type to search for
+         * @return this builder
+         */
+        public Builder withComponentType(SW360ComponentType componentType) {
+            this.componentType = componentType;
+            return this;
+        }
+
+        /**
+         * Sets the index of the page to be requested from the server. Setting
+         * a value &gt;= 0 enables paging of the result set. Using this
+         * mechanism, large result sets can be processed in multiple chunks.
+         *
+         * @param pageIndex the index of the page to be requested
+         * @return this builder
+         */
+        public Builder withPage(int pageIndex) {
+            this.pageIndex = pageIndex;
+            return this;
+        }
+
+        /**
+         * Sets the number of entries contained on a result page. This property
+         * is evaluated only if paging is enabled. It then allows controlling
+         * the size of the chunks that are queried.
+         *
+         * @param pageSize the number of elements of a result page
+         * @return this builder
+         */
+        public Builder withPageSize(int pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        /**
+         * Specifies a field for an ascending order. The {@code order()}
+         * methods can be called multiple times to define the sort order of the
+         * search result.
+         *
+         * @param field the name of the field to sort
+         * @return this builder
+         */
+        public Builder orderAscending(String field) {
+            orderClauses.add(field + SORT_ASC);
+            return this;
+        }
+
+        /**
+         * Specifies a field for a descending order. The {@code order()}
+         * methods can be called multiple times to define the sort order of the
+         * search result.
+         *
+         * @param field the name of the field to sort
+         * @return this builder
+         */
+        public Builder orderDescending(String field) {
+            orderClauses.add(field + SORT_DESC);
+            return this;
+        }
+
+        /**
+         * Adds the fields provided to the list of fields to query from the
+         * server. Using this method, it is possible to restrict the data that
+         * is queried. The embedded components in the result will contain only
+         * the fields listed here. (If this method is not called, all fields
+         * available are retrieved.) Unknown fields are ignored. Note that not
+         * all fields of component entities are supported by this mechanism.
+         *
+         * @param fields a set of fields to retrieve from the server
+         * @return this builder
+         */
+        public Builder retrieveFields(String... fields) {
+            this.fields.addAll(Arrays.asList(fields));
+            return this;
+        }
+
+        /**
+         * Returns a new {@code ComponentSearchParams} instance that is
+         * initialized from the properties set for this builder.
+         *
+         * @return the newly created {@code ComponentSearchParams} object
+         */
+        public ComponentSearchParams build() {
+            return new ComponentSearchParams(this);
+        }
+    }
+}

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/SW360ComponentList.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/SW360ComponentList.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,11 +11,11 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.rest.resource.components;
 
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Paging;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.PagingLinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 
-public class SW360ComponentList extends SW360HalResource<LinkObjects, SW360ComponentListEmbedded> {
+public class SW360ComponentList extends SW360HalResource<PagingLinkObjects, SW360ComponentListEmbedded> {
     private Paging page;
 
     public Paging getPage() {
@@ -26,8 +27,8 @@ public class SW360ComponentList extends SW360HalResource<LinkObjects, SW360Compo
     }
 
     @Override
-    public LinkObjects createEmptyLinks() {
-        return new LinkObjects();
+    public PagingLinkObjects createEmptyLinks() {
+        return new PagingLinkObjects();
     }
 
     @Override

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/SW360ComponentList.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/SW360ComponentList.java
@@ -11,9 +11,19 @@
 package org.eclipse.sw360.antenna.sw360.client.rest.resource.components;
 
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.Paging;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360HalResource;
 
 public class SW360ComponentList extends SW360HalResource<LinkObjects, SW360ComponentListEmbedded> {
+    private Paging page;
+
+    public Paging getPage() {
+        return page;
+    }
+
+    public void setPage(Paging page) {
+        this.page = page;
+    }
 
     @Override
     public LinkObjects createEmptyLinks() {

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360ReleaseLinkObjects.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360ReleaseLinkObjects.java
@@ -17,7 +17,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
 
 import java.util.Objects;
 
-public class SW360ReleaseLinkObjects extends LinkObjects {
+public final class SW360ReleaseLinkObjects extends LinkObjects {
     @JsonProperty("sw360:component")
     private Self selfComponent;
 
@@ -33,8 +33,7 @@ public class SW360ReleaseLinkObjects extends LinkObjects {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (!(o instanceof SW360ReleaseLinkObjects) || !super.equals(o)) return false;
         SW360ReleaseLinkObjects that = (SW360ReleaseLinkObjects) o;
         return Objects.equals(selfComponent, that.selfComponent);
     }
@@ -42,5 +41,10 @@ public class SW360ReleaseLinkObjects extends LinkObjects {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), selfComponent);
+    }
+
+    @Override
+    public boolean canEqual(Object o) {
+        return o instanceof SW360ReleaseLinkObjects;
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
 import org.eclipse.sw360.antenna.http.utils.HttpConstants;
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
@@ -43,6 +44,11 @@ import static org.mockito.Mockito.when;
 public class SW360ComponentClientAdapterAsyncImplTest {
     private final static String COMPONENT_ID = "12345";
     private final static String COMPONENT_NAME = "componentName";
+
+    private static final ComponentSearchParams NAME_SEARCH_PARAMS =
+            ComponentSearchParams.builder()
+            .withName(COMPONENT_NAME)
+            .build();
 
     private SW360ComponentClientAdapterAsync componentClientAdapter;
 
@@ -82,7 +88,7 @@ public class SW360ComponentClientAdapterAsyncImplTest {
 
         when(componentClient.getComponent(COMPONENT_ID))
                 .thenReturn(CompletableFuture.completedFuture(component));
-        when(componentClient.searchByName(COMPONENT_NAME))
+        when(componentClient.search(NAME_SEARCH_PARAMS))
                 .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseComponent)));
 
         Optional<SW360Component> optResult = block(componentClientAdapter.getOrCreateComponent(componentFromRelease));
@@ -95,7 +101,7 @@ public class SW360ComponentClientAdapterAsyncImplTest {
         when(componentFromRelease.getId()).thenReturn(null);
         when(componentFromRelease.getName()).thenReturn(COMPONENT_NAME);
         when(componentFromRelease.getCategories()).thenReturn(Collections.singleton("Antenna"));
-        when(componentClient.searchByName(COMPONENT_NAME))
+        when(componentClient.search(NAME_SEARCH_PARAMS))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         when(componentClient.createComponent(componentFromRelease))
                 .thenReturn(CompletableFuture.completedFuture(component));
@@ -167,7 +173,7 @@ public class SW360ComponentClientAdapterAsyncImplTest {
 
         when(componentClient.getComponent(COMPONENT_ID))
                 .thenReturn(CompletableFuture.completedFuture(component));
-        when(componentClient.searchByName(COMPONENT_NAME))
+        when(componentClient.search(NAME_SEARCH_PARAMS))
                 .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseComponent)));
 
         Optional<SW360Component> componentByName = block(componentClientAdapter.getComponentByName(COMPONENT_NAME));
@@ -175,7 +181,15 @@ public class SW360ComponentClientAdapterAsyncImplTest {
         assertThat(componentByName).isPresent();
         assertThat(componentByName).hasValue(component);
         verify(componentClient).getComponent(COMPONENT_ID);
-        verify(componentClient).searchByName(COMPONENT_NAME);
+    }
+
+    @Test
+    public void testGetComponentByNameNotFound() {
+        when(componentClient.search(NAME_SEARCH_PARAMS))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+
+        Optional<SW360Component> result = block(componentClientAdapter.getComponentByName(COMPONENT_NAME));
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -15,6 +15,7 @@ import org.eclipse.sw360.antenna.http.utils.HttpConstants;
 import org.eclipse.sw360.antenna.sw360.client.rest.MultiStatusResponse;
 import org.eclipse.sw360.antenna.sw360.client.rest.SW360ComponentClient;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentType;
 import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.Self;
@@ -193,15 +194,19 @@ public class SW360ComponentClientAdapterAsyncImplTest {
     }
 
     @Test
-    public void testGetComponents() {
-        when(componentClient.getComponents())
+    public void testSearch() {
+        ComponentSearchParams searchParams = ComponentSearchParams.builder()
+                .withComponentType(SW360ComponentType.INNER_SOURCE)
+                .retrieveFields("name", "releaseIds")
+                .orderAscending("createdOn")
+                .build();
+        when(componentClient.search(searchParams))
                 .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(sparseComponent)));
 
-        List<SW360SparseComponent> components = block(componentClientAdapter.getComponents());
+        List<SW360SparseComponent> components = block(componentClientAdapter.search(searchParams));
 
         assertThat(components).hasSize(1);
         assertThat(components).containsExactly(sparseComponent);
-        verify(componentClient).getComponents();
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/PagingResultTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/PagingResultTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PagingResultTest {
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(PagingResult.class)
+                .withNonnullFields("result")
+                .verify();
+    }
+
+    @Test
+    public void testDefensiveCopyOfResultList() {
+        List<Object> data = new ArrayList<>();
+        data.add("entry1");
+
+        PagingResult<Object> result = new PagingResult<>(data, null, null);
+        data.add("entry2");
+        assertThat(result.getResult()).containsOnly("entry1");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetResultUnmodifiable() {
+        PagingResult<Object> result = new PagingResult<>(Arrays.asList("a", "b", "c"), null, null);
+
+        result.getResult().add("d");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreationFailsForNullResultList() {
+        new PagingResult<Object>(null, null, null);
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.antenna.sw360.client.rest;
 
 import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
 import org.eclipse.sw360.antenna.http.utils.HttpConstants;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.Paging;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentEmbedded;
@@ -74,8 +75,11 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
                         .withBodyFile("all_components.json")));
 
-        List<SW360SparseComponent> components = waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
-        checkComponentsList(components);
+        PagingResult<SW360SparseComponent> result =
+                waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
+        checkComponentsList(result.getResult());
+        assertThat(result.getPaging()).isNull();
+        assertThat(result.getPagingLinkObjects().getFirst()).isNull();
     }
 
     @Test
@@ -91,8 +95,9 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
                 .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
 
-        List<SW360SparseComponent> components = waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
-        assertThat(components).isEmpty();
+        PagingResult<SW360SparseComponent> result =
+                waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
+        assertThat(result.getResult()).isEmpty();
     }
 
     @Test
@@ -132,8 +137,10 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
                 .retrieveFields("name", "createdOn", "type")
                 .retrieveFields("releaseIds")
                 .build();
-        List<SW360SparseComponent> components = waitFor(componentClient.search(params));
-        checkComponentsList(components);
+        PagingResult<SW360SparseComponent> result = waitFor(componentClient.search(params));
+        checkComponentsList(result.getResult());
+        assertThat(result.getPaging()).isEqualTo(new Paging(5, 1, 12, 3));
+        assertThat(result.getPagingLinkObjects().getFirst()).isNotNull();
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClientIT.java
@@ -12,9 +12,10 @@ package org.eclipse.sw360.antenna.sw360.client.rest;
 
 import org.eclipse.sw360.antenna.http.utils.FailedRequestException;
 import org.eclipse.sw360.antenna.http.utils.HttpConstants;
-import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360Attributes;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.ComponentSearchParams;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentEmbedded;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
 import org.junit.Before;
@@ -67,81 +68,72 @@ public class SW360ComponentClientIT extends AbstractMockServerTest {
     }
 
     @Test
-    public void testGetComponents() throws IOException {
+    public void testSearchNoParameters() throws IOException {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
+                .withQueryParams(Collections.emptyMap())
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
                         .withBodyFile("all_components.json")));
 
-        List<SW360SparseComponent> components = waitFor(componentClient.getComponents());
+        List<SW360SparseComponent> components = waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
         checkComponentsList(components);
     }
 
     @Test
-    public void testGetComponentsNoBody() {
+    public void testSearchNoBody() {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
 
-        extractException(componentClient.getComponents(), IOException.class);
+        extractException(componentClient.search(ComponentSearchParams.ALL_COMPONENTS), IOException.class);
     }
 
     @Test
-    public void testGetComponentsStatusNoContent() throws IOException {
+    public void testSearchNoContent() throws IOException {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
                 .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
 
-        List<SW360SparseComponent> components = waitFor(componentClient.getComponents());
+        List<SW360SparseComponent> components = waitFor(componentClient.search(ComponentSearchParams.ALL_COMPONENTS));
         assertThat(components).isEmpty();
     }
 
     @Test
-    public void testGetComponentsError() {
+    public void testSearchError() {
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
                 .willReturn(aJsonResponse(HttpConstants.STATUS_ERR_BAD_REQUEST)));
 
         FailedRequestException exception =
-                expectFailedRequest(componentClient.getComponents(), HttpConstants.STATUS_ERR_BAD_REQUEST);
+                expectFailedRequest(componentClient.search(ComponentSearchParams.ALL_COMPONENTS),
+                        HttpConstants.STATUS_ERR_BAD_REQUEST);
         assertThat(exception.getTag()).isEqualTo(SW360ComponentClient.TAG_GET_COMPONENTS);
     }
 
     @Test
-    public void testSearchByName() throws IOException {
-        final String componentName = "testComponentSearchPattern";
+    public void testSearchWithParameters() throws IOException {
+        final String name = "desiredComponent";
+        final SW360ComponentType componentType = SW360ComponentType.SERVICE;
+        final int pageIndex = 42;
+        final int pageSize = 11;
         wireMockRule.stubFor(get(urlPathEqualTo("/components"))
-                .withQueryParam(SW360Attributes.COMPONENT_SEARCH_BY_NAME, equalTo(componentName))
+                .withQueryParam("name", equalTo(name))
+                .withQueryParam("type", equalTo(componentType.name()))
+                .withQueryParam("page", equalTo(String.valueOf(pageIndex)))
+                .withQueryParam("page_entries", equalTo(String.valueOf(pageSize)))
+                .withQueryParam("fields", equalTo("name,createdOn,type,releaseIds"))
+                .withQueryParam("sort", equalTo("name,ASC,createdOn,DESC"))
                 .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
-                        .withBodyFile("all_components.json")));
+                        .withBodyFile("all_components_paging.json")));
 
-        List<SW360SparseComponent> components = waitFor(componentClient.searchByName(componentName));
+        ComponentSearchParams params = ComponentSearchParams.builder()
+                .withName(name)
+                .withComponentType(componentType)
+                .withPage(pageIndex)
+                .withPageSize(pageSize)
+                .orderAscending("name")
+                .orderDescending("createdOn")
+                .retrieveFields("name", "createdOn", "type")
+                .retrieveFields("releaseIds")
+                .build();
+        List<SW360SparseComponent> components = waitFor(componentClient.search(params));
         checkComponentsList(components);
-    }
-
-    @Test
-    public void testSearchByNameNoResults() throws IOException {
-        wireMockRule.stubFor(get(anyUrl())
-                .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
-                        .withBody("{}")));
-
-        List<SW360SparseComponent> components = waitFor(componentClient.searchByName("foo"));
-        assertThat(components).hasSize(0);
-    }
-
-    @Test
-    public void testSearchByNameStatusNoContent() throws IOException {
-        wireMockRule.stubFor(get(anyUrl())
-                .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
-
-        List<SW360SparseComponent> components = waitFor(componentClient.searchByName("test"));
-        assertThat(components).isEmpty();
-    }
-
-    @Test
-    public void testSearchByNameError() {
-        wireMockRule.stubFor(get(anyUrl())
-                .willReturn(aJsonResponse(HttpConstants.STATUS_ERR_UNAUTHORIZED)));
-
-        FailedRequestException exception =
-                expectFailedRequest(componentClient.searchByName("foo"), HttpConstants.STATUS_ERR_UNAUTHORIZED);
-        assertThat(exception.getTag()).isEqualTo(SW360ComponentClient.TAG_GET_COMPONENTS_BY_NAME);
     }
 
     @Test

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingLinkObjectsTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingLinkObjectsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentList;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PagingLinkObjectsTest {
+    /**
+     * Template for the base URL used to request a specific page.
+     */
+    private static final String PAGING_URL = "https://sw360.test.com//resource/api/components?page=%d&page_entries=5";
+
+    /**
+     * Checks whether a paging link contains the expected URI.
+     *
+     * @param index the index of the expected target page
+     * @param link  the link to be checked
+     */
+    private static void assertPage(int index, Self link) {
+        String expUri = String.format(PAGING_URL, index);
+        assertThat(link.getHref()).isEqualTo(expUri);
+    }
+
+    @Test
+    public void testDeserializeFromJson() throws IOException {
+        URL testFile = getClass().getResource("/__files/all_components_paging.json");
+        ObjectMapper mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        SW360ComponentList componentList = mapper.readValue(testFile, SW360ComponentList.class);
+        PagingLinkObjects links = componentList.getLinks();
+        assertPage(0, links.getFirst());
+        assertPage(1, links.getPrevious());
+        assertPage(2, links.getNext());
+        assertPage(3, links.getLast());
+    }
+
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(PagingLinkObjects.class)
+                .withRedefinedSuperclass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/PagingTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentList;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PagingTest {
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(Paging.class)
+                .verify();
+    }
+
+    @Test
+    public void testToString() {
+        Paging paging = new Paging(42, 5, 1024, 25);
+
+        String s = paging.toString();
+        assertThat(s).contains("size=" + paging.getSize(), "number=" + paging.getNumber(),
+                "totalElements=" + paging.getTotalElements(), "totalPages=" + paging.getTotalPages());
+    }
+
+    @Test
+    public void testDeserializeFromJson() throws IOException {
+        URL testFile = getClass().getResource("/__files/all_components_paging.json");
+        Paging expPaging = new Paging(5, 1, 12, 3);
+        ObjectMapper mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        SW360ComponentList componentList = mapper.readValue(testFile, SW360ComponentList.class);
+        assertThat(componentList.getPage()).isEqualTo(expPaging);
+    }
+}

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/SW360ResourcesEqualsTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/SW360ResourcesEqualsTest.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360Projec
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectListEmbedded;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.projects.SW360ProjectReleaseRelationship;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseEmbedded;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseLinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ReleaseListEmbedded;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360SparseRelease;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.users.SW360SparseUser;
@@ -121,6 +122,22 @@ public class SW360ResourcesEqualsTest {
     @Test
     public void testEqualsReleaseListEmbedded() {
         EqualsVerifier.forClass(SW360ReleaseListEmbedded.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+
+    @Test
+    public void testEqualsLinkObject() {
+        EqualsVerifier.forClass(LinkObjects.class)
+                .usingGetClass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+
+    @Test
+    public void testEqualsReleaseLinkObjects() {
+        EqualsVerifier.forClass(SW360ReleaseLinkObjects.class)
+                .withRedefinedSuperclass()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/ComponentSearchParamsTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/components/ComponentSearchParamsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.sw360.client.rest.resource.components;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentSearchParamsTest {
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(ComponentSearchParams.class)
+                .withNonnullFields("orderClauses", "fields")
+                .verify();
+    }
+
+    @Test
+    public void testDefensiveCopyOfOrderClauses() {
+        ComponentSearchParams.Builder builder = ComponentSearchParams.builder();
+        ComponentSearchParams params = builder
+                .orderAscending("foo")
+                .build();
+
+        builder.orderDescending("bar");
+        assertThat(params.getOrderClauses()).containsOnly("foo,ASC");
+    }
+
+    @Test
+    public void testDefensiveCopyOfFields() {
+        ComponentSearchParams.Builder builder = ComponentSearchParams.builder();
+        ComponentSearchParams params = builder.retrieveFields("foo")
+                .build();
+
+        builder.retrieveFields("bar", "baz");
+        assertThat(params.getFields()).containsOnly("foo");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testOrderClausesUnmodifiable() {
+        ComponentSearchParams params = ComponentSearchParams.builder()
+                .orderDescending("foo")
+                .orderAscending("bar")
+                .build();
+
+        params.getOrderClauses().add("another order");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFieldsUnmodifiable() {
+        ComponentSearchParams params = ComponentSearchParams.builder()
+                .retrieveFields("a", "b", "c")
+                .build();
+
+        params.getFields().add("z");
+    }
+}

--- a/modules/sw360/sw360-client/src/test/resources/__files/all_components_paging.json
+++ b/modules/sw360/sw360-client/src/test/resources/__files/all_components_paging.json
@@ -32,13 +32,13 @@
       "href": "https://sw360.test.com//resource/api/components?page=0&page_entries=5"
     },
     "previous": {
-      "href": "https://sw360.test.com//resource/api/components?page=0&page_entries=5"
+      "href": "https://sw360.test.com//resource/api/components?page=1&page_entries=5"
     },
     "next": {
       "href": "https://sw360.test.com//resource/api/components?page=2&page_entries=5"
     },
     "last": {
-      "href": "https://sw360.test.com//resource/api/components?page=2&page_entries=5"
+      "href": "https://sw360.test.com//resource/api/components?page=3&page_entries=5"
     },
     "curies": [
       {

--- a/modules/sw360/sw360-client/src/test/resources/__files/all_components_paging.json
+++ b/modules/sw360/sw360-client/src/test/resources/__files/all_components_paging.json
@@ -1,0 +1,57 @@
+{
+  "_embedded": {
+    "sw360:components": [
+      {
+        "name": "jackson-annotations",
+        "_links": {
+          "self": {
+            "href": "https://sw360.test.com/resource/api/components/xxxxxxyyyyyzzzzz8c34"
+          }
+        }
+      },
+      {
+        "name": "jakarta.validation-api",
+        "_links": {
+          "self": {
+            "href": "https://sw360.test.com/resource/api/components/xxxxxxyyyyyzzzzz9e53"
+          }
+        }
+      },
+      {
+        "name": "jsoup",
+        "_links": {
+          "self": {
+            "href": "https://sw360.test.com/resource/api/components/xxxxxxyyyyyzzzzzb9ee"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "first": {
+      "href": "https://sw360.test.com//resource/api/components?page=0&page_entries=5"
+    },
+    "previous": {
+      "href": "https://sw360.test.com//resource/api/components?page=0&page_entries=5"
+    },
+    "next": {
+      "href": "https://sw360.test.com//resource/api/components?page=2&page_entries=5"
+    },
+    "last": {
+      "href": "https://sw360.test.com//resource/api/components?page=2&page_entries=5"
+    },
+    "curies": [
+      {
+        "href": "https://sw360.test.com//resource/docs/{rel}.html",
+        "name": "sw360",
+        "templated": true
+      }
+    ]
+  },
+  "page": {
+    "size": 5,
+    "totalElements": 12,
+    "totalPages": 3,
+    "number": 1
+  }
+}


### PR DESCRIPTION
Issue 429

This PR improves the API of the SW360 client library regarding searches for components.

SW360 offers some advanced query facilities for components: It is possible to filter components by name and type and even select the fields to be returned. In addition, a paging mechanism is supported, so that huge search results can be avoided by loading the results in smaller chunks. The component adapter classes now support these features.

For the paging mechanism a couple of helper classes have been added. At the moment, the SW360 REST API supports paging only for components; but as this mechanism is pretty useful in general, it may well be the case that this functionality is added for other endpoints as well. Therefore, the helper classes are generic and can work with other entity types, too.

Note: The rework of the components API is not yet complete; but as already a larger number of classes is affected, I think it is better to create a dedicated PR for the improvements of the component search API.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
Existing tests have been extended or new tests have been added to cover the complete new functionality.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
