### PR TITLE
fix weird NPE in getMainLicenseIds if Set contains null element

### DIFF
--- a/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360Release.java
+++ b/modules/sw360/sw360-client/src/main/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360Release.java
@@ -115,10 +115,11 @@ public final class SW360Release extends SW360HalResource<SW360ReleaseLinkObjects
         return Optional.ofNullable(getEmbedded().getLicenses())
                 .map(lics -> lics
                         .stream()
+                        .filter(Objects::nonNull)
                         .map(SW360SparseLicense::getShortName)
                         .collect(Collectors.toSet()))
                 .orElse(Collections.emptySet());
-    }
+        }
 
     public SW360Release setMainLicenseIds(Set<String> mainLicenseIds) {
         if (!mainLicenseIds.isEmpty()) {

--- a/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360ReleaseTest.java
+++ b/modules/sw360/sw360-client/src/test/java/org/eclipse/sw360/antenna/sw360/client/rest/resource/releases/SW360ReleaseTest.java
@@ -15,15 +15,15 @@ import org.eclipse.sw360.antenna.sw360.client.rest.resource.LinkObjects;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.SW360ResourcesTestUtils;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType;
 import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360SparseAttachment;
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.licenses.SW360SparseLicense;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.mock;
 
 public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
@@ -200,5 +200,38 @@ public class SW360ReleaseTest extends SW360ResourcesTestUtils<SW360Release> {
         sw360Release1.mergeWith(sw360Release2);
 
         assertThat(sw360Release1.getEmbedded().getAttachments()).hasSize(2);
+    }
+
+    @Test
+    public void testReleaseGetMainLicenseWhenLicenseIsNull() {
+        SW360Release release = prepareItemWithoutOptionalInput();
+
+        SW360ReleaseEmbedded embedded = new SW360ReleaseEmbedded();
+        List<SW360SparseLicense> licenses = new ArrayList<>();
+        licenses.add(null);
+        embedded.setLicenses(licenses);
+
+        release.setEmbedded(embedded);
+
+        Set<String> emptyLicenses = release.getMainLicenseIds();
+
+        assertThat(emptyLicenses).isEqualTo(Collections.emptySet());
+    }
+
+    @Test
+    public void testReleaseGetMainLicenseWhenLicenseIsContained() {
+        SW360Release release = prepareItemWithoutOptionalInput();
+
+        SW360ReleaseEmbedded embedded = new SW360ReleaseEmbedded();
+        List<SW360SparseLicense> licenses = new ArrayList<>();
+        final String some_license = "some license";
+        licenses.add(new SW360SparseLicense().setShortName(some_license));
+        embedded.setLicenses(licenses);
+
+        release.setEmbedded(embedded);
+
+        Set<String> emptyLicenses = release.getMainLicenseIds();
+
+        assertThat(emptyLicenses).containsExactly(some_license);
     }
 }


### PR DESCRIPTION
When executing the status reporter a weird NPE occured that
releases gotten from SW360 where mapped to contain an element
in the embedded license set that was null.

This is now fixed.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.
@oheger-bosch 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bog fix

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
