### PR TITLE
AntennaCLIFrontend now takes properties file

### DIFF
--- a/assembly/cli/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontend.java
+++ b/assembly/cli/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -22,6 +22,10 @@ public final class AntennaCLIFrontend extends AbstractAntennaCLIFrontend {
 
     public AntennaCLIFrontend(File file) {
         super(file);
+    }
+
+    public AntennaCLIFrontend(File pomFile, File propertiesFile) {
+        super(pomFile, propertiesFile);
     }
 
     @Override
@@ -47,7 +51,18 @@ public final class AntennaCLIFrontend extends AbstractAntennaCLIFrontend {
                 throw new IllegalArgumentException("Cannot find " + pomFilePath.toString());
             }
 
-            AntennaCLIFrontend frontend = new AntennaCLIFrontend(pomFilePath.toFile());
+            AntennaCLIFrontend frontend;
+
+            if (options.getPropertiesFilePath() != null) {
+                Path propertiesFilePath = Paths.get(options.getPropertiesFilePath()).toAbsolutePath();
+                if (!propertiesFilePath.toFile().exists()) {
+                    throw new IllegalArgumentException("Cannot find " + propertiesFilePath.toString());
+                }
+                frontend = new AntennaCLIFrontend(pomFilePath.toFile(), propertiesFilePath.toFile());
+            } else {
+                frontend = new AntennaCLIFrontend(pomFilePath.toFile());
+            }
+
             frontend.execute();
         } catch (Exception e) {
             e.printStackTrace();

--- a/assembly/cli/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIOptions.java
+++ b/assembly/cli/src/main/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIOptions.java
@@ -41,6 +41,10 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
      */
     private final String configFilePath;
 
+    /**
+     * The path to the file with environment properties.
+     */
+    private final String propertiesFilePath;
 
     /**
      * Creates a new instance of {@code AntennaCLIOptions} with the properties
@@ -52,8 +56,27 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
      * @param valid          flag whether the command line is valid
      */
     AntennaCLIOptions(String configFilePath, boolean debugLog, boolean showHelp, boolean valid) {
+        this(configFilePath, null, debugLog, showHelp, valid);
+    }
+
+    /**
+     * Creates a new instance of {@code AntennaCLIOptions} with the properties
+     * provided.
+     *
+     * @param configFilePath     the path to the Antenna config file
+     * @param propertiesFilePath the path to the properties file
+     * @param debugLog           flag whether debug log should be active
+     * @param showHelp           flag whether the help message should be printed
+     * @param valid              flag whether the command line is valid
+     */
+    AntennaCLIOptions(String configFilePath,
+                      String propertiesFilePath,
+                      boolean debugLog,
+                      boolean showHelp,
+                      boolean valid) {
         super(debugLog, showHelp, valid);
         this.configFilePath = configFilePath;
+        this.propertiesFilePath = propertiesFilePath;
     }
 
     /**
@@ -64,6 +87,16 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
      */
     String getConfigFilePath() {
         return configFilePath;
+    }
+
+    /**
+     * Returns the path to the properties file that has been
+     * specified on the command line.
+     *
+     * @return the path to the properties file
+     */
+    String getPropertiesFilePath() {
+        return propertiesFilePath;
     }
 
     /**
@@ -79,7 +112,8 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
      */
     static AntennaCLIOptions parse(String[] args) {
         List<String> paths = readPathsFromArgs(args);
-        if (paths.size() != 1) {
+        int pathsSize = paths.size();
+        if (paths.isEmpty() || pathsSize > 2) {
             return INVALID_OPTIONS;
         }
 
@@ -92,7 +126,11 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
             return INVALID_OPTIONS;
         }
 
-        return new AntennaCLIOptions(paths.get(0), debug1 || debug2, help1 || help2, true);
+        if (pathsSize == 1) {
+            return new AntennaCLIOptions(paths.get(0), debug1 || debug2, help1 || help2, true);
+        } else {
+            return new AntennaCLIOptions(paths.get(0), paths.get(1), debug1 || debug2, help1 || help2, true);
+        }
     }
 
     /**
@@ -103,7 +141,7 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
      */
     static String helpMessage() {
         String cr = System.lineSeparator();
-        return "Usage: java -jar antenna.jar [options] <pomFilePath>" + cr + cr +
+        return "Usage: java -jar antenna.jar [options] <pomFilePath> [<propertiesFilePath>]" + cr + cr +
                 "Supported options:" + cr +
                 SWITCH_HELP_SHORT + ", " + SWITCH_HELP_LONG + ":    Displays this help message." + cr +
                 SWITCH_DEBUG_SHORT + ", " + SWITCH_DEBUG_LONG +
@@ -122,18 +160,20 @@ public final class AntennaCLIOptions extends AbstractAntennaCLIOptions {
             return false;
         }
         AntennaCLIOptions that = (AntennaCLIOptions) o;
-        return Objects.equals(getConfigFilePath(), that.getConfigFilePath());
+        return Objects.equals(getConfigFilePath(), that.getConfigFilePath())
+                && Objects.equals(getPropertiesFilePath(), that.getPropertiesFilePath());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getConfigFilePath());
+        return Objects.hash(super.hashCode(), getConfigFilePath(), getPropertiesFilePath());
     }
 
     @Override
     public String toString() {
         return "AntennaCLIOptions{" +
                 "configFilePath='" + configFilePath + '\'' +
+                "propertiesFilePath='" + propertiesFilePath + '\'' +
                 ", debugLog=" + debugLog +
                 ", showHelp=" + showHelp +
                 ", valid=" + valid +

--- a/assembly/cli/src/site/markdown/index.md.vm
+++ b/assembly/cli/src/site/markdown/index.md.vm
@@ -110,6 +110,14 @@ SECRET=password12345 java -jar path\to\ ${docName}.jar path\to\toolConfiguration
 Should you execute it within the command, the variable will not be saved in your environment but only exist for the run of the command.
 ${docNameCap} adheres to standards and only renders environment variables that are written in upper case letters.
 
+Alternatively, it is possible to specify environment variables inside a properties file which can be given to the analyzer command:
+
+```
+java -jar path\to\ ${docName}.jar path\to\toolConfiguration.xml path\to\example.properties
+```
+
+Note that variables in the properties file can also be lower case.
+
 Within both, your `toolConfiguration.xml` and the `workflow.xml`, you can then reference the variables.
 
 #[[##]]# Enabling debug logging

--- a/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendDebugLogTest.java
+++ b/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendDebugLogTest.java
@@ -223,4 +223,12 @@ public class AntennaCLIFrontendDebugLogTest {
 
         assertThat(output).contains(Arrays.asList("Cannot find ", nonExistingPath.toString()));
     }
+
+    @Test
+    public void testNonExistingPropertiesFileIsHandled() throws UnsupportedEncodingException {
+        Path nonExistingPath = Paths.get("non", "existing", "example.properties");
+        String output = runAntennaAndExpectFailure(antennaConfigFile, nonExistingPath.toString());
+
+        assertThat(output).contains(Arrays.asList("Cannot find ", nonExistingPath.toString()));
+    }
 }

