### PR TITLE
Correcting mapping of nuget and dotnet packages.

### DIFF
--- a/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
+++ b/modules/ort/src/main/kotlin/resolver/OrtResultArtifactResolver.kt
@@ -32,7 +32,7 @@ private fun mapCoordinates(pkg: Package): Coordinate {
 
     val type = pkg.id.type.toLowerCase()
     return when (type) {
-        "nuget", "dotnet" -> Coordinate(Coordinate.Types.NPM, name, version)
+        "nuget", "dotnet" -> Coordinate(Coordinate.Types.NUGET, name, version)
         "maven" -> Coordinate(Coordinate.Types.MAVEN, namespace, name, version)
         "npm" -> Coordinate(Coordinate.Types.NPM, namespace, name, version)
         else -> if (Coordinate.Types.all.contains(type)) {


### PR DESCRIPTION
> Please provide a summary of your changes here.
nuget and dotnet packages used to map to "npm". Now they map to "nuget".
> * Which issue is this pull request belonging to? (*Refer to issue here*)
N/A
> * How is it solving the issue?
N/A
> * Did you add or update any new dependencies that are required for your change?
No

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*

