### PR TITLE
Get resources from classpath without using file separator 

### DIFF
--- a/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGenerator.java
+++ b/core/core-workflow-steps/src/main/java/org/eclipse/sw360/antenna/workflow/generators/HTMLReportGenerator.java
@@ -57,7 +57,7 @@ public class HTMLReportGenerator extends AbstractGenerator {
         // Get path to disclosure documents
         ToolConfiguration toolConfig = context.getToolConfiguration();
         Path reportFilePath = toolConfig.getAntennaTargetDirectory().resolve(LICENSE_REPORT_FILE);
-        URL styleSource = getClass().getResource(File.separator + LICENSE_REPORT_STYLE_FILE);
+        URL styleSource = getClass().getClassLoader().getResource(LICENSE_REPORT_STYLE_FILE);
         Path reportStyleFilePath = toolConfig.getAntennaTargetDirectory().resolve(LICENSE_REPORT_STYLE_FILE);
 
         Set<ArtifactForHTMLReport> artifactsForHTMLReport = extractRelevantArtifactInformation(artifacts);


### PR DESCRIPTION
Resolves #574.

Since there are no platform-dependent separators in JAR files, the
File.separator for searching for styles.css has been removed and a /
has been hardcoded.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>

### Request Reviewer
@neubs-bsi 

### Type of Change
*bug fix*

### Checklist
Must:
- [x] All related issues are referenced in commit messages