### PR TITLE
Make SONAR_TOKEN as a secret

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -59,7 +59,7 @@ jobs:
       run: mvn sonar:sonar -Dsonar.organization=sw360antenna -Dsonar.projectKey=sw360antenna -Dsonar.host.url=https://sonarcloud.io
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: "e5dbb8f62a0b8bf02dbbcf4c9fd745c31b63f4b3"
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Run Example Project Test with JDK8
       run: |


### PR DESCRIPTION
Fixes #640

There is one task that needs to be completed is to add **`SONAR_TOKEN`** as a secret for this repository.

