### PR TITLE
Document automatic setting of ECC status in SW360

### DIFF
--- a/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
+++ b/antenna-documentation/src/site/markdown/generators/sw360-update-generator-step.md
@@ -56,3 +56,13 @@ the antenna configuration file will be used.
 
 #### Data Model
 You can find a description of the data model mapping in the [SW360 data model](../sw360-data-model.html) section.
+
+**Note**:
+In the current implementation, SW360 automatically sets the ECC (Export Control & Customs) status of a release that 
+is to be updated or created to `APPROVED` if the following conditions are fulfilled:
+* The release contains a valid `Download URL`, i.e., the URL has a correct format. It does not necessarily need to be 
+reachable.
+* The`Component Type` is of `OSS`. This is the default if not set otherwise.
+* The SW360 user has sufficient writing rights. In terms of SW360 user groups, these are `ADMIN`, `CLEARING_ADMIN`, and
+`CLEARING_EXPERT`. Alternatively, this holds also true if the release's `contributor` field (on the SW360 side)
+contains the SW360 user's email.

--- a/antenna-documentation/src/site/markdown/sw360-data-model.md.vm
+++ b/antenna-documentation/src/site/markdown/sw360-data-model.md.vm
@@ -82,3 +82,12 @@ In the following section there is an outline what data of SW360 ${docNameCap} ma
 **Note**:
 All string fields in this data model have a limit of 2147483647 - 1 in length, since this is the frame size of the binary protocol used with thrift.
 
+**Note**:
+In the current implementation, SW360 automatically sets the ECC (Export Control & Customs) status of a release that 
+is to be updated or created to `APPROVED` if the following conditions are fulfilled:
+* The release contains a valid `Download URL`, i.e., the URL has a correct format. It does not necessarily need to be 
+reachable.
+* The`Component Type` is of `OSS`. This is the default if not set otherwise.
+* The SW360 user has sufficient writing rights. In terms of SW360 user groups, these are `ADMIN`, `CLEARING_ADMIN`, and
+`CLEARING_EXPERT`. Alternatively, this holds also true if the release's `contributor` field (on the SW360 side)
+contains the SW360 user's email.


### PR DESCRIPTION
Resolves #576

Update documentation to note that updating an OSS release with a valid
download url can automatically set the ECC status in SW360 to APPROVED.

Signed-off-by: Korbinian Singhammer <external.Korbinian.Singhammer2@bosch.io>

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.

@neubs-bsi 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  documentation update

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have updated the documentation accordingly to my changes 
