### PR TITLE
Update docker documentation for usage of properties file

### DIFF
--- a/antenna-documentation/src/site/markdown/docker.md
+++ b/antenna-documentation/src/site/markdown/docker.md
@@ -52,6 +52,7 @@ project-to-scan
 ├── antenna-related-files (referenced from the antennaConfiguration.xml
 │   ├── workflow.xml
 │   ├── dependencies.csv
+│   ├── example.properties
 │   └── sources
 │       └── test-component.jar
 └── src (source code of project
@@ -78,6 +79,7 @@ project-to-scan
 │   ├── antennaConfiguration.xml
 │   ├── workflow.xml
 │   ├── dependencies.csv
+│   ├── example.properties
 │   └── sources
 │       └── test-component.jar
 └── src (source code of project
@@ -101,4 +103,23 @@ If you have a project that needs to be scanned by Antenna, do not simple mount t
 `antenna-related-files` folder, because then the project's source code itself would not be mounted
 and a proper scan could not be executed.
 
+### Using files defining properties
+The antenna CLI is able to process an optional properties file. If this file is, as in the previous hierarchy,
+part of the mounted project folder, the path can be specified in the docker run command.
 
+```
+docker run -it \
+ --mount src=<path-to-project>/project-to-scan,target=/antenna,type=bind \ 
+ antenna/antenna-related-files/antennaConfiguration.xml \
+ antenna/antenna-related-files/example.properties 
+``` 
+
+Alternatively, if the file is located somewhere else, it can be included via the docker run volume option.
+
+```
+docker run -it \
+ --mount src=<path-to-project>/project-to-scan,target=/antenna,type=bind \ 
+ -v <path-to-properties-file>:<path-alias>
+ antenna/antenna-related-files/antennaConfiguration.xml \
+ <path-alias> 
+``` 


### PR DESCRIPTION
Resolves #584

The Antenna CLI is already capable of using a properties file.
Therefore, update the documentation how to use such a file within the
docker run command. This is done by either having it inside of the
project folder that is mounted on the docker daemon or by including it
with the -v (--volume) option.

Signed-off-by: Korbinian Singhammer <external.Korbinian.Singhammer2@bosch.io>

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  documentation update

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have updated the documentation accordingly to my changes 
