### PR TITLE
Oheger bosch/sw360/#429 component api

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -30,8 +30,6 @@ import java.util.Optional;
 public interface SW360ComponentClientAdapter {
     SW360ComponentClient getComponentClient();
 
-    Optional<SW360Component> getOrCreateComponent(SW360Component componentFromRelease);
-
     SW360Component createComponent(SW360Component component);
 
     Optional<SW360Component> getComponentById(String componentId);

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -28,12 +28,39 @@ import java.util.Optional;
  * </p>
  */
 public interface SW360ComponentClientAdapter {
+    /**
+     * Returns the {@code SW360ComponentClient} object used by this adapter to
+     * interact with the SW360 server. Clients may use this object as well if
+     * they need access to a low-level API.
+     *
+     * @return the underlying {@code SW360ComponentClient}
+     */
     SW360ComponentClient getComponentClient();
 
+    /**
+     * Creates a new component in SW360 based on the passed in data object.
+     *
+     * @param component the object describing the new component
+     * @return the newly created component entity
+     */
     SW360Component createComponent(SW360Component component);
 
+    /**
+     * Queries a component by its ID. Result is an {@code Optional}, which is
+     * empty if the component ID cannot be resolved.
+     *
+     * @param componentId the ID of the desired component
+     * @return an {@code Optional} containing the resulting component
+     */
     Optional<SW360Component> getComponentById(String componentId);
 
+    /**
+     * Queries a component by its name. Tries to find a component whose name
+     * matches the passed in string exactly. Result is an {@code Optional},
+     * which is empty if no matching component can be found.
+     *
+     * @return an {@code Optional} containing the resulting component
+     */
     Optional<SW360Component> getComponentByName(String componentName);
 
     /**

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -87,6 +87,8 @@ public interface SW360ComponentClientAdapter {
      */
     PagingResult<SW360SparseComponent> searchWithPaging(ComponentSearchParams searchParams);
 
+
+
     /**
      * Triggers a multi-delete operation for the components with the IDs
      * specified. Returns a {@code MultiStatusResponse} that allows checking

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -29,12 +29,41 @@ import java.util.concurrent.CompletableFuture;
  * </p>
  */
 public interface SW360ComponentClientAdapterAsync {
+    /**
+     * Returns the {@code SW360ComponentClient} object used by this adapter to
+     * interact with the SW360 server. Clients may use this object as well if
+     * they need access to a low-level API.
+     *
+     * @return the underlying {@code SW360ComponentClient}
+     */
     SW360ComponentClient getComponentClient();
 
+    /**
+     * Creates a new component in SW360 based on the passed in data object.
+     *
+     * @param component the object describing the new component
+     * @return a future with the newly created component entity
+     */
     CompletableFuture<SW360Component> createComponent(SW360Component component);
 
+    /**
+     * Queries a component by its ID. Result is an {@code Optional}, which is
+     * empty if the component ID cannot be resolved.
+     *
+     * @param componentId the ID of the desired component
+     * @return a future with an {@code Optional} containing the resulting
+     * component
+     */
     CompletableFuture<Optional<SW360Component>> getComponentById(String componentId);
 
+    /**
+     * Queries a component by its name. Tries to find a component whose name
+     * matches the passed in string exactly. Result is an {@code Optional},
+     * which is empty if no matching component can be found.
+     *
+     * @return a future with an {@code Optional} containing the resulting
+     * component
+     */
     CompletableFuture<Optional<SW360Component>> getComponentByName(String componentName);
 
     /**

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -31,8 +31,6 @@ import java.util.concurrent.CompletableFuture;
 public interface SW360ComponentClientAdapterAsync {
     SW360ComponentClient getComponentClient();
 
-    CompletableFuture<Optional<SW360Component>> getOrCreateComponent(SW360Component componentFromRelease);
-
     CompletableFuture<SW360Component> createComponent(SW360Component component);
 
     CompletableFuture<Optional<SW360Component>> getComponentById(String componentId);

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImpl.java
@@ -41,18 +41,6 @@ class SW360ComponentClientAdapterAsyncImpl implements SW360ComponentClientAdapte
     }
 
     @Override
-    public CompletableFuture<Optional<SW360Component>> getOrCreateComponent(SW360Component componentFromRelease) {
-        if (componentFromRelease.getId() != null) {
-            return getComponentById(componentFromRelease.getId());
-        }
-        return getComponentByName(componentFromRelease.getName())
-                .thenCompose(optComponent -> optComponent.isPresent() ?
-                        CompletableFuture.completedFuture(optComponent) :
-                        createComponent(componentFromRelease)
-                                .thenApply(Optional::of));
-    }
-
-    @Override
     public CompletableFuture<SW360Component> createComponent(SW360Component component) {
         if (!SW360ComponentAdapterUtils.isValidComponent(component)) {
             return failedFuture(new SW360ClientException("Can not write invalid component for " + component.getName()));

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/SW360ComponentClient.java
@@ -51,6 +51,11 @@ public class SW360ComponentClient extends SW360Client {
     static final String TAG_CREATE_COMPONENT = "post_create_component";
 
     /**
+     * Tag for the request to update a component.
+     */
+    static final String TAG_UPDATE_COMPONENT = "patch_update_component";
+
+    /**
      * Tag for the request to delete components.
      */
     static final String TAG_DELETE_COMPONENTS = "delete_components";
@@ -142,6 +147,20 @@ public class SW360ComponentClient extends SW360Client {
                         .uri(resourceUrl(COMPONENTS_ENDPOINT))
                         .body(body -> body.json(sw360Component)),
                 SW360Component.class, TAG_CREATE_COMPONENT);
+    }
+
+    /**
+     * Updates a release based on the data object passed in and returns a
+     * future with the result.
+     *
+     * @param component a data object for the component to be updated
+     * @return a future with the updated component entity
+     */
+    public CompletableFuture<SW360Component> patchComponent(SW360Component component) {
+        return executeJsonRequest(builder -> builder.method(RequestBuilder.Method.PATCH)
+                        .uri(resourceUrl(COMPONENTS_ENDPOINT, component.getId()))
+                        .body(body -> body.json(component)),
+                SW360Component.class, TAG_UPDATE_COMPONENT);
     }
 
     /**

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -77,51 +77,6 @@ public class SW360ComponentClientAdapterAsyncImplTest {
     }
 
     @Test
-    public void testGetOrCreateComponentByID() {
-        SW360Component componentFromRelease = mock(SW360Component.class);
-        when(componentFromRelease.getId()).thenReturn(COMPONENT_ID);
-        when(componentClient.getComponent(COMPONENT_ID))
-                .thenReturn(CompletableFuture.completedFuture(component));
-
-        Optional<SW360Component> optResult = block(componentClientAdapter.getOrCreateComponent(componentFromRelease));
-        assertThat(optResult).contains(component);
-    }
-
-    @Test
-    public void testGetOrCreateComponentByName() {
-        SW360Component componentFromRelease = mock(SW360Component.class);
-        when(componentFromRelease.getId()).thenReturn(null);
-        when(componentFromRelease.getName()).thenReturn(COMPONENT_NAME);
-        LinkObjects linkObjects = makeLinkObjects();
-        sparseComponent.setName(COMPONENT_NAME)
-                .setLinks(linkObjects);
-        component.setName(COMPONENT_NAME);
-
-        when(componentClient.getComponent(COMPONENT_ID))
-                .thenReturn(CompletableFuture.completedFuture(component));
-        when(componentClient.search(NAME_SEARCH_PARAMS))
-                .thenReturn(createSearchResult(Collections.singletonList(sparseComponent)));
-
-        Optional<SW360Component> optResult = block(componentClientAdapter.getOrCreateComponent(componentFromRelease));
-        assertThat(optResult).contains(component);
-    }
-
-    @Test
-    public void testGetOrCreateComponentCreateNew() {
-        SW360Component componentFromRelease = mock(SW360Component.class);
-        when(componentFromRelease.getId()).thenReturn(null);
-        when(componentFromRelease.getName()).thenReturn(COMPONENT_NAME);
-        when(componentFromRelease.getCategories()).thenReturn(Collections.singleton("Antenna"));
-        when(componentClient.search(NAME_SEARCH_PARAMS))
-                .thenReturn(createSearchResult(Collections.emptyList()));
-        when(componentClient.createComponent(componentFromRelease))
-                .thenReturn(CompletableFuture.completedFuture(component));
-
-        Optional<SW360Component> optResult = block(componentClientAdapter.getOrCreateComponent(componentFromRelease));
-        assertThat(optResult).contains(component);
-    }
-
-    @Test
     public void testCreateComponent() {
         component.setName(COMPONENT_NAME);
         component.setCategories(Collections.singleton("Antenna"));


### PR DESCRIPTION
Issue 429

This PR adds further improvements to the component client adapter API:

* The getOrCreateComponent() method has been removed.
* A method to update a component has been added.
* Better validation when creating or updating components.
* All methods in the interfaces now have proper Javadocs.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
As usual, tests have been added to cover the new functionality.

### Checklist
Must:
- [X] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [X] I have provided tests for the changes (if there are changes that need additional tests)