--- a/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendTest.java
+++ b/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIFrontendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Bosch Software Innovations GmbH 2018.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -38,7 +38,13 @@ public class AntennaCLIFrontendTest extends AbstractAntennaCLIFrontendTest {
         assumeTrue(isRunExecutionTest());
         protoypeExecutionTest(() -> {
             Path pom = testData.getProjectPom();
-            String[] args = new String[]{ pom.toAbsolutePath().toString() };
+            String[] args;
+            if (hasPropertiesFile()) {
+                Path propertiesFile = testData.getPropertiesFile();
+                args = new String[]{ pom.toAbsolutePath().toString(), propertiesFile.toAbsolutePath().toString() };
+            } else {
+                args = new String[]{ pom.toAbsolutePath().toString() };
+            }
             AntennaCLIFrontend.main(args);
         }, tf -> null);
     }

--- a/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIOptionsTest.java
+++ b/assembly/cli/src/test/java/org/eclipse/sw360/antenna/frontend/cli/AntennaCLIOptionsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AntennaCLIOptionsTest {
     private static final String CONFIG_PATH = "path/to/config.xml";
+    private static final String PROPERTIES_PATH = "path/to/example.properties";
 
     @Test
     public void testEquals() {
@@ -30,10 +31,11 @@ public class AntennaCLIOptionsTest {
 
     @Test
     public void testToString() {
-        AntennaCLIOptions options = new AntennaCLIOptions(CONFIG_PATH, true, false, true);
+        AntennaCLIOptions options = new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, false, true);
         String s = options.toString();
 
         assertThat(s).contains("configFilePath='" + options.getConfigFilePath());
+        assertThat(s).contains("propertiesFilePath='" + options.getPropertiesFilePath());
         assertThat(s).contains("debugLog=" + options.isDebugLog());
         assertThat(s).contains("showHelp=" + options.isShowHelp());
         assertThat(s).contains("valid=" + options.isValid());
@@ -76,8 +78,18 @@ public class AntennaCLIOptionsTest {
     }
 
     @Test
+    public void testParseConfigAndPropertiesPathOnly() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, false, false, true), CONFIG_PATH, PROPERTIES_PATH);
+    }
+
+    @Test
     public void testParseWithXSwitch() {
         checkParse(new AntennaCLIOptions(CONFIG_PATH, true, false, true), CONFIG_PATH, "-X");
+    }
+
+    @Test
+    public void testParseWithMultiplePathsAndXSwitch() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, false, true), CONFIG_PATH, PROPERTIES_PATH, "-X");
     }
 
     @Test
