### PR TITLE
Component client adapter now allows updating components.

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentAdapterUtils.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentAdapterUtils.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.sw360.antenna.sw360.client.adapter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
@@ -19,7 +20,8 @@ import java.util.Collections;
 
 public class SW360ComponentAdapterUtils {
 
-    private SW360ComponentAdapterUtils() {}
+    private SW360ComponentAdapterUtils() {
+    }
 
     public static void setComponentType(SW360Component component, boolean isProprietary) {
         if (isProprietary) {
@@ -37,10 +39,22 @@ public class SW360ComponentAdapterUtils {
         return sw360Component;
     }
 
-    static boolean isValidComponent(SW360Component component) {
-        return component.getName() != null &&
-                !component.getName().isEmpty() &&
-                component.getCategories() != null &&
-                !component.getCategories().isEmpty();
+    /**
+     * Validates the passed in component. Checks whether all mandatory fields
+     * are set. If the component is valid, it is returned without changes.
+     * Otherwise, an exception is thrown reporting the concrete validation
+     * failure.
+     *
+     * @param component the component to validate
+     * @return the validated component
+     */
+    static SW360Component validateComponent(SW360Component component) {
+        if (StringUtils.isEmpty(component.getName())) {
+            throw new IllegalArgumentException("Invalid component: missing property 'name'.");
+        }
+        if (component.getCategories() == null || component.getCategories().isEmpty()) {
+            throw new IllegalArgumentException("Invalid component: missing property 'categories'.");
+        }
+        return component;
     }
 }

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapter.java
@@ -87,7 +87,14 @@ public interface SW360ComponentClientAdapter {
      */
     PagingResult<SW360SparseComponent> searchWithPaging(ComponentSearchParams searchParams);
 
-
+    /**
+     * Updates a component based on the data object passed in.
+     *
+     * @param component the data object describing the component to update
+     * @return the updated component
+     * @throws org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException if an error occurs
+     */
+    SW360Component updateComponent(SW360Component component);
 
     /**
      * Triggers a multi-delete operation for the components with the IDs

--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsync.java
@@ -91,6 +91,14 @@ public interface SW360ComponentClientAdapterAsync {
     CompletableFuture<PagingResult<SW360SparseComponent>> searchWithPaging(ComponentSearchParams searchParams);
 
     /**
+     * Updates a component based on the data object passed in.
+     *
+     * @param component the data object describing the component to update
+     * @return a future with the updated component
+     */
+    CompletableFuture<SW360Component> updateComponent(SW360Component component);
+
+    /**
      * Triggers a multi-delete operation for the components with the IDs
      * specified. Returns a {@code MultiStatusResponse} that allows checking
      * whether all the components could be deleted successfully.

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentAdapterUtilsTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentAdapterUtilsTest.java
@@ -14,11 +14,13 @@ package org.eclipse.sw360.antenna.sw360.client.adapter;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360Component;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.components.SW360ComponentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.antenna.sw360.client.utils.SW360ClientException;
 import org.junit.Test;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SW360ComponentAdapterUtilsTest {
     @Test
@@ -55,24 +57,65 @@ public class SW360ComponentAdapterUtilsTest {
     }
 
     @Test
-    public void testIsValidComponentWithValidComponent() {
+    public void testValidateComponentValid() {
         SW360Component component = new SW360Component();
         component.setName("test");
         component.setCategories(Collections.singleton("Antenna"));
 
-        boolean validComponent = SW360ComponentAdapterUtils.isValidComponent(component);
-
-        assertThat(validComponent).isTrue();
-
+        assertThat(SW360ComponentAdapterUtils.validateComponent(component)).isSameAs(component);
     }
 
     @Test
-    public void testIsValidComponentWithInvalidComponent() {
+    public void testValidateComponentNullName() {
         SW360Component component = new SW360Component();
+        component.setCategories(Collections.singleton("Antenna"));
 
-        boolean validComponent = SW360ComponentAdapterUtils.isValidComponent(component);
+        try {
+            SW360ComponentAdapterUtils.validateComponent(component);
+            fail("Invalid component not detected");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("missing property 'name'");
+        }
+    }
 
-        assertThat(validComponent).isFalse();
+    @Test
+    public void testValidateComponentEmptyName() {
+        SW360Component component = new SW360Component();
+        component.setName("");
+        component.setCategories(Collections.singleton("Antenna"));
 
+        try {
+            SW360ComponentAdapterUtils.validateComponent(component);
+            fail("Invalid component not detected");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("missing property 'name'");
+        }
+    }
+
+    @Test
+    public void testValidateComponentNullCategories() {
+        SW360Component component = new SW360Component();
+        component.setName("component");
+
+        try {
+            SW360ComponentAdapterUtils.validateComponent(component);
+            fail("Invalid component not detected");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("missing property 'categories'");
+        }
+    }
+
+    @Test
+    public void testValidateComponentEmptyCategories() {
+        SW360Component component = new SW360Component();
+        component.setCategories(Collections.emptySet());
+        component.setName("component");
+
+        try {
+            SW360ComponentAdapterUtils.validateComponent(component);
+            fail("Invalid component not detected");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("missing property 'categories'");
+        }
     }
 }

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -108,6 +108,29 @@ public class SW360ComponentClientAdapterAsyncImplTest {
     }
 
     @Test
+    public void testUpdateComponent() {
+        component.setName(COMPONENT_NAME);
+        component.setCategories(Collections.singleton("Antenna"));
+        SW360Component updatedComponent = new SW360Component();
+        updatedComponent.setName(COMPONENT_NAME + "_updated");
+        when(componentClient.patchComponent(component))
+                .thenReturn(CompletableFuture.completedFuture(updatedComponent));
+
+        SW360Component result = block(componentClientAdapter.updateComponent(component));
+        assertThat(result).isEqualTo(updatedComponent);
+    }
+
+    @Test
+    public void testUpdateComponentInvalid() {
+        try {
+            block(componentClientAdapter.updateComponent(component));
+            fail("Invalid component not detected.");
+        } catch (SW360ClientException e) {
+            assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
     public void testGetComponentById() {
         when(componentClient.getComponent(COMPONENT_ID))
                 .thenReturn(CompletableFuture.completedFuture(component));


### PR DESCRIPTION
Issue: eclipse#429.

This PR adds functionality which is missing from my [previous PR regarding the component API](https://github.com/eclipse/antenna/pull/563): It implements the update operation for components on the client adapter level and adds some better validation when creating or updating components.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
Adapted test cases and added some new ones.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
