### PR TITLE
Oheger bosch/http/#630 improve proxy handling

### DIFF
--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImpl.java
@@ -43,10 +43,12 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
      */
     private static OkHttpClient createClient(HttpClientConfig config) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
-        if (config.proxySettings().isProxyUse()) {
-            Proxy proxy = createProxy(config.proxySettings());
+        if (!config.proxySettings().isDefaultProxySelectorUse()) {
+            Proxy proxy = config.proxySettings().isNoProxy() ? Proxy.NO_PROXY :
+                    createProxy(config.proxySettings());
             builder.proxy(proxy);
         }
+
         if (unverifiedSSLCertificate()) {
             builder.hostnameVerifier((s, sslSession) -> true);
         }

--- a/http-support/src/main/java/org/eclipse/sw360/antenna/http/config/HttpClientConfig.java
+++ b/http-support/src/main/java/org/eclipse/sw360/antenna/http/config/HttpClientConfig.java
@@ -32,7 +32,7 @@ public final class HttpClientConfig {
      * Constant for the basic configuration instance.
      */
     private static final HttpClientConfig BASIC_CONFIG =
-            new HttpClientConfig(null, ProxySettings.noProxy());
+            new HttpClientConfig(null, ProxySettings.defaultProxySelector());
 
     /**
      * Stores a custom JSON object mapper. The field is null if no custom

--- a/http-support/src/site/markdown/index_http.md.vm
+++ b/http-support/src/site/markdown/index_http.md.vm
@@ -69,8 +69,17 @@ The properties that can be changed in a client configuration are the following:
   generate the payload for JSON requests.
 * Proxy settings: Requests can be routed through an HTTP proxy. For this 
   purpose, the _ProxySettings_ class exists that collects the properties of the
-  proxy server.
-* SSL Certificate Verification: Dynmically, ssl certificate verification can be
+  proxy server. There are multiple options:
+  * Users can configure a specific proxy to be used for all requests with the
+    `ProxySettings.useProxy()` method.
+  * Usage of a proxy can be disabled completely by using
+    `ProxySettings.noProxy()`.
+  * The selection of a proxy can be delegated to the default
+    [ProxySelector](https://docs.oracle.com/javase/8/docs/api/java/net/ProxySelector.html)
+    installed in the JVM by using `ProxySettings.defaultProxySelector()`. This
+    option is the default if the client configuration does not contain any
+    explicit settings.
+* SSL Certificate Verification: Dynamically, ssl certificate verification can be
   disabled by setting the system property _client.access.unverified_ to true.
 
 Below is a code fragment that shows the construction of an _HttpClientConfig_ 

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImplTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/HttpClientFactoryImplTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.ProxySelector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -55,6 +56,7 @@ public class HttpClientFactoryImplTest {
         HttpClientImpl client = createClient(config);
         assertThat(client.getMapper()).isSameAs(mapper);
         assertThat(client.getClient().proxy()).isNull();
+        assertThat(client.getClient().proxySelector()).isEqualTo(ProxySelector.getDefault());
     }
 
     @Test
@@ -73,6 +75,18 @@ public class HttpClientFactoryImplTest {
         assertThat(address.getHostName()).isEqualTo(host);
         assertThat(address.getPort()).isEqualTo(port);
         assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
+    }
+
+    @Test
+    public void testNewClientWithNoProxy() {
+        ObjectMapper mapper = mock(ObjectMapper.class);
+        HttpClientConfig config = HttpClientConfig.basicConfig()
+                .withObjectMapper(mapper)
+                .withProxySettings(ProxySettings.noProxy());
+
+        HttpClientImpl client = createClient(config);
+        assertThat(client.getMapper()).isSameAs(mapper);
+        assertThat(client.getClient().proxy()).isEqualTo(Proxy.NO_PROXY);
     }
 
     @Test

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/config/HttpClientConfigTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/config/HttpClientConfigTest.java
@@ -23,7 +23,7 @@ public class HttpClientConfigTest {
         HttpClientConfig basicConfig = HttpClientConfig.basicConfig();
 
         assertThat(basicConfig.customObjectMapper()).isNotPresent();
-        assertThat(basicConfig.proxySettings().isProxyUse()).isFalse();
+        assertThat(basicConfig.proxySettings()).isEqualTo(ProxySettings.defaultProxySelector());
     }
 
     @Test

--- a/http-support/src/test/java/org/eclipse/sw360/antenna/http/config/ProxySettingsTest.java
+++ b/http-support/src/test/java/org/eclipse/sw360/antenna/http/config/ProxySettingsTest.java
@@ -36,11 +36,11 @@ public class ProxySettingsTest {
 
     @Test
     public void testNoProxy() {
-        ProxySettings emptySettings = ProxySettings.noProxy();
+        ProxySettings settings = ProxySettings.noProxy();
 
-        assertThat(emptySettings.isProxyUse()).isFalse();
-        assertThat(emptySettings.getProxyHost()).isEqualTo(ProxySettings.UNDEFINED_HOST);
-        assertThat(emptySettings.getProxyPort()).isEqualTo(ProxySettings.UNDEFINED_PORT);
+        assertThat(settings.isNoProxy()).isTrue();
+        assertThat(settings.isProxyUse()).isFalse();
+        assertThat(settings.isDefaultProxySelectorUse()).isFalse();
     }
 
     @Test
@@ -51,17 +51,37 @@ public class ProxySettingsTest {
     }
 
     @Test
+    public void testDefaultProxySelector() {
+        ProxySettings settings = ProxySettings.defaultProxySelector();
+
+        assertThat(settings.isDefaultProxySelectorUse()).isTrue();
+        assertThat(settings.isProxyUse()).isTrue();
+        assertThat(settings.isNoProxy()).isFalse();
+    }
+
+    @Test
+    public void testDefaultProxySelectorReturnsACachedInstance() {
+        ProxySettings settings = ProxySettings.defaultProxySelector();
+
+        assertThat(ProxySettings.defaultProxySelector()).isSameAs(settings);
+    }
+
+    @Test
     public void testIsProxyUseNullHost() {
-        ProxySettings settings = ProxySettings.useProxy(null, -1);
+        ProxySettings settings = ProxySettings.useProxy(null, 0);
 
         assertThat(settings.isProxyUse()).isFalse();
+        assertThat(settings.isDefaultProxySelectorUse()).isFalse();
+        assertThat(settings.isNoProxy()).isTrue();
     }
 
     @Test
     public void testIsProxyUseUndefinedPort() {
-        ProxySettings settings = ProxySettings.useProxy(PROXY_HOST, ProxySettings.UNDEFINED_PORT);
+        ProxySettings settings = ProxySettings.useProxy(PROXY_HOST, -1);
 
         assertThat(settings.isProxyUse()).isFalse();
+        assertThat(settings.isDefaultProxySelectorUse()).isFalse();
+        assertThat(settings.isNoProxy()).isTrue();
     }
 
     @Test
@@ -71,6 +91,8 @@ public class ProxySettingsTest {
         assertThat(settings.getProxyHost()).isEqualTo(PROXY_HOST);
         assertThat(settings.getProxyPort()).isEqualTo(PROXY_PORT);
         assertThat(settings.isProxyUse()).isTrue();
+        assertThat(settings.isNoProxy()).isFalse();
+        assertThat(settings.isDefaultProxySelectorUse()).isFalse();
     }
 
     @Test
@@ -90,9 +112,23 @@ public class ProxySettingsTest {
     }
 
     @Test
-    public void testFromConfigUndefined() {
+    public void testFromConfigUndefinedHost() {
         ProxySettings settings = ProxySettings.fromConfig(true, null, 128);
 
-        assertThat(settings).isEqualTo(ProxySettings.noProxy());
+        assertThat(settings).isEqualTo(ProxySettings.defaultProxySelector());
+    }
+
+    @Test
+    public void testFromConfigEmptyHost() {
+        ProxySettings settings = ProxySettings.fromConfig(true, "", 128);
+
+        assertThat(settings).isEqualTo(ProxySettings.defaultProxySelector());
+    }
+
+    @Test
+    public void testFromConfigUndefinedPort() {
+        ProxySettings settings = ProxySettings.fromConfig(true, PROXY_HOST, 0);
+
+        assertThat(settings).isEqualTo(ProxySettings.defaultProxySelector());
     }
 }


### PR DESCRIPTION
Issue 630

The documentation of the proxy settings for the HTTP support library was slightly incorrect. Due to defaults applied by the underlying OkHttpClient, the default ProxySelector of the JVM was used rather than a direct Internet connection when the constant ProxySettings.noProxy() was specified.

This PR updates the documentation accordingly and makes this behaviour more explicit by introducing a new method ProxySettings.defaultProxySelector(). As the latter is now the default when creating a new HTTP client, there are no behavioural changes. However, users can now actually specify that they want to circumvent any proxy.

### Request Reviewer
@neubs-bsi @bs-ondem 

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  
improvements / documentation update

### How Has This Been Tested?
Test cases have been added for the new methods of ProxySettings. The tests for the proxy configuration applied by HttpClientFactoryImpl have been extended.
A run with the Compliance Tool was triggered to manually check that there are no undesired side effects.

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
- [x] I have updated the documentation accordingly to my changes 
