### PR TITLE
Make HTMLReportGenerator configurable

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/HTML-report-generator-step.md
+++ b/antenna-documentation/src/site/markdown/generators/HTML-report-generator-step.md
@@ -17,10 +17,20 @@ Add this configuration to the workflow.xml
         <step>
             <name>HTML Report Generator</name>
             <classHint>org.eclipse.sw360.antenna.workflow.generators.HTMLReportGenerator</classHint>
+            <configuration>
+                <entry key="license.report.template.file" value="${project.basedir}/myVelocityTemplate.vm"/>
+                <entry key="license.report.file" value="${project.build.directory}/myDirectory/generatedHtmlReport.html"/>
+                <entry key="license.report.style.file" value="${project.basedir}/myStyles.css"/>
+            </configuration>
         </step>
     </generators>
 </workflow>
 ```
+
+#### Explanation of parameters
+* `license.report.template.file`: Absolute path to the custom velocity template file. 
+* `license.report.file`: The self-selected file name for the HTML file if it should not be 3rdparty-licenses.html.
+* `license.report.style.file`: Absolute path to the custom styles.css file.
 
 ### Magic string for output handlers
 


### PR DESCRIPTION
Resolves #598.

The HTMLReportGenerator couldn't be configured and was therefore not
customizable. In order to make it customizable, the generator can be
configured via the workflow.xml file. The velocity template file,
styles.css file and the report file name can be configured now.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>

### Request Reviewer
@neubs-bsi 

### Type of Change
*improvements*:  

### Checklist
Must:
- [x] All related issues are referenced in commit messages