@@ -86,8 +98,13 @@ public class AntennaCLIOptionsTest {
     }
 
     @Test
-    public void testParseWithMultiplePaths() {
-        checkFailedParse(CONFIG_PATH, "another/path");
+    public void testParsePositionOfOptionsDoesNotMatterWithMultiplePaths() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, false, true), "-X", CONFIG_PATH, PROPERTIES_PATH);
+    }
+
+    @Test
+    public void testParseWithMoreThanTwoPaths() {
+        checkFailedParse(CONFIG_PATH, PROPERTIES_PATH, "another/path");
     }
 
     @Test
@@ -101,9 +118,20 @@ public class AntennaCLIOptionsTest {
     }
 
     @Test
+    public void testParseWithMultiplePathsAndDebugSwitch() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, false, true), "--debug", CONFIG_PATH, PROPERTIES_PATH);
+    }
+
+    @Test
     public void testParseWithMultipleDebugSwitches() {
         checkParse(new AntennaCLIOptions(CONFIG_PATH, true, false, true),
                 AntennaCLIOptions.SWITCH_DEBUG_LONG, CONFIG_PATH, AntennaCLIOptions.SWITCH_DEBUG_SHORT);
+    }
+
+    @Test
+    public void testParseWithMultiplePathsAndDebugSwitches() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, false, true),
+                AntennaCLIOptions.SWITCH_DEBUG_LONG, CONFIG_PATH, PROPERTIES_PATH, AntennaCLIOptions.SWITCH_DEBUG_SHORT);
     }
 
     @Test
@@ -113,7 +141,19 @@ public class AntennaCLIOptionsTest {
     }
 
     @Test
+    public void testParseWithMultiplePathsAndShortHelpSwitch() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, PROPERTIES_PATH, true, true, true),
+                CONFIG_PATH, PROPERTIES_PATH, "-X", "-h");
+    }
+
+    @Test
     public void testParseWithLongHelpSwitch() {
+        checkParse(new AntennaCLIOptions(CONFIG_PATH, false, true, true),
+                "--help", CONFIG_PATH);
+    }
+
+    @Test
+    public void testParseWithMultiplePathsAndLongHelpSwitch() {
         checkParse(new AntennaCLIOptions(CONFIG_PATH, false, true, true),
                 "--help", CONFIG_PATH);
     }

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/AbstractAntennaFrontendTest.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/AbstractAntennaFrontendTest.java
@@ -55,11 +55,20 @@ public abstract class AbstractAntennaFrontendTest {
         return runExecutionTest;
     }
 
