### PR TITLE
Checks for failCausingResults when no Artifacts after Analyzer run

### DIFF
--- a/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/AntennaWorkflowTest.java
+++ b/core/runtime/src/test/java/org/eclipse/sw360/antenna/workflow/AntennaWorkflowTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2021.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.antenna.workflow;
+
+import org.eclipse.sw360.antenna.api.IAttachable;
+import org.eclipse.sw360.antenna.api.IEvaluationResult;
+import org.eclipse.sw360.antenna.api.exceptions.ExecutionException;
+import org.eclipse.sw360.antenna.api.workflow.AbstractAnalyzer;
+import org.eclipse.sw360.antenna.api.workflow.WorkflowStepResult;
+import org.eclipse.sw360.antenna.model.artifact.Artifact;
+import org.eclipse.sw360.antenna.testing.AntennaTestWithMockedContext;
+/*
+ * Copyright (c) Bosch.IO GmbH 2021.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import org.eclipse.sw360.antenna.workflow.stubs.DefaultPolicyEvaluation;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AntennaWorkflowTest extends AntennaTestWithMockedContext {
+
+    private AntennaWorkflowConfiguration antennaWFConfigMock;
+
+    /**
+     * Creates a mock of an {@code AntennaWFConfig} with all workflow steps.
+     * @param analyzer Analyzer to be returned by the getAnalyzers method
+     */
+    private void createAntennaWFConfigMock(DummyAnalyzer analyzer) {
+        antennaWFConfigMock = mock(AntennaWorkflowConfiguration.class);
+        when(antennaWFConfigMock.getAnalyzers()).thenReturn(Collections.singleton(analyzer));
+        when(antennaWFConfigMock.getProcessors()).thenReturn(Collections.emptySet());
+        when(antennaWFConfigMock.getGenerators()).thenReturn(Collections.emptySet());
+        when(antennaWFConfigMock.getOutputHandlers()).thenReturn(Collections.emptyList());
+    }
+
+    @Test (expected = ExecutionException.class)
+    public void failCausingResultWithNoArtifactsInAnalyzerBreaksBuild() {
+        DummyAnalyzer analyzer = mock(DummyAnalyzer.class);
+        WorkflowStepResult workflowStepResult = new WorkflowStepResult(Collections.emptySet());
+        workflowStepResult.addFailCausingResults("Test",
+                Collections.singleton(new DefaultPolicyEvaluation.DefaultEvaluationResult("", "", IEvaluationResult.Severity.FAIL, new Artifact())));
+        when(analyzer.yield()).thenReturn(workflowStepResult);
+        when(analyzer.getWorkflowItemName()).thenReturn("");
+        createAntennaWFConfigMock(analyzer);
+
+        AntennaWorkflow workflow = new AntennaWorkflow(antennaWFConfigMock);
+
+        workflow.execute();
+    }
+
+    @Test
+    public void noArtifactsInAnalyzerBreaksBuild() {
+        DummyAnalyzer analyzer = mock(DummyAnalyzer.class);
+        WorkflowStepResult workflowStepResult = new WorkflowStepResult(Collections.emptySet());
+        when(analyzer.yield()).thenReturn(workflowStepResult);
+        when(analyzer.getWorkflowItemName()).thenReturn("");
+        createAntennaWFConfigMock(analyzer);
+
+        AntennaWorkflow workflow = new AntennaWorkflow(antennaWFConfigMock);
+
+        Map<String, IAttachable> result = workflow.execute();
+        assertThat(result).isEmpty();
+    }
+
+    /**
+     * Dummy class to create a dummy analyzer usable
+     * for mocking purposes.
+     */
+    class DummyAnalyzer extends AbstractAnalyzer {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public WorkflowStepResult yield() throws ExecutionException {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This enures that the build breaks even when there are no artifacts
found in the Analyzer run. This is important because the reason
that there are no artifacts might be a fail causing result.

Issue #634
Closes #34

Signed-off-by: Stephanie Neubauer <Stephanie.Neubauer@bosch.io>

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to? (*Refer to issue here*)
> * How is it solving the issue?
> * Did you add or update any new dependencies that are required for your change?

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 
New unit test was created. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [x] I have provided tests for the changes (if there are changes that need additional tests)
