### PR TITLE
Oheger bosch/build/#577 build on jdk11

### DIFF
--- a/core/frontend-stubs/maven-frontend-stub/src/test/java/org/eclipse/sw360/antenna/frontend/stub/mojo/DependencyTest.java
+++ b/core/frontend-stubs/maven-frontend-stub/src/test/java/org/eclipse/sw360/antenna/frontend/stub/mojo/DependencyTest.java
@@ -63,6 +63,8 @@ public class DependencyTest {
             dependency("org.gradle", "gradle-core-api"),
             dependency("org.gradle", "gradle-logging"),
             dependency("org.codehaus.groovy", "groovy"),
+            dependency("javax.xml.bind", "jaxb-api"),
+            dependency("org.glassfish.jaxb", "jaxb-runtime"),
             dependency("org.apache.logging.log4j", "log4j-api"),
             dependency("org.apache.logging.log4j", "log4j-core"),
             dependency("org.apache.logging.log4j", "log4j-jcl"),

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -24,6 +24,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>http-support</artifactId>
             <version>${project.version}</version>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -44,6 +44,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.sw360.antenna</groupId>
             <artifactId>model</artifactId>
             <version>${project.version}</version>

--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/AntennaUtilsTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/util/AntennaUtilsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2017.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -36,7 +37,7 @@ public class AntennaUtilsTest {
 
     @Test
     public void getJarPathTestStripsPrefix() throws  Exception {
-        String fileBasename = "AntennaUtilsTest_testfile.jar";
+        String fileBasename = "AntennaUtilsTest_testfile.arc";
         final URL url = this.getClass().getClassLoader().getResource(fileBasename);
 
         final Path jarPath = AntennaUtils.getJarPath(url);

--- a/pom.xml
+++ b/pom.xml
@@ -668,6 +668,27 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>3.1.12</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.19</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>animal-sniffer</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ort.rev>706dfbdb8f</ort.rev>
         <cyclonedx.version>2.6.5</cyclonedx.version>
+        <jaxb.version>2.3.1</jaxb.version>
     </properties>
 
     <scm>
@@ -75,6 +76,17 @@
                 <groupId>org.jvnet.jaxb2_commons</groupId>
                 <artifactId>jaxb2-basics-runtime</artifactId>
                 <version>1.11.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.version}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.cliftonlabs</groupId>


### PR DESCRIPTION
Issue 577

This PR makes Antenna build with JDK 11.

The PR adds dependencies to Jaxb (API and runtime), which is required by Antenna, but no longer available on newer JDKs.

To make sure that only Java8-compatible APIs are used even when building with a newer JDK, the Animal-sniffer plugin has been added; it causes the build to fail when it detects usage of classes introduced with Java 9 or later.

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
CI

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
I ran the build with both JDK 8 and 11.
To check Java 8 compatibility, I built with JDK 11 and then run the Antenna test project on JDK 8.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