+    protected boolean hasPropertiesFile() {
+        return hasPropertiesFile;
+    }
+
     protected void setRunExecutionTest(boolean runExecutionTest) {
         this.runExecutionTest = runExecutionTest;
     }
 
+    protected void setHasPropertiesFile(boolean hasPropertiesFile) {
+        this.hasPropertiesFile = hasPropertiesFile;
+    }
+
     private boolean runExecutionTest;
+    private boolean hasPropertiesFile;
 
     @Parameterized.Parameters(name = "{index}: Test data = {1}")
     public static Collection<Object[]> data() {

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/cli/AbstractAntennaCLIFrontendTest.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/cli/AbstractAntennaCLIFrontendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Bosch Software Innovations GmbH 2017.
+ * Copyright (c) Bosch.IO GmbH 2020.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -53,6 +53,7 @@ public abstract class AbstractAntennaCLIFrontendTest extends AbstractAntennaFron
         assertNotNull(antennaContext.getProject());
 
         setRunExecutionTest(!testData.requiresMaven());
+        setHasPropertiesFile(testData.hasPropertiesFile());
     }
 
     @Ignore("would fail due to unrelated templating issues")

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/AbstractTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/AbstractTestProject.java
@@ -111,5 +111,9 @@ public abstract class AbstractTestProject {
         return getProjectRoot().resolve(POM);
     }
 
+    public Path getPropertiesFile() throws NoSuchMethodException {
+        throw new NoSuchMethodException("There is no properties file for this test project");
+    }
+
     public abstract String getExpectedProjectArtifactId();
 }

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/AbstractTestProjectWithExpectations.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/AbstractTestProjectWithExpectations.java
@@ -121,4 +121,8 @@ public abstract class AbstractTestProjectWithExpectations extends AbstractTestPr
     public boolean requiresMaven() {
         return false;
     }
+
+    public boolean hasPropertiesFile () {
+        return false;
+    }
 }

--- a/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
+++ b/core/frontend-stubs-testing/src/main/java/org/eclipse/sw360/antenna/frontend/testing/testProjects/ExampleTestProject.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ExampleTestProject extends AbstractTestProjectWithExpectations implements ExecutableTestProject {
 
+    private static final String PATH_TO_PROPERTIES_FILE = "example.properties";
+
     public ExampleTestProject() {
         super();
     }
@@ -35,7 +37,8 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
     public List<String> getOtherFilesToCopy() {
         return Stream.of("src/reportData.json",
                 "src/dependencies.csv",
-                "src/analyzer-result.yml")
+                "src/analyzer-result.yml",
+                PATH_TO_PROPERTIES_FILE)
                 .collect(Collectors.toList());
     }
 
@@ -211,5 +214,15 @@ public class ExampleTestProject extends AbstractTestProjectWithExpectations impl
         List<String> endingsList = super.getExpectedToolConfigurationConfigFilesEndings();
         endingsList.add(File.separator + "src" + File.separator + "antennaconf.xml");
         return endingsList;
+    }
+
+    @Override
+    public boolean hasPropertiesFile () {
+        return true;
+    }
+
+    @Override
+    public Path getPropertiesFile() {
+        return getProjectRoot().resolve(PATH_TO_PROPERTIES_FILE);
     }
 }

--- a/example-projects/example-project/example.properties
+++ b/example-projects/example-project/example.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Bosch Software Innovations GmbH 2020.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+dummy_name=Mustermann
+dummy_passwort=password12345


### PR DESCRIPTION
Issue #561.

Giving a second path to the CLI does not result in a wrong usage message
anymore.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
