### PR TITLE
Fix a problem with a platform-specific path conversion.

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapper.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/csvreader/CSVArtifactMapper.java
@@ -75,10 +75,10 @@ public class CSVArtifactMapper {
             CPE,
             PATH_NAME};
 
-    private Path csvFile;
-    private Charset encoding;
-    private char delimiter;
-    private Path baseDir;
+    private final Path csvFile;
+    private final Charset encoding;
+    private final char delimiter;
+    private final Path baseDir;
 
 
     public CSVArtifactMapper(Path csvFile, Charset encoding, char delimiter, Path baseDir) {
@@ -437,7 +437,8 @@ public class CSVArtifactMapper {
 
     private String getPathAsStringIfExists(Path path, Artifact artifact) {
         if (Files.exists(path)) {
-            return baseDir.relativize(path).toString();
+            Path relativePath = path.startsWith(baseDir) ? baseDir.relativize(path) : path;
+            return relativePath.toString();
         } else {
             artifact.getMainCoordinate().ifPresent(coordinate ->
                     LOGGER.debug("The given source file for artifact {} does not exist", coordinate));


### PR DESCRIPTION
Issue: eclipse#591.

CSVArtifactMapper tries to convert paths to source files to relative
paths, so that they are not specific to a local configuration.
However, for absolute paths that are not below the base directory,
this obviously does not work reliably on all platforms - and does not
make any sense either. So such paths are now stored as absolute paths.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.
@blaumeiser-at-bosch @neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
A new test case has been added to check the concrete problem.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
