### PR TITLE
Change java version to only use 11 in github action

### DIFF
--- a/.ci-scripts/test-for-licenseHeaders.sh
+++ b/.ci-scripts/test-for-licenseHeaders.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) Bosch Software Innovations GmbH 2018.
-# Copyright (c) Bosch.IO GmbH 2020.
+# Copyright (c) Bosch.IO GmbH 2020-2021.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -36,7 +36,7 @@ testFile() {
     if ! head -15 $file | grep -q 'Copyright (c)'; then
         echo "ERROR: No copyright remark found in $file"
         failure=true
-    elif ! head -15 $file | grep -q "^.*Copyright (c) .* $(date +%Y).*$"; then
+    elif ! head -15 $file | grep -q "^.*Copyright (c) .*$(date +%Y).*$"; then
         echo "ERROR: The year of your copyright remark is not correct in $file"
         failure=true
     fi

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -1,5 +1,5 @@
 # Copyright (c) Bosch Software Innovations GmbH 2018
-# Copyright (c) Bosch.IO GmbH 2020
+# Copyright (c) Bosch.IO GmbH 2020-2021
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
@@ -30,6 +30,11 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+
+    - name: Setup JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
 
     - name: Cache sonarcloud
       uses: actions/cache@v1


### PR DESCRIPTION
Java 8 is no longer supported by sonar and a change to 11 is encouraged.

This PR should move the sonar cloud step Java 11

Issue: #635 

### Request Reviewer
> You can add desired reviewers here with an @mention.

### Type of Change
> Mention one of the following:   
> bug fix | new feature | improvements | documentation update | CI | Other

*Type of change*:  bug / CI

### How Has This Been Tested?
> If you have added any changes that require additional tests, or changes in tests, you should implement them and describe them here.  
> All test that passed before your contribution should pass after it as well. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages

Optional: *(delete if not applicable)*
- [ ] I have provided tests for the changes (if there are changes that need additional tests)
- [ ] I have updated the documentation accordingly to my changes 
