### PR TITLE
Replace '/' and '\' by '_' in auto generated clearing document name

### DIFF
--- a/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
+++ b/assembly/compliance-tool/src/main/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGenerator.java
@@ -22,7 +22,8 @@ public class ClearingReportGenerator {
     private static final String CLEARING_DOC_SUFFIX = "_clearing.json";
 
     Path createClearingDocument(SW360Release release, Path targetDir) {
-        Path clearingDocument = targetDir.resolve(release.getName() + release.getVersion() + CLEARING_DOC_SUFFIX);
+        String clearingDocumentName = release.getName() + "_" + release.getVersion() + CLEARING_DOC_SUFFIX;
+        Path clearingDocument = targetDir.resolve(clearingDocumentName.replaceAll("[/\\\\]", "_"));
         try {
             Files.createDirectories(targetDir);
             ObjectMapper mapper = new ObjectMapper();

--- a/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
+++ b/assembly/compliance-tool/src/test/java/org/eclipse/sw360/antenna/frontend/compliancetool/sw360/updater/ClearingReportGeneratorTest.java
@@ -26,6 +26,9 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClearingReportGeneratorTest {
+    private static final String TEST_RELEASE_NAME = "testRelease.com/release\\commons";
+    private static final String EXPECTED_CLEARING_DOC_NAME = "testRelease.com_release_commons_1.0.0_clearing.json";
+
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -39,12 +42,12 @@ public class ClearingReportGeneratorTest {
     @Test
     public void createClearingDocument() throws IOException {
         File targetFolder = folder.newFolder();
-        SW360Release release = SW360TestUtils.mkSW360Release("testRelease");
+        SW360Release release = SW360TestUtils.mkSW360Release(TEST_RELEASE_NAME);
         release.setOverriddenLicense("overridden");
 
         Path clearingDocument = generator.createClearingDocument(release, targetFolder.toPath());
         assertThat(Files.exists(clearingDocument)).isTrue();
-        assertThat(clearingDocument.getFileName().toString()).isEqualTo(release.getName() + release.getVersion() + "_clearing.json");
+        assertThat(clearingDocument.getFileName().toString()).isEqualTo(EXPECTED_CLEARING_DOC_NAME);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.readValue(clearingDocument.toFile(), SW360Release.class);


### PR DESCRIPTION
Resolves #615

When no clearing document is specified for a release to be updated, a
document is generated with a name consisting of the release's name and
version. However, this name might contain a '/' or '\' character and the
documents name is interpreted to contain a subdirectory, leading to file
errors. Thus, every '/' and '\' occuring is replaced by a '_' character.

Signed-off-by: Korbinian Singhammer <external.Korbinian.Singhammer2@bosch.io>

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.
@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug-fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [x ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x ] I have provided tests for the changes (if there are changes that need additional tests)